### PR TITLE
Move interpolation resolving to very end

### DIFF
--- a/eval/testdata/eval/imports_interpolate/a.yaml
+++ b/eval/testdata/eval/imports_interpolate/a.yaml
@@ -1,0 +1,4 @@
+values:
+  first: hello
+  second: world
+  test: ${first}, ${second}

--- a/eval/testdata/eval/imports_interpolate/env.yaml
+++ b/eval/testdata/eval/imports_interpolate/env.yaml
@@ -1,0 +1,4 @@
+imports:
+  - a
+values:
+  second: everybody

--- a/eval/testdata/eval/imports_interpolate/expected.json
+++ b/eval/testdata/eval/imports_interpolate/expected.json
@@ -1,0 +1,132 @@
+{
+    "environment": {
+        "exprs": {
+            "second": {
+                "range": {
+                    "environment": "imports_interpolate",
+                    "begin": {
+                        "line": 4,
+                        "column": 11,
+                        "byte": 33
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 20,
+                        "byte": 42
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "everybody"
+                },
+                "base": {
+                    "range": {
+                        "environment": "a",
+                        "begin": {
+                            "line": 3,
+                            "column": 11,
+                            "byte": 33
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 16,
+                            "byte": 38
+                        }
+                    },
+                    "schema": {
+                        "type": "string",
+                        "const": "world"
+                    },
+                    "literal": "world"
+                },
+                "literal": "everybody"
+            }
+        },
+        "properties": {
+            "first": {
+                "value": "hello",
+                "trace": {
+                    "def": {
+                        "environment": "a",
+                        "begin": {
+                            "line": 2,
+                            "column": 10,
+                            "byte": 17
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 15,
+                            "byte": 22
+                        }
+                    }
+                }
+            },
+            "second": {
+                "value": "everybody",
+                "trace": {
+                    "def": {
+                        "environment": "imports_interpolate",
+                        "begin": {
+                            "line": 4,
+                            "column": 11,
+                            "byte": 33
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 20,
+                            "byte": 42
+                        }
+                    },
+                    "base": {
+                        "value": "world",
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 11,
+                                    "byte": 33
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 16,
+                                    "byte": 38
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "test": {
+                "value": "hello, everybody",
+                "trace": {
+                    "def": {
+                        "environment": "a",
+                        "begin": {
+                            "line": 4,
+                            "column": 9,
+                            "byte": 47
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 28,
+                            "byte": 66
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "second": {
+                    "type": "string",
+                    "const": "everybody"
+                }
+            },
+            "type": "object",
+            "required": [
+                "second"
+            ]
+        }
+    }
+}

--- a/eval/value.go
+++ b/eval/value.go
@@ -29,8 +29,9 @@ type value struct {
 
 	// true if the value is unknown (e.g. because it did not evaluate successfully or is the result of an unevaluated
 	// fn::open)
-	unknown bool
-	secret  bool // true if the value is secret
+	unknown     bool
+	secret      bool             // true if the value is secret
+	interpolate *interpolateExpr // delay resolved interpolate expr
 
 	repr any // nil | bool | json.Number | string | []*value | map[string]*value
 }
@@ -101,12 +102,13 @@ func (v *value) copy() *value {
 		repr = vr
 	}
 	return &value{
-		def:     v.def,
-		base:    v.base.copy(),
-		schema:  v.schema,
-		unknown: v.unknown,
-		secret:  v.secret,
-		repr:    repr,
+		def:         v.def,
+		base:        v.base.copy(),
+		schema:      v.schema,
+		unknown:     v.unknown,
+		secret:      v.secret,
+		interpolate: v.interpolate,
+		repr:        repr,
 	}
 }
 


### PR DESCRIPTION
This delays interpolation resolution to the very end to allow overriding values to behave as **I think** customers would expect.

This should resolve two issues, the first one being what I think customers would perceive as a bug with an env hierarch like this:
Env A
```yaml
values:
   first: hello
   second: world
   test: ${first}, ${second}
```
Env B
```yaml
imports:
- a
values:
   second: everybody
```

I believe most people will expect `test` to have the value "hello, everybody" instead of "hello, world"

We may want to have some sort of marker/option to override this behavior, but that is easily setup with separate variables as well.

This would also solve https://github.com/pulumi/pulumi-service/issues/15620  allowing for this config to work:
Env A
```yaml
values:
   test: https://${serviceName}.${aws.region}.${environmentName}.contoso.com
```
Env B
```yaml
imports:
- a
values:
   aws:
      region: us-west
   environmentName: prod
   serviceName: myservice
```


