### PR TITLE
eval: do not open providers with unknown inputs

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -736,7 +736,7 @@ func (e *evalContext) evaluateBuiltinOpen(x *expr, repr *openExpr) *value {
 	v.schema = x.schema
 
 	inputs, ok := e.evaluateTypedExpr(repr.inputs, repr.inputSchema)
-	if !ok || e.validating || err != nil {
+	if !ok || inputs.unknown || e.validating || err != nil {
 		v.unknown = true
 		return v
 	}

--- a/eval/testdata/eval/open-unknown/env.yaml
+++ b/eval/testdata/eval/open-unknown/env.yaml
@@ -1,0 +1,7 @@
+values:
+  error:
+    fn::open::error:
+      why: testing
+  dependent:
+    fn::open::error:
+      why: ${error}

--- a/eval/testdata/eval/open-unknown/expected.json
+++ b/eval/testdata/eval/open-unknown/expected.json
@@ -1,0 +1,345 @@
+{
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "testing",
+            "Detail": "",
+            "Subject": {
+                "Filename": "open-unknown",
+                "Start": {
+                    "Line": 3,
+                    "Column": 5,
+                    "Byte": 21
+                },
+                "End": {
+                    "Line": 4,
+                    "Column": 19,
+                    "Byte": 56
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Shown": false
+        }
+    ],
+    "environment": {
+        "exprs": {
+            "dependent": {
+                "range": {
+                    "environment": "open-unknown",
+                    "begin": {
+                        "line": 6,
+                        "column": 5,
+                        "byte": 74
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 20,
+                        "byte": 110
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "",
+                    "argSchema": {
+                        "properties": {
+                            "inputs": {
+                                "properties": {
+                                    "why": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "why"
+                                ]
+                            },
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "open-unknown",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 7,
+                                        "byte": 97
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 20,
+                                        "byte": 110
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "why": true
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "why"
+                                    ]
+                                },
+                                "object": {
+                                    "why": {
+                                        "range": {
+                                            "environment": "open-unknown",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 12,
+                                                "byte": 102
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 20,
+                                                "byte": 110
+                                            }
+                                        },
+                                        "schema": true,
+                                        "symbol": [
+                                            {
+                                                "key": "error",
+                                                "value": {
+                                                    "environment": "open-unknown",
+                                                    "begin": {
+                                                        "line": 3,
+                                                        "column": 5,
+                                                        "byte": 21
+                                                    },
+                                                    "end": {
+                                                        "line": 4,
+                                                        "column": 19,
+                                                        "byte": 56
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "open-unknown",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 5,
+                                        "byte": 74
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 20,
+                                        "byte": 89
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "error"
+                                },
+                                "literal": "error"
+                            }
+                        }
+                    }
+                }
+            },
+            "error": {
+                "range": {
+                    "environment": "open-unknown",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 21
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 19,
+                        "byte": 56
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "",
+                    "argSchema": {
+                        "properties": {
+                            "inputs": {
+                                "properties": {
+                                    "why": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "why"
+                                ]
+                            },
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "open-unknown",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 7,
+                                        "byte": 44
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 19,
+                                        "byte": 56
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "why": {
+                                            "type": "string",
+                                            "const": "testing"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "why"
+                                    ]
+                                },
+                                "object": {
+                                    "why": {
+                                        "range": {
+                                            "environment": "open-unknown",
+                                            "begin": {
+                                                "line": 4,
+                                                "column": 12,
+                                                "byte": 49
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 19,
+                                                "byte": 56
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "testing"
+                                        },
+                                        "literal": "testing"
+                                    }
+                                }
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "open-unknown",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 5,
+                                        "byte": 21
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 20,
+                                        "byte": 36
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "error"
+                                },
+                                "literal": "error"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "dependent": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "open-unknown",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 74
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 20,
+                            "byte": 110
+                        }
+                    }
+                }
+            },
+            "error": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "open-unknown",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 21
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 19,
+                            "byte": 56
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "dependent": true,
+                "error": true
+            },
+            "type": "object",
+            "required": [
+                "dependent",
+                "error"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This can happen during evaluation if the provider inputs come from another open expression that failed.