### PR TITLE
schema, eval: support anyOf, oneOf, $defs, $ref

### DIFF
--- a/eval/testdata/eval/omnibus/a.yaml
+++ b/eval/testdata/eval/omnibus/a.yaml
@@ -1,0 +1,4 @@
+values:
+  open:
+    foo: bar
+  strings: [ "hello", "world" ]

--- a/eval/testdata/eval/omnibus/env.yaml
+++ b/eval/testdata/eval/omnibus/env.yaml
@@ -1,0 +1,21 @@
+imports:
+  - a
+values:
+  join:
+    fn::join: [ ",", "${strings}" ]
+  open:
+    fn::open::test:
+      baz: qux
+  secret:
+    fn::secret:
+      hunter2
+  toBase64:
+    fn::toBase64: ${join}
+  toJSON:
+    fn::toJSON: ${open}
+  toString:
+    fn::toString: ${open}
+  open2:
+    fn::open::test: ${open}
+  interp: hello, ${toString}
+  access: ${open["baz"]}

--- a/eval/testdata/eval/omnibus/expected.json
+++ b/eval/testdata/eval/omnibus/expected.json
@@ -1,0 +1,1186 @@
+{
+    "environment": {
+        "exprs": {
+            "access": {
+                "range": {
+                    "environment": "omnibus",
+                    "begin": {
+                        "line": 21,
+                        "column": 11,
+                        "byte": 336
+                    },
+                    "end": {
+                        "line": 21,
+                        "column": 25,
+                        "byte": 350
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "qux"
+                },
+                "symbol": [
+                    {
+                        "key": "open",
+                        "value": {
+                            "environment": "omnibus",
+                            "begin": {
+                                "line": 7,
+                                "column": 5,
+                                "byte": 79
+                            },
+                            "end": {
+                                "line": 8,
+                                "column": 15,
+                                "byte": 109
+                            }
+                        }
+                    },
+                    {
+                        "key": "baz",
+                        "value": {
+                            "environment": "omnibus",
+                            "begin": {
+                                "line": 7,
+                                "column": 5,
+                                "byte": 79
+                            },
+                            "end": {
+                                "line": 8,
+                                "column": 15,
+                                "byte": 109
+                            }
+                        }
+                    }
+                ]
+            },
+            "interp": {
+                "range": {
+                    "environment": "omnibus",
+                    "begin": {
+                        "line": 20,
+                        "column": 11,
+                        "byte": 307
+                    },
+                    "end": {
+                        "line": 20,
+                        "column": 29,
+                        "byte": 325
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "interpolate": [
+                    {
+                        "text": "hello, ",
+                        "value": [
+                            {
+                                "key": "toString",
+                                "value": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 17,
+                                        "column": 5,
+                                        "byte": 238
+                                    },
+                                    "end": {
+                                        "line": 17,
+                                        "column": 26,
+                                        "byte": 259
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            "join": {
+                "range": {
+                    "environment": "omnibus",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 35
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 32,
+                        "byte": 62
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "",
+                    "argSchema": {
+                        "prefixItems": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        ],
+                        "items": false,
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 17,
+                                        "byte": 47
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 18,
+                                        "byte": 48
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": ","
+                                },
+                                "literal": ","
+                            },
+                            {
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 22,
+                                        "byte": 52
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 32,
+                                        "byte": 62
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "const": "world"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "symbol": [
+                                    {
+                                        "key": "strings",
+                                        "value": {
+                                            "environment": "a",
+                                            "begin": {
+                                                "line": 4,
+                                                "column": 12,
+                                                "byte": 40
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 28,
+                                                "byte": 56
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "open": {
+                "range": {
+                    "environment": "omnibus",
+                    "begin": {
+                        "line": 7,
+                        "column": 5,
+                        "byte": 79
+                    },
+                    "end": {
+                        "line": 8,
+                        "column": 15,
+                        "byte": 109
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "baz": {
+                            "type": "string",
+                            "const": "qux"
+                        },
+                        "foo": {
+                            "type": "string",
+                            "const": "bar"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "baz",
+                        "foo"
+                    ]
+                },
+                "base": {
+                    "range": {
+                        "environment": "a",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 13,
+                            "byte": 28
+                        }
+                    },
+                    "schema": {
+                        "properties": {
+                            "foo": {
+                                "type": "string",
+                                "const": "bar"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "foo"
+                        ]
+                    },
+                    "object": {
+                        "foo": {
+                            "range": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 10,
+                                    "byte": 25
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 13,
+                                    "byte": 28
+                                }
+                            },
+                            "schema": {
+                                "type": "string",
+                                "const": "bar"
+                            },
+                            "literal": "bar"
+                        }
+                    }
+                },
+                "builtin": {
+                    "name": "",
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 7,
+                                        "byte": 101
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 15,
+                                        "byte": 109
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "baz": {
+                                            "type": "string",
+                                            "const": "qux"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "baz"
+                                    ]
+                                },
+                                "object": {
+                                    "baz": {
+                                        "range": {
+                                            "environment": "omnibus",
+                                            "begin": {
+                                                "line": 8,
+                                                "column": 12,
+                                                "byte": 106
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 15,
+                                                "byte": 109
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "qux"
+                                        },
+                                        "literal": "qux"
+                                    }
+                                }
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 5,
+                                        "byte": 79
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 19,
+                                        "byte": 93
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "test"
+                                },
+                                "literal": "test"
+                            }
+                        }
+                    }
+                }
+            },
+            "open2": {
+                "range": {
+                    "environment": "omnibus",
+                    "begin": {
+                        "line": 19,
+                        "column": 5,
+                        "byte": 273
+                    },
+                    "end": {
+                        "line": 19,
+                        "column": 28,
+                        "byte": 296
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "baz": {
+                            "type": "string",
+                            "const": "qux"
+                        },
+                        "foo": {
+                            "type": "string",
+                            "const": "bar"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "baz",
+                        "foo"
+                    ]
+                },
+                "builtin": {
+                    "name": "",
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 19,
+                                        "column": 21,
+                                        "byte": 289
+                                    },
+                                    "end": {
+                                        "line": 19,
+                                        "column": 28,
+                                        "byte": 296
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "baz": {
+                                            "type": "string",
+                                            "const": "qux"
+                                        },
+                                        "foo": {
+                                            "type": "string",
+                                            "const": "bar"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "baz",
+                                        "foo"
+                                    ]
+                                },
+                                "symbol": [
+                                    {
+                                        "key": "open",
+                                        "value": {
+                                            "environment": "omnibus",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 5,
+                                                "byte": 79
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 15,
+                                                "byte": 109
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 19,
+                                        "column": 5,
+                                        "byte": 273
+                                    },
+                                    "end": {
+                                        "line": 19,
+                                        "column": 19,
+                                        "byte": 287
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "test"
+                                },
+                                "literal": "test"
+                            }
+                        }
+                    }
+                }
+            },
+            "secret": {
+                "range": {
+                    "environment": "omnibus",
+                    "begin": {
+                        "line": 10,
+                        "column": 5,
+                        "byte": 124
+                    },
+                    "end": {
+                        "line": 11,
+                        "column": 14,
+                        "byte": 149
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "hunter2"
+                },
+                "builtin": {
+                    "name": "",
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "omnibus",
+                            "begin": {
+                                "line": 11,
+                                "column": 7,
+                                "byte": 142
+                            },
+                            "end": {
+                                "line": 11,
+                                "column": 14,
+                                "byte": 149
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "hunter2"
+                        },
+                        "literal": "hunter2"
+                    }
+                }
+            },
+            "toBase64": {
+                "range": {
+                    "environment": "omnibus",
+                    "begin": {
+                        "line": 13,
+                        "column": 5,
+                        "byte": 166
+                    },
+                    "end": {
+                        "line": 13,
+                        "column": 26,
+                        "byte": 187
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "",
+                    "argSchema": {
+                        "type": "string"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "omnibus",
+                            "begin": {
+                                "line": 13,
+                                "column": 19,
+                                "byte": 180
+                            },
+                            "end": {
+                                "line": 13,
+                                "column": 26,
+                                "byte": 187
+                            }
+                        },
+                        "schema": {
+                            "type": "string"
+                        },
+                        "symbol": [
+                            {
+                                "key": "join",
+                                "value": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 5,
+                                        "byte": 35
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 32,
+                                        "byte": 62
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "toJSON": {
+                "range": {
+                    "environment": "omnibus",
+                    "begin": {
+                        "line": 15,
+                        "column": 5,
+                        "byte": 202
+                    },
+                    "end": {
+                        "line": 15,
+                        "column": 24,
+                        "byte": 221
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "",
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "omnibus",
+                            "begin": {
+                                "line": 15,
+                                "column": 17,
+                                "byte": 214
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 24,
+                                "byte": 221
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "baz": {
+                                    "type": "string",
+                                    "const": "qux"
+                                },
+                                "foo": {
+                                    "type": "string",
+                                    "const": "bar"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "baz",
+                                "foo"
+                            ]
+                        },
+                        "symbol": [
+                            {
+                                "key": "open",
+                                "value": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 5,
+                                        "byte": 79
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 15,
+                                        "byte": 109
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "toString": {
+                "range": {
+                    "environment": "omnibus",
+                    "begin": {
+                        "line": 17,
+                        "column": 5,
+                        "byte": 238
+                    },
+                    "end": {
+                        "line": 17,
+                        "column": 26,
+                        "byte": 259
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "",
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "omnibus",
+                            "begin": {
+                                "line": 17,
+                                "column": 19,
+                                "byte": 252
+                            },
+                            "end": {
+                                "line": 17,
+                                "column": 26,
+                                "byte": 259
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "baz": {
+                                    "type": "string",
+                                    "const": "qux"
+                                },
+                                "foo": {
+                                    "type": "string",
+                                    "const": "bar"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "baz",
+                                "foo"
+                            ]
+                        },
+                        "symbol": [
+                            {
+                                "key": "open",
+                                "value": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 5,
+                                        "byte": 79
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 15,
+                                        "byte": 109
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "properties": {
+            "access": {
+                "value": "qux",
+                "trace": {
+                    "def": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 21,
+                            "column": 11,
+                            "byte": 336
+                        },
+                        "end": {
+                            "line": 21,
+                            "column": 25,
+                            "byte": 350
+                        }
+                    }
+                }
+            },
+            "interp": {
+                "value": "hello, \"baz\"=\"qux\"",
+                "trace": {
+                    "def": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 20,
+                            "column": 11,
+                            "byte": 307
+                        },
+                        "end": {
+                            "line": 20,
+                            "column": 29,
+                            "byte": 325
+                        }
+                    }
+                }
+            },
+            "join": {
+                "value": "hello,world",
+                "trace": {
+                    "def": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 35
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 32,
+                            "byte": 62
+                        }
+                    }
+                }
+            },
+            "open": {
+                "value": {
+                    "baz": {
+                        "value": "qux",
+                        "trace": {
+                            "def": {
+                                "environment": "omnibus",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 5,
+                                    "byte": 79
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 15,
+                                    "byte": 109
+                                }
+                            }
+                        }
+                    },
+                    "foo": {
+                        "value": "bar",
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 10,
+                                    "byte": 25
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 13,
+                                    "byte": 28
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 7,
+                            "column": 5,
+                            "byte": 79
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 15,
+                            "byte": 109
+                        }
+                    },
+                    "base": {
+                        "value": {
+                            "foo": {
+                                "value": "bar",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 10,
+                                            "byte": 25
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 13,
+                                            "byte": 28
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 20
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 13,
+                                    "byte": 28
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "open2": {
+                "value": {
+                    "baz": {
+                        "value": "qux",
+                        "trace": {
+                            "def": {
+                                "environment": "omnibus",
+                                "begin": {
+                                    "line": 19,
+                                    "column": 5,
+                                    "byte": 273
+                                },
+                                "end": {
+                                    "line": 19,
+                                    "column": 28,
+                                    "byte": 296
+                                }
+                            }
+                        }
+                    },
+                    "foo": {
+                        "value": "bar",
+                        "trace": {
+                            "def": {
+                                "environment": "omnibus",
+                                "begin": {
+                                    "line": 19,
+                                    "column": 5,
+                                    "byte": 273
+                                },
+                                "end": {
+                                    "line": 19,
+                                    "column": 28,
+                                    "byte": 296
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 19,
+                            "column": 5,
+                            "byte": 273
+                        },
+                        "end": {
+                            "line": 19,
+                            "column": 28,
+                            "byte": 296
+                        }
+                    }
+                }
+            },
+            "secret": {
+                "value": "hunter2",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 11,
+                            "column": 7,
+                            "byte": 142
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 14,
+                            "byte": 149
+                        }
+                    }
+                }
+            },
+            "strings": {
+                "value": [
+                    {
+                        "value": "hello",
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 14,
+                                    "byte": 42
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 19,
+                                    "byte": 47
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "world",
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 23,
+                                    "byte": 51
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 28,
+                                    "byte": 56
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "a",
+                        "begin": {
+                            "line": 4,
+                            "column": 12,
+                            "byte": 40
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 28,
+                            "byte": 56
+                        }
+                    }
+                }
+            },
+            "toBase64": {
+                "value": "aGVsbG8sd29ybGQ=",
+                "trace": {
+                    "def": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 13,
+                            "column": 5,
+                            "byte": 166
+                        },
+                        "end": {
+                            "line": 13,
+                            "column": 26,
+                            "byte": 187
+                        }
+                    }
+                }
+            },
+            "toJSON": {
+                "value": "{\"baz\":\"qux\",\"foo\":\"bar\"}",
+                "trace": {
+                    "def": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 15,
+                            "column": 5,
+                            "byte": 202
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 24,
+                            "byte": 221
+                        }
+                    }
+                }
+            },
+            "toString": {
+                "value": "\"baz\"=\"qux\"",
+                "trace": {
+                    "def": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 17,
+                            "column": 5,
+                            "byte": 238
+                        },
+                        "end": {
+                            "line": 17,
+                            "column": 26,
+                            "byte": 259
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "access": {
+                    "type": "string",
+                    "const": "qux"
+                },
+                "interp": {
+                    "type": "string"
+                },
+                "join": {
+                    "type": "string"
+                },
+                "open": {
+                    "properties": {
+                        "baz": {
+                            "type": "string",
+                            "const": "qux"
+                        },
+                        "foo": {
+                            "type": "string",
+                            "const": "bar"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "baz",
+                        "foo"
+                    ]
+                },
+                "open2": {
+                    "properties": {
+                        "baz": {
+                            "type": "string",
+                            "const": "qux"
+                        },
+                        "foo": {
+                            "type": "string",
+                            "const": "bar"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "baz",
+                        "foo"
+                    ]
+                },
+                "secret": {
+                    "type": "string",
+                    "const": "hunter2"
+                },
+                "toBase64": {
+                    "type": "string"
+                },
+                "toJSON": {
+                    "type": "string"
+                },
+                "toString": {
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "required": [
+                "access",
+                "interp",
+                "join",
+                "open",
+                "open2",
+                "secret",
+                "toBase64",
+                "toJSON",
+                "toString"
+            ]
+        }
+    }
+}

--- a/eval/testdata/eval/schema/env.yaml
+++ b/eval/testdata/eval/schema/env.yaml
@@ -1,0 +1,27 @@
+values:
+  source:
+    fn::open::schema:
+      "null": null
+      boolean: true
+      "false": false
+      "true": true
+      number: 42
+      pi: 3.14
+      string: esc
+      hello: hello
+      array: [ 2, items, { some: object }, [ array ] ]
+      tuple: [ hello, world ]
+      map: { hello: world, blue: 42 }
+      record: { foo: bar }
+      anyOf: hello
+      oneOf: 42
+      ref: { baz: qux }
+  sink:
+    fn::open::schema: ${source}
+  accesses:
+    - ${sink.record.foo}
+    - ${sink.tuple[0]}
+    - ${sink.map.hello}
+    - ${sink.array[1]}
+    - ${sink.array[2].some}
+    - ${sink.array[3][0]}

--- a/eval/testdata/eval/schema/expected.json
+++ b/eval/testdata/eval/schema/expected.json
@@ -1,0 +1,3626 @@
+{
+    "environment": {
+        "exprs": {
+            "accesses": {
+                "range": {
+                    "environment": "schema",
+                    "begin": {
+                        "line": 22,
+                        "column": 5,
+                        "byte": 453
+                    },
+                    "end": {
+                        "line": 27,
+                        "column": 26,
+                        "byte": 597
+                    }
+                },
+                "schema": {
+                    "prefixItems": [
+                        {
+                            "type": "string",
+                            "const": "bar"
+                        },
+                        {
+                            "type": "string",
+                            "const": "hello"
+                        },
+                        {
+                            "type": "string",
+                            "const": "world"
+                        },
+                        {
+                            "type": "string",
+                            "const": "items"
+                        },
+                        {
+                            "type": "string",
+                            "const": "object"
+                        },
+                        {
+                            "type": "string",
+                            "const": "array"
+                        }
+                    ],
+                    "items": false,
+                    "type": "array"
+                },
+                "list": [
+                    {
+                        "range": {
+                            "environment": "schema",
+                            "begin": {
+                                "line": 22,
+                                "column": 7,
+                                "byte": 455
+                            },
+                            "end": {
+                                "line": 22,
+                                "column": 25,
+                                "byte": 473
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "bar"
+                        },
+                        "symbol": [
+                            {
+                                "key": "sink",
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            },
+                            {
+                                "key": "record",
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            },
+                            {
+                                "key": "foo",
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "schema",
+                            "begin": {
+                                "line": 23,
+                                "column": 7,
+                                "byte": 480
+                            },
+                            "end": {
+                                "line": 23,
+                                "column": 23,
+                                "byte": 496
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "hello"
+                        },
+                        "symbol": [
+                            {
+                                "key": "sink",
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            },
+                            {
+                                "key": "tuple",
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            },
+                            {
+                                "index": 0,
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "schema",
+                            "begin": {
+                                "line": 24,
+                                "column": 7,
+                                "byte": 503
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 24,
+                                "byte": 520
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "world"
+                        },
+                        "symbol": [
+                            {
+                                "key": "sink",
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            },
+                            {
+                                "key": "map",
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            },
+                            {
+                                "key": "hello",
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "schema",
+                            "begin": {
+                                "line": 25,
+                                "column": 7,
+                                "byte": 527
+                            },
+                            "end": {
+                                "line": 25,
+                                "column": 23,
+                                "byte": 543
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "items"
+                        },
+                        "symbol": [
+                            {
+                                "key": "sink",
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            },
+                            {
+                                "key": "array",
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            },
+                            {
+                                "index": 1,
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "schema",
+                            "begin": {
+                                "line": 26,
+                                "column": 7,
+                                "byte": 550
+                            },
+                            "end": {
+                                "line": 26,
+                                "column": 28,
+                                "byte": 571
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "object"
+                        },
+                        "symbol": [
+                            {
+                                "key": "sink",
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            },
+                            {
+                                "key": "array",
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            },
+                            {
+                                "index": 2,
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            },
+                            {
+                                "key": "some",
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "schema",
+                            "begin": {
+                                "line": 27,
+                                "column": 7,
+                                "byte": 578
+                            },
+                            "end": {
+                                "line": 27,
+                                "column": 26,
+                                "byte": 597
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "array"
+                        },
+                        "symbol": [
+                            {
+                                "key": "sink",
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            },
+                            {
+                                "key": "array",
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            },
+                            {
+                                "index": 3,
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            },
+                            {
+                                "index": 0,
+                                "value": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            "sink": {
+                "range": {
+                    "environment": "schema",
+                    "begin": {
+                        "line": 20,
+                        "column": 5,
+                        "byte": 409
+                    },
+                    "end": {
+                        "line": 20,
+                        "column": 32,
+                        "byte": 436
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "anyOf": {
+                            "type": "string",
+                            "const": "hello"
+                        },
+                        "array": {
+                            "prefixItems": [
+                                {
+                                    "type": "number",
+                                    "const": 2
+                                },
+                                {
+                                    "type": "string",
+                                    "const": "items"
+                                },
+                                {
+                                    "properties": {
+                                        "some": {
+                                            "type": "string",
+                                            "const": "object"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "some"
+                                    ]
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "array"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "boolean": {
+                            "type": "boolean",
+                            "const": true
+                        },
+                        "false": {
+                            "type": "boolean",
+                            "const": false
+                        },
+                        "hello": {
+                            "type": "string",
+                            "const": "hello"
+                        },
+                        "map": {
+                            "properties": {
+                                "blue": {
+                                    "type": "number",
+                                    "const": 42
+                                },
+                                "hello": {
+                                    "type": "string",
+                                    "const": "world"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "blue",
+                                "hello"
+                            ]
+                        },
+                        "null": {
+                            "type": "null"
+                        },
+                        "number": {
+                            "type": "number",
+                            "const": 42
+                        },
+                        "oneOf": {
+                            "type": "number",
+                            "const": 42
+                        },
+                        "pi": {
+                            "type": "number",
+                            "const": 3.14
+                        },
+                        "record": {
+                            "properties": {
+                                "foo": {
+                                    "type": "string",
+                                    "const": "bar"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "foo"
+                            ]
+                        },
+                        "ref": {
+                            "properties": {
+                                "baz": {
+                                    "type": "string",
+                                    "const": "qux"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "baz"
+                            ]
+                        },
+                        "string": {
+                            "type": "string",
+                            "const": "esc"
+                        },
+                        "true": {
+                            "type": "boolean",
+                            "const": true
+                        },
+                        "tuple": {
+                            "prefixItems": [
+                                {
+                                    "type": "string",
+                                    "const": "hello"
+                                },
+                                {
+                                    "type": "string",
+                                    "const": "world"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "anyOf",
+                        "array",
+                        "boolean",
+                        "false",
+                        "hello",
+                        "map",
+                        "null",
+                        "number",
+                        "oneOf",
+                        "pi",
+                        "record",
+                        "ref",
+                        "string",
+                        "true",
+                        "tuple"
+                    ]
+                },
+                "builtin": {
+                    "name": "",
+                    "argSchema": {
+                        "properties": {
+                            "inputs": {
+                                "$defs": {
+                                    "defRecord": {
+                                        "properties": {
+                                            "baz": {
+                                                "type": "string",
+                                                "const": "qux"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "required": [
+                                            "baz"
+                                        ]
+                                    }
+                                },
+                                "properties": {
+                                    "anyOf": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            }
+                                        ],
+                                        "type": ""
+                                    },
+                                    "array": {
+                                        "items": true,
+                                        "type": "array"
+                                    },
+                                    "boolean": {
+                                        "type": "boolean"
+                                    },
+                                    "false": {
+                                        "type": "boolean",
+                                        "const": false
+                                    },
+                                    "hello": {
+                                        "type": "string",
+                                        "const": "hello"
+                                    },
+                                    "map": {
+                                        "additionalProperties": true,
+                                        "type": "object"
+                                    },
+                                    "null": {
+                                        "type": "null"
+                                    },
+                                    "number": {
+                                        "type": "number"
+                                    },
+                                    "oneOf": {
+                                        "oneOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            }
+                                        ],
+                                        "type": ""
+                                    },
+                                    "pi": {
+                                        "type": "number",
+                                        "const": 3.14
+                                    },
+                                    "record": {
+                                        "properties": {
+                                            "foo": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "required": [
+                                            "foo"
+                                        ]
+                                    },
+                                    "ref": {
+                                        "$ref": "#/$defs/defRecord",
+                                        "type": ""
+                                    },
+                                    "string": {
+                                        "type": "string"
+                                    },
+                                    "true": {
+                                        "type": "boolean",
+                                        "const": true
+                                    },
+                                    "tuple": {
+                                        "prefixItems": [
+                                            {
+                                                "type": "string",
+                                                "const": "hello"
+                                            },
+                                            {
+                                                "type": "string",
+                                                "const": "world"
+                                            }
+                                        ],
+                                        "items": false,
+                                        "type": "array"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 23,
+                                        "byte": 427
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32,
+                                        "byte": 436
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "anyOf": {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        "array": {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 2
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "const": "items"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "some": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "required": [
+                                                        "some"
+                                                    ]
+                                                },
+                                                {
+                                                    "prefixItems": [
+                                                        {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                        }
+                                                    ],
+                                                    "items": false,
+                                                    "type": "array"
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        },
+                                        "boolean": {
+                                            "type": "boolean",
+                                            "const": true
+                                        },
+                                        "false": {
+                                            "type": "boolean",
+                                            "const": false
+                                        },
+                                        "hello": {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        "map": {
+                                            "properties": {
+                                                "blue": {
+                                                    "type": "number",
+                                                    "const": 42
+                                                },
+                                                "hello": {
+                                                    "type": "string",
+                                                    "const": "world"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "blue",
+                                                "hello"
+                                            ]
+                                        },
+                                        "null": {
+                                            "type": "null"
+                                        },
+                                        "number": {
+                                            "type": "number",
+                                            "const": 42
+                                        },
+                                        "oneOf": {
+                                            "type": "number",
+                                            "const": 42
+                                        },
+                                        "pi": {
+                                            "type": "number",
+                                            "const": 3.14
+                                        },
+                                        "record": {
+                                            "properties": {
+                                                "foo": {
+                                                    "type": "string",
+                                                    "const": "bar"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "foo"
+                                            ]
+                                        },
+                                        "ref": {
+                                            "properties": {
+                                                "baz": {
+                                                    "type": "string",
+                                                    "const": "qux"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "baz"
+                                            ]
+                                        },
+                                        "string": {
+                                            "type": "string",
+                                            "const": "esc"
+                                        },
+                                        "true": {
+                                            "type": "boolean",
+                                            "const": true
+                                        },
+                                        "tuple": {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "string",
+                                                    "const": "hello"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "const": "world"
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "anyOf",
+                                        "array",
+                                        "boolean",
+                                        "false",
+                                        "hello",
+                                        "map",
+                                        "null",
+                                        "number",
+                                        "oneOf",
+                                        "pi",
+                                        "record",
+                                        "ref",
+                                        "string",
+                                        "true",
+                                        "tuple"
+                                    ]
+                                },
+                                "symbol": [
+                                    {
+                                        "key": "source",
+                                        "value": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 3,
+                                                "column": 5,
+                                                "byte": 22
+                                            },
+                                            "end": {
+                                                "line": 18,
+                                                "column": 22,
+                                                "byte": 394
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 5,
+                                        "byte": 409
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 21,
+                                        "byte": 425
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "schema"
+                                },
+                                "literal": "schema"
+                            }
+                        }
+                    }
+                }
+            },
+            "source": {
+                "range": {
+                    "environment": "schema",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 22
+                    },
+                    "end": {
+                        "line": 18,
+                        "column": 22,
+                        "byte": 394
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "anyOf": {
+                            "type": "string",
+                            "const": "hello"
+                        },
+                        "array": {
+                            "prefixItems": [
+                                {
+                                    "type": "number",
+                                    "const": 2
+                                },
+                                {
+                                    "type": "string",
+                                    "const": "items"
+                                },
+                                {
+                                    "properties": {
+                                        "some": {
+                                            "type": "string",
+                                            "const": "object"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "some"
+                                    ]
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "array"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "boolean": {
+                            "type": "boolean",
+                            "const": true
+                        },
+                        "false": {
+                            "type": "boolean",
+                            "const": false
+                        },
+                        "hello": {
+                            "type": "string",
+                            "const": "hello"
+                        },
+                        "map": {
+                            "properties": {
+                                "blue": {
+                                    "type": "number",
+                                    "const": 42
+                                },
+                                "hello": {
+                                    "type": "string",
+                                    "const": "world"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "blue",
+                                "hello"
+                            ]
+                        },
+                        "null": {
+                            "type": "null"
+                        },
+                        "number": {
+                            "type": "number",
+                            "const": 42
+                        },
+                        "oneOf": {
+                            "type": "number",
+                            "const": 42
+                        },
+                        "pi": {
+                            "type": "number",
+                            "const": 3.14
+                        },
+                        "record": {
+                            "properties": {
+                                "foo": {
+                                    "type": "string",
+                                    "const": "bar"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "foo"
+                            ]
+                        },
+                        "ref": {
+                            "properties": {
+                                "baz": {
+                                    "type": "string",
+                                    "const": "qux"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "baz"
+                            ]
+                        },
+                        "string": {
+                            "type": "string",
+                            "const": "esc"
+                        },
+                        "true": {
+                            "type": "boolean",
+                            "const": true
+                        },
+                        "tuple": {
+                            "prefixItems": [
+                                {
+                                    "type": "string",
+                                    "const": "hello"
+                                },
+                                {
+                                    "type": "string",
+                                    "const": "world"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "anyOf",
+                        "array",
+                        "boolean",
+                        "false",
+                        "hello",
+                        "map",
+                        "null",
+                        "number",
+                        "oneOf",
+                        "pi",
+                        "record",
+                        "ref",
+                        "string",
+                        "true",
+                        "tuple"
+                    ]
+                },
+                "builtin": {
+                    "name": "",
+                    "argSchema": {
+                        "properties": {
+                            "inputs": {
+                                "$defs": {
+                                    "defRecord": {
+                                        "properties": {
+                                            "baz": {
+                                                "type": "string",
+                                                "const": "qux"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "required": [
+                                            "baz"
+                                        ]
+                                    }
+                                },
+                                "properties": {
+                                    "anyOf": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            }
+                                        ],
+                                        "type": ""
+                                    },
+                                    "array": {
+                                        "items": true,
+                                        "type": "array"
+                                    },
+                                    "boolean": {
+                                        "type": "boolean"
+                                    },
+                                    "false": {
+                                        "type": "boolean",
+                                        "const": false
+                                    },
+                                    "hello": {
+                                        "type": "string",
+                                        "const": "hello"
+                                    },
+                                    "map": {
+                                        "additionalProperties": true,
+                                        "type": "object"
+                                    },
+                                    "null": {
+                                        "type": "null"
+                                    },
+                                    "number": {
+                                        "type": "number"
+                                    },
+                                    "oneOf": {
+                                        "oneOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            }
+                                        ],
+                                        "type": ""
+                                    },
+                                    "pi": {
+                                        "type": "number",
+                                        "const": 3.14
+                                    },
+                                    "record": {
+                                        "properties": {
+                                            "foo": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "required": [
+                                            "foo"
+                                        ]
+                                    },
+                                    "ref": {
+                                        "$ref": "#/$defs/defRecord",
+                                        "type": ""
+                                    },
+                                    "string": {
+                                        "type": "string"
+                                    },
+                                    "true": {
+                                        "type": "boolean",
+                                        "const": true
+                                    },
+                                    "tuple": {
+                                        "prefixItems": [
+                                            {
+                                                "type": "string",
+                                                "const": "hello"
+                                            },
+                                            {
+                                                "type": "string",
+                                                "const": "world"
+                                            }
+                                        ],
+                                        "items": false,
+                                        "type": "array"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 7,
+                                        "byte": 46
+                                    },
+                                    "end": {
+                                        "line": 18,
+                                        "column": 22,
+                                        "byte": 394
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "anyOf": {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        "array": {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 2
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "const": "items"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "some": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "required": [
+                                                        "some"
+                                                    ]
+                                                },
+                                                {
+                                                    "prefixItems": [
+                                                        {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                        }
+                                                    ],
+                                                    "items": false,
+                                                    "type": "array"
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        },
+                                        "boolean": {
+                                            "type": "boolean",
+                                            "const": true
+                                        },
+                                        "false": {
+                                            "type": "boolean",
+                                            "const": false
+                                        },
+                                        "hello": {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        "map": {
+                                            "properties": {
+                                                "blue": {
+                                                    "type": "number",
+                                                    "const": 42
+                                                },
+                                                "hello": {
+                                                    "type": "string",
+                                                    "const": "world"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "blue",
+                                                "hello"
+                                            ]
+                                        },
+                                        "null": {
+                                            "type": "null"
+                                        },
+                                        "number": {
+                                            "type": "number",
+                                            "const": 42
+                                        },
+                                        "oneOf": {
+                                            "type": "number",
+                                            "const": 42
+                                        },
+                                        "pi": {
+                                            "type": "number",
+                                            "const": 3.14
+                                        },
+                                        "record": {
+                                            "properties": {
+                                                "foo": {
+                                                    "type": "string",
+                                                    "const": "bar"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "foo"
+                                            ]
+                                        },
+                                        "ref": {
+                                            "properties": {
+                                                "baz": {
+                                                    "type": "string",
+                                                    "const": "qux"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "baz"
+                                            ]
+                                        },
+                                        "string": {
+                                            "type": "string",
+                                            "const": "esc"
+                                        },
+                                        "true": {
+                                            "type": "boolean",
+                                            "const": true
+                                        },
+                                        "tuple": {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "string",
+                                                    "const": "hello"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "const": "world"
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "anyOf",
+                                        "array",
+                                        "boolean",
+                                        "false",
+                                        "hello",
+                                        "map",
+                                        "null",
+                                        "number",
+                                        "oneOf",
+                                        "pi",
+                                        "record",
+                                        "ref",
+                                        "string",
+                                        "true",
+                                        "tuple"
+                                    ]
+                                },
+                                "object": {
+                                    "anyOf": {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 16,
+                                                "column": 14,
+                                                "byte": 351
+                                            },
+                                            "end": {
+                                                "line": 16,
+                                                "column": 19,
+                                                "byte": 356
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        "literal": "hello"
+                                    },
+                                    "array": {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 12,
+                                                "column": 14,
+                                                "byte": 201
+                                            },
+                                            "end": {
+                                                "line": 12,
+                                                "column": 51,
+                                                "byte": 238
+                                            }
+                                        },
+                                        "schema": {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 2
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "const": "items"
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "some": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "required": [
+                                                        "some"
+                                                    ]
+                                                },
+                                                {
+                                                    "prefixItems": [
+                                                        {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                        }
+                                                    ],
+                                                    "items": false,
+                                                    "type": "array"
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        },
+                                        "list": [
+                                            {
+                                                "range": {
+                                                    "environment": "schema",
+                                                    "begin": {
+                                                        "line": 12,
+                                                        "column": 16,
+                                                        "byte": 203
+                                                    },
+                                                    "end": {
+                                                        "line": 12,
+                                                        "column": 17,
+                                                        "byte": 204
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "number",
+                                                    "const": 2
+                                                },
+                                                "literal": 2
+                                            },
+                                            {
+                                                "range": {
+                                                    "environment": "schema",
+                                                    "begin": {
+                                                        "line": 12,
+                                                        "column": 19,
+                                                        "byte": 206
+                                                    },
+                                                    "end": {
+                                                        "line": 12,
+                                                        "column": 24,
+                                                        "byte": 211
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "items"
+                                                },
+                                                "literal": "items"
+                                            },
+                                            {
+                                                "range": {
+                                                    "environment": "schema",
+                                                    "begin": {
+                                                        "line": 12,
+                                                        "column": 26,
+                                                        "byte": 213
+                                                    },
+                                                    "end": {
+                                                        "line": 12,
+                                                        "column": 40,
+                                                        "byte": 227
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "properties": {
+                                                        "some": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "required": [
+                                                        "some"
+                                                    ]
+                                                },
+                                                "object": {
+                                                    "some": {
+                                                        "range": {
+                                                            "environment": "schema",
+                                                            "begin": {
+                                                                "line": 12,
+                                                                "column": 34,
+                                                                "byte": 221
+                                                            },
+                                                            "end": {
+                                                                "line": 12,
+                                                                "column": 40,
+                                                                "byte": 227
+                                                            }
+                                                        },
+                                                        "schema": {
+                                                            "type": "string",
+                                                            "const": "object"
+                                                        },
+                                                        "literal": "object"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "range": {
+                                                    "environment": "schema",
+                                                    "begin": {
+                                                        "line": 12,
+                                                        "column": 44,
+                                                        "byte": 231
+                                                    },
+                                                    "end": {
+                                                        "line": 12,
+                                                        "column": 51,
+                                                        "byte": 238
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "prefixItems": [
+                                                        {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                        }
+                                                    ],
+                                                    "items": false,
+                                                    "type": "array"
+                                                },
+                                                "list": [
+                                                    {
+                                                        "range": {
+                                                            "environment": "schema",
+                                                            "begin": {
+                                                                "line": 12,
+                                                                "column": 46,
+                                                                "byte": 233
+                                                            },
+                                                            "end": {
+                                                                "line": 12,
+                                                                "column": 51,
+                                                                "byte": 238
+                                                            }
+                                                        },
+                                                        "schema": {
+                                                            "type": "string",
+                                                            "const": "array"
+                                                        },
+                                                        "literal": "array"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "boolean": {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 5,
+                                                "column": 16,
+                                                "byte": 74
+                                            },
+                                            "end": {
+                                                "line": 5,
+                                                "column": 20,
+                                                "byte": 78
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "boolean",
+                                            "const": true
+                                        },
+                                        "literal": true
+                                    },
+                                    "false": {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 6,
+                                                "column": 16,
+                                                "byte": 94
+                                            },
+                                            "end": {
+                                                "line": 6,
+                                                "column": 21,
+                                                "byte": 99
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "boolean",
+                                            "const": false
+                                        },
+                                        "literal": false
+                                    },
+                                    "hello": {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 11,
+                                                "column": 14,
+                                                "byte": 182
+                                            },
+                                            "end": {
+                                                "line": 11,
+                                                "column": 19,
+                                                "byte": 187
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        "literal": "hello"
+                                    },
+                                    "map": {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 14,
+                                                "column": 12,
+                                                "byte": 284
+                                            },
+                                            "end": {
+                                                "line": 14,
+                                                "column": 36,
+                                                "byte": 308
+                                            }
+                                        },
+                                        "schema": {
+                                            "properties": {
+                                                "blue": {
+                                                    "type": "number",
+                                                    "const": 42
+                                                },
+                                                "hello": {
+                                                    "type": "string",
+                                                    "const": "world"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "blue",
+                                                "hello"
+                                            ]
+                                        },
+                                        "object": {
+                                            "blue": {
+                                                "range": {
+                                                    "environment": "schema",
+                                                    "begin": {
+                                                        "line": 14,
+                                                        "column": 34,
+                                                        "byte": 306
+                                                    },
+                                                    "end": {
+                                                        "line": 14,
+                                                        "column": 36,
+                                                        "byte": 308
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "number",
+                                                    "const": 42
+                                                },
+                                                "literal": 42
+                                            },
+                                            "hello": {
+                                                "range": {
+                                                    "environment": "schema",
+                                                    "begin": {
+                                                        "line": 14,
+                                                        "column": 21,
+                                                        "byte": 293
+                                                    },
+                                                    "end": {
+                                                        "line": 14,
+                                                        "column": 26,
+                                                        "byte": 298
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "world"
+                                                },
+                                                "literal": "world"
+                                            }
+                                        }
+                                    },
+                                    "null": {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 4,
+                                                "column": 15,
+                                                "byte": 54
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 19,
+                                                "byte": 58
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "null"
+                                        }
+                                    },
+                                    "number": {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 8,
+                                                "column": 15,
+                                                "byte": 133
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 17,
+                                                "byte": 135
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 42
+                                        },
+                                        "literal": 42
+                                    },
+                                    "oneOf": {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 14,
+                                                "byte": 370
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 16,
+                                                "byte": 372
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 42
+                                        },
+                                        "literal": 42
+                                    },
+                                    "pi": {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 9,
+                                                "column": 11,
+                                                "byte": 146
+                                            },
+                                            "end": {
+                                                "line": 9,
+                                                "column": 15,
+                                                "byte": 150
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 3.14
+                                        },
+                                        "literal": 3.14
+                                    },
+                                    "record": {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 15,
+                                                "column": 15,
+                                                "byte": 325
+                                            },
+                                            "end": {
+                                                "line": 15,
+                                                "column": 25,
+                                                "byte": 335
+                                            }
+                                        },
+                                        "schema": {
+                                            "properties": {
+                                                "foo": {
+                                                    "type": "string",
+                                                    "const": "bar"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "foo"
+                                            ]
+                                        },
+                                        "object": {
+                                            "foo": {
+                                                "range": {
+                                                    "environment": "schema",
+                                                    "begin": {
+                                                        "line": 15,
+                                                        "column": 22,
+                                                        "byte": 332
+                                                    },
+                                                    "end": {
+                                                        "line": 15,
+                                                        "column": 25,
+                                                        "byte": 335
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "bar"
+                                                },
+                                                "literal": "bar"
+                                            }
+                                        }
+                                    },
+                                    "ref": {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 18,
+                                                "column": 12,
+                                                "byte": 384
+                                            },
+                                            "end": {
+                                                "line": 18,
+                                                "column": 22,
+                                                "byte": 394
+                                            }
+                                        },
+                                        "schema": {
+                                            "properties": {
+                                                "baz": {
+                                                    "type": "string",
+                                                    "const": "qux"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "baz"
+                                            ]
+                                        },
+                                        "object": {
+                                            "baz": {
+                                                "range": {
+                                                    "environment": "schema",
+                                                    "begin": {
+                                                        "line": 18,
+                                                        "column": 19,
+                                                        "byte": 391
+                                                    },
+                                                    "end": {
+                                                        "line": 18,
+                                                        "column": 22,
+                                                        "byte": 394
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "qux"
+                                                },
+                                                "literal": "qux"
+                                            }
+                                        }
+                                    },
+                                    "string": {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 10,
+                                                "column": 15,
+                                                "byte": 165
+                                            },
+                                            "end": {
+                                                "line": 10,
+                                                "column": 18,
+                                                "byte": 168
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "esc"
+                                        },
+                                        "literal": "esc"
+                                    },
+                                    "true": {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 15,
+                                                "byte": 114
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 19,
+                                                "byte": 118
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "boolean",
+                                            "const": true
+                                        },
+                                        "literal": true
+                                    },
+                                    "tuple": {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 13,
+                                                "column": 14,
+                                                "byte": 256
+                                            },
+                                            "end": {
+                                                "line": 13,
+                                                "column": 28,
+                                                "byte": 270
+                                            }
+                                        },
+                                        "schema": {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "string",
+                                                    "const": "hello"
+                                                },
+                                                {
+                                                    "type": "string",
+                                                    "const": "world"
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        },
+                                        "list": [
+                                            {
+                                                "range": {
+                                                    "environment": "schema",
+                                                    "begin": {
+                                                        "line": 13,
+                                                        "column": 16,
+                                                        "byte": 258
+                                                    },
+                                                    "end": {
+                                                        "line": 13,
+                                                        "column": 21,
+                                                        "byte": 263
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "hello"
+                                                },
+                                                "literal": "hello"
+                                            },
+                                            {
+                                                "range": {
+                                                    "environment": "schema",
+                                                    "begin": {
+                                                        "line": 13,
+                                                        "column": 23,
+                                                        "byte": 265
+                                                    },
+                                                    "end": {
+                                                        "line": 13,
+                                                        "column": 28,
+                                                        "byte": 270
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "world"
+                                                },
+                                                "literal": "world"
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 5,
+                                        "byte": 22
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 21,
+                                        "byte": 38
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "schema"
+                                },
+                                "literal": "schema"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "accesses": {
+                "value": [
+                    {
+                        "value": "bar",
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 22,
+                                    "column": 7,
+                                    "byte": 455
+                                },
+                                "end": {
+                                    "line": 22,
+                                    "column": 25,
+                                    "byte": 473
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "hello",
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 23,
+                                    "column": 7,
+                                    "byte": 480
+                                },
+                                "end": {
+                                    "line": 23,
+                                    "column": 23,
+                                    "byte": 496
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "world",
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 24,
+                                    "column": 7,
+                                    "byte": 503
+                                },
+                                "end": {
+                                    "line": 24,
+                                    "column": 24,
+                                    "byte": 520
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "items",
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 25,
+                                    "column": 7,
+                                    "byte": 527
+                                },
+                                "end": {
+                                    "line": 25,
+                                    "column": 23,
+                                    "byte": 543
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "object",
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 26,
+                                    "column": 7,
+                                    "byte": 550
+                                },
+                                "end": {
+                                    "line": 26,
+                                    "column": 28,
+                                    "byte": 571
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "array",
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 27,
+                                    "column": 7,
+                                    "byte": 578
+                                },
+                                "end": {
+                                    "line": 27,
+                                    "column": 26,
+                                    "byte": 597
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "schema",
+                        "begin": {
+                            "line": 22,
+                            "column": 5,
+                            "byte": 453
+                        },
+                        "end": {
+                            "line": 27,
+                            "column": 26,
+                            "byte": 597
+                        }
+                    }
+                }
+            },
+            "sink": {
+                "value": {
+                    "anyOf": {
+                        "value": "hello",
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 5,
+                                    "byte": 409
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 32,
+                                    "byte": 436
+                                }
+                            }
+                        }
+                    },
+                    "array": {
+                        "value": [
+                            {
+                                "value": 2,
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 20,
+                                            "column": 5,
+                                            "byte": 409
+                                        },
+                                        "end": {
+                                            "line": 20,
+                                            "column": 32,
+                                            "byte": 436
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "value": "items",
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 20,
+                                            "column": 5,
+                                            "byte": 409
+                                        },
+                                        "end": {
+                                            "line": 20,
+                                            "column": 32,
+                                            "byte": 436
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "value": {
+                                    "some": {
+                                        "value": "object",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "schema",
+                                                "begin": {
+                                                    "line": 20,
+                                                    "column": 5,
+                                                    "byte": 409
+                                                },
+                                                "end": {
+                                                    "line": 20,
+                                                    "column": 32,
+                                                    "byte": 436
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 20,
+                                            "column": 5,
+                                            "byte": 409
+                                        },
+                                        "end": {
+                                            "line": 20,
+                                            "column": 32,
+                                            "byte": 436
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "value": [
+                                    {
+                                        "value": "array",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "schema",
+                                                "begin": {
+                                                    "line": 20,
+                                                    "column": 5,
+                                                    "byte": 409
+                                                },
+                                                "end": {
+                                                    "line": 20,
+                                                    "column": 32,
+                                                    "byte": 436
+                                                }
+                                            }
+                                        }
+                                    }
+                                ],
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 20,
+                                            "column": 5,
+                                            "byte": 409
+                                        },
+                                        "end": {
+                                            "line": 20,
+                                            "column": 32,
+                                            "byte": 436
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 5,
+                                    "byte": 409
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 32,
+                                    "byte": 436
+                                }
+                            }
+                        }
+                    },
+                    "boolean": {
+                        "value": true,
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 5,
+                                    "byte": 409
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 32,
+                                    "byte": 436
+                                }
+                            }
+                        }
+                    },
+                    "false": {
+                        "value": false,
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 5,
+                                    "byte": 409
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 32,
+                                    "byte": 436
+                                }
+                            }
+                        }
+                    },
+                    "hello": {
+                        "value": "hello",
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 5,
+                                    "byte": 409
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 32,
+                                    "byte": 436
+                                }
+                            }
+                        }
+                    },
+                    "map": {
+                        "value": {
+                            "blue": {
+                                "value": 42,
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 20,
+                                            "column": 5,
+                                            "byte": 409
+                                        },
+                                        "end": {
+                                            "line": 20,
+                                            "column": 32,
+                                            "byte": 436
+                                        }
+                                    }
+                                }
+                            },
+                            "hello": {
+                                "value": "world",
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 20,
+                                            "column": 5,
+                                            "byte": 409
+                                        },
+                                        "end": {
+                                            "line": 20,
+                                            "column": 32,
+                                            "byte": 436
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 5,
+                                    "byte": 409
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 32,
+                                    "byte": 436
+                                }
+                            }
+                        }
+                    },
+                    "null": {
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 5,
+                                    "byte": 409
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 32,
+                                    "byte": 436
+                                }
+                            }
+                        }
+                    },
+                    "number": {
+                        "value": 42,
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 5,
+                                    "byte": 409
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 32,
+                                    "byte": 436
+                                }
+                            }
+                        }
+                    },
+                    "oneOf": {
+                        "value": 42,
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 5,
+                                    "byte": 409
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 32,
+                                    "byte": 436
+                                }
+                            }
+                        }
+                    },
+                    "pi": {
+                        "value": 3.14,
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 5,
+                                    "byte": 409
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 32,
+                                    "byte": 436
+                                }
+                            }
+                        }
+                    },
+                    "record": {
+                        "value": {
+                            "foo": {
+                                "value": "bar",
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 20,
+                                            "column": 5,
+                                            "byte": 409
+                                        },
+                                        "end": {
+                                            "line": 20,
+                                            "column": 32,
+                                            "byte": 436
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 5,
+                                    "byte": 409
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 32,
+                                    "byte": 436
+                                }
+                            }
+                        }
+                    },
+                    "ref": {
+                        "value": {
+                            "baz": {
+                                "value": "qux",
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 20,
+                                            "column": 5,
+                                            "byte": 409
+                                        },
+                                        "end": {
+                                            "line": 20,
+                                            "column": 32,
+                                            "byte": 436
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 5,
+                                    "byte": 409
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 32,
+                                    "byte": 436
+                                }
+                            }
+                        }
+                    },
+                    "string": {
+                        "value": "esc",
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 5,
+                                    "byte": 409
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 32,
+                                    "byte": 436
+                                }
+                            }
+                        }
+                    },
+                    "true": {
+                        "value": true,
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 5,
+                                    "byte": 409
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 32,
+                                    "byte": 436
+                                }
+                            }
+                        }
+                    },
+                    "tuple": {
+                        "value": [
+                            {
+                                "value": "hello",
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 20,
+                                            "column": 5,
+                                            "byte": 409
+                                        },
+                                        "end": {
+                                            "line": 20,
+                                            "column": 32,
+                                            "byte": 436
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "value": "world",
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 20,
+                                            "column": 5,
+                                            "byte": 409
+                                        },
+                                        "end": {
+                                            "line": 20,
+                                            "column": 32,
+                                            "byte": 436
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 5,
+                                    "byte": 409
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 32,
+                                    "byte": 436
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "schema",
+                        "begin": {
+                            "line": 20,
+                            "column": 5,
+                            "byte": 409
+                        },
+                        "end": {
+                            "line": 20,
+                            "column": 32,
+                            "byte": 436
+                        }
+                    }
+                }
+            },
+            "source": {
+                "value": {
+                    "anyOf": {
+                        "value": "hello",
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 22
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 22,
+                                    "byte": 394
+                                }
+                            }
+                        }
+                    },
+                    "array": {
+                        "value": [
+                            {
+                                "value": 2,
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 5,
+                                            "byte": 22
+                                        },
+                                        "end": {
+                                            "line": 18,
+                                            "column": 22,
+                                            "byte": 394
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "value": "items",
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 5,
+                                            "byte": 22
+                                        },
+                                        "end": {
+                                            "line": 18,
+                                            "column": 22,
+                                            "byte": 394
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "value": {
+                                    "some": {
+                                        "value": "object",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "schema",
+                                                "begin": {
+                                                    "line": 3,
+                                                    "column": 5,
+                                                    "byte": 22
+                                                },
+                                                "end": {
+                                                    "line": 18,
+                                                    "column": 22,
+                                                    "byte": 394
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 5,
+                                            "byte": 22
+                                        },
+                                        "end": {
+                                            "line": 18,
+                                            "column": 22,
+                                            "byte": 394
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "value": [
+                                    {
+                                        "value": "array",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "schema",
+                                                "begin": {
+                                                    "line": 3,
+                                                    "column": 5,
+                                                    "byte": 22
+                                                },
+                                                "end": {
+                                                    "line": 18,
+                                                    "column": 22,
+                                                    "byte": 394
+                                                }
+                                            }
+                                        }
+                                    }
+                                ],
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 5,
+                                            "byte": 22
+                                        },
+                                        "end": {
+                                            "line": 18,
+                                            "column": 22,
+                                            "byte": 394
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 22
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 22,
+                                    "byte": 394
+                                }
+                            }
+                        }
+                    },
+                    "boolean": {
+                        "value": true,
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 22
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 22,
+                                    "byte": 394
+                                }
+                            }
+                        }
+                    },
+                    "false": {
+                        "value": false,
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 22
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 22,
+                                    "byte": 394
+                                }
+                            }
+                        }
+                    },
+                    "hello": {
+                        "value": "hello",
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 22
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 22,
+                                    "byte": 394
+                                }
+                            }
+                        }
+                    },
+                    "map": {
+                        "value": {
+                            "blue": {
+                                "value": 42,
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 5,
+                                            "byte": 22
+                                        },
+                                        "end": {
+                                            "line": 18,
+                                            "column": 22,
+                                            "byte": 394
+                                        }
+                                    }
+                                }
+                            },
+                            "hello": {
+                                "value": "world",
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 5,
+                                            "byte": 22
+                                        },
+                                        "end": {
+                                            "line": 18,
+                                            "column": 22,
+                                            "byte": 394
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 22
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 22,
+                                    "byte": 394
+                                }
+                            }
+                        }
+                    },
+                    "null": {
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 22
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 22,
+                                    "byte": 394
+                                }
+                            }
+                        }
+                    },
+                    "number": {
+                        "value": 42,
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 22
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 22,
+                                    "byte": 394
+                                }
+                            }
+                        }
+                    },
+                    "oneOf": {
+                        "value": 42,
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 22
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 22,
+                                    "byte": 394
+                                }
+                            }
+                        }
+                    },
+                    "pi": {
+                        "value": 3.14,
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 22
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 22,
+                                    "byte": 394
+                                }
+                            }
+                        }
+                    },
+                    "record": {
+                        "value": {
+                            "foo": {
+                                "value": "bar",
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 5,
+                                            "byte": 22
+                                        },
+                                        "end": {
+                                            "line": 18,
+                                            "column": 22,
+                                            "byte": 394
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 22
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 22,
+                                    "byte": 394
+                                }
+                            }
+                        }
+                    },
+                    "ref": {
+                        "value": {
+                            "baz": {
+                                "value": "qux",
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 5,
+                                            "byte": 22
+                                        },
+                                        "end": {
+                                            "line": 18,
+                                            "column": 22,
+                                            "byte": 394
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 22
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 22,
+                                    "byte": 394
+                                }
+                            }
+                        }
+                    },
+                    "string": {
+                        "value": "esc",
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 22
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 22,
+                                    "byte": 394
+                                }
+                            }
+                        }
+                    },
+                    "true": {
+                        "value": true,
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 22
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 22,
+                                    "byte": 394
+                                }
+                            }
+                        }
+                    },
+                    "tuple": {
+                        "value": [
+                            {
+                                "value": "hello",
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 5,
+                                            "byte": 22
+                                        },
+                                        "end": {
+                                            "line": 18,
+                                            "column": 22,
+                                            "byte": 394
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "value": "world",
+                                "trace": {
+                                    "def": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 5,
+                                            "byte": 22
+                                        },
+                                        "end": {
+                                            "line": 18,
+                                            "column": 22,
+                                            "byte": 394
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "trace": {
+                            "def": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 22
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 22,
+                                    "byte": 394
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "schema",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 22
+                        },
+                        "end": {
+                            "line": 18,
+                            "column": 22,
+                            "byte": 394
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "accesses": {
+                    "prefixItems": [
+                        {
+                            "type": "string",
+                            "const": "bar"
+                        },
+                        {
+                            "type": "string",
+                            "const": "hello"
+                        },
+                        {
+                            "type": "string",
+                            "const": "world"
+                        },
+                        {
+                            "type": "string",
+                            "const": "items"
+                        },
+                        {
+                            "type": "string",
+                            "const": "object"
+                        },
+                        {
+                            "type": "string",
+                            "const": "array"
+                        }
+                    ],
+                    "items": false,
+                    "type": "array"
+                },
+                "sink": {
+                    "properties": {
+                        "anyOf": {
+                            "type": "string",
+                            "const": "hello"
+                        },
+                        "array": {
+                            "prefixItems": [
+                                {
+                                    "type": "number",
+                                    "const": 2
+                                },
+                                {
+                                    "type": "string",
+                                    "const": "items"
+                                },
+                                {
+                                    "properties": {
+                                        "some": {
+                                            "type": "string",
+                                            "const": "object"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "some"
+                                    ]
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "array"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "boolean": {
+                            "type": "boolean",
+                            "const": true
+                        },
+                        "false": {
+                            "type": "boolean",
+                            "const": false
+                        },
+                        "hello": {
+                            "type": "string",
+                            "const": "hello"
+                        },
+                        "map": {
+                            "properties": {
+                                "blue": {
+                                    "type": "number",
+                                    "const": 42
+                                },
+                                "hello": {
+                                    "type": "string",
+                                    "const": "world"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "blue",
+                                "hello"
+                            ]
+                        },
+                        "null": {
+                            "type": "null"
+                        },
+                        "number": {
+                            "type": "number",
+                            "const": 42
+                        },
+                        "oneOf": {
+                            "type": "number",
+                            "const": 42
+                        },
+                        "pi": {
+                            "type": "number",
+                            "const": 3.14
+                        },
+                        "record": {
+                            "properties": {
+                                "foo": {
+                                    "type": "string",
+                                    "const": "bar"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "foo"
+                            ]
+                        },
+                        "ref": {
+                            "properties": {
+                                "baz": {
+                                    "type": "string",
+                                    "const": "qux"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "baz"
+                            ]
+                        },
+                        "string": {
+                            "type": "string",
+                            "const": "esc"
+                        },
+                        "true": {
+                            "type": "boolean",
+                            "const": true
+                        },
+                        "tuple": {
+                            "prefixItems": [
+                                {
+                                    "type": "string",
+                                    "const": "hello"
+                                },
+                                {
+                                    "type": "string",
+                                    "const": "world"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "anyOf",
+                        "array",
+                        "boolean",
+                        "false",
+                        "hello",
+                        "map",
+                        "null",
+                        "number",
+                        "oneOf",
+                        "pi",
+                        "record",
+                        "ref",
+                        "string",
+                        "true",
+                        "tuple"
+                    ]
+                },
+                "source": {
+                    "properties": {
+                        "anyOf": {
+                            "type": "string",
+                            "const": "hello"
+                        },
+                        "array": {
+                            "prefixItems": [
+                                {
+                                    "type": "number",
+                                    "const": 2
+                                },
+                                {
+                                    "type": "string",
+                                    "const": "items"
+                                },
+                                {
+                                    "properties": {
+                                        "some": {
+                                            "type": "string",
+                                            "const": "object"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "some"
+                                    ]
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "array"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "boolean": {
+                            "type": "boolean",
+                            "const": true
+                        },
+                        "false": {
+                            "type": "boolean",
+                            "const": false
+                        },
+                        "hello": {
+                            "type": "string",
+                            "const": "hello"
+                        },
+                        "map": {
+                            "properties": {
+                                "blue": {
+                                    "type": "number",
+                                    "const": 42
+                                },
+                                "hello": {
+                                    "type": "string",
+                                    "const": "world"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "blue",
+                                "hello"
+                            ]
+                        },
+                        "null": {
+                            "type": "null"
+                        },
+                        "number": {
+                            "type": "number",
+                            "const": 42
+                        },
+                        "oneOf": {
+                            "type": "number",
+                            "const": 42
+                        },
+                        "pi": {
+                            "type": "number",
+                            "const": 3.14
+                        },
+                        "record": {
+                            "properties": {
+                                "foo": {
+                                    "type": "string",
+                                    "const": "bar"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "foo"
+                            ]
+                        },
+                        "ref": {
+                            "properties": {
+                                "baz": {
+                                    "type": "string",
+                                    "const": "qux"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "baz"
+                            ]
+                        },
+                        "string": {
+                            "type": "string",
+                            "const": "esc"
+                        },
+                        "true": {
+                            "type": "boolean",
+                            "const": true
+                        },
+                        "tuple": {
+                            "prefixItems": [
+                                {
+                                    "type": "string",
+                                    "const": "hello"
+                                },
+                                {
+                                    "type": "string",
+                                    "const": "world"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "anyOf",
+                        "array",
+                        "boolean",
+                        "false",
+                        "hello",
+                        "map",
+                        "null",
+                        "number",
+                        "oneOf",
+                        "pi",
+                        "record",
+                        "ref",
+                        "string",
+                        "true",
+                        "tuple"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "accesses",
+                "sink",
+                "source"
+            ]
+        }
+    }
+}

--- a/schema/arrays.go
+++ b/schema/arrays.go
@@ -19,6 +19,22 @@ func Tuple(prefixItems ...Builder) *ArrayBuilder {
 	return Array().PrefixItems(prefixItems...).Items(Never())
 }
 
+func (b *ArrayBuilder) Defs(defs map[string]Builder) *ArrayBuilder {
+	return buildDefs(b, defs)
+}
+
+func (b *ArrayBuilder) Ref(ref string) *ArrayBuilder {
+	return buildRef(b, ref)
+}
+
+func (b *ArrayBuilder) AnyOf(anyOf ...Builder) *ArrayBuilder {
+	return buildAnyOf(b, anyOf)
+}
+
+func (b *ArrayBuilder) OneOf(oneOf ...Builder) *ArrayBuilder {
+	return buildOneOf(b, oneOf)
+}
+
 func (b *ArrayBuilder) PrefixItems(prefixItems ...Builder) *ArrayBuilder {
 	b.s.PrefixItems = make([]*Schema, len(prefixItems))
 	for i, e := range prefixItems {

--- a/schema/booleans.go
+++ b/schema/booleans.go
@@ -10,6 +10,18 @@ func Boolean() *BooleanBuilder {
 	return &BooleanBuilder{}
 }
 
+func (b *BooleanBuilder) Ref(ref string) *BooleanBuilder {
+	return buildRef(b, ref)
+}
+
+func (b *BooleanBuilder) AnyOf(anyOf ...Builder) *BooleanBuilder {
+	return buildAnyOf(b, anyOf)
+}
+
+func (b *BooleanBuilder) OneOf(oneOf ...Builder) *BooleanBuilder {
+	return buildOneOf(b, oneOf)
+}
+
 func (b *BooleanBuilder) Const(v bool) *BooleanBuilder {
 	b.s.Const = v
 	return b

--- a/schema/nulls.go
+++ b/schema/nulls.go
@@ -10,6 +10,18 @@ func Null() *NullBuilder {
 	return &NullBuilder{}
 }
 
+func (b *NullBuilder) Ref(ref string) *NullBuilder {
+	return buildRef(b, ref)
+}
+
+func (b *NullBuilder) AnyOf(anyOf ...Builder) *NullBuilder {
+	return buildAnyOf(b, anyOf)
+}
+
+func (b *NullBuilder) OneOf(oneOf ...Builder) *NullBuilder {
+	return buildOneOf(b, oneOf)
+}
+
 func (b *NullBuilder) Title(title string) *NullBuilder {
 	b.s.Title = title
 	return b

--- a/schema/numbers.go
+++ b/schema/numbers.go
@@ -12,6 +12,18 @@ func Number() *NumberBuilder {
 	return &NumberBuilder{}
 }
 
+func (b *NumberBuilder) Ref(ref string) *NumberBuilder {
+	return buildRef(b, ref)
+}
+
+func (b *NumberBuilder) AnyOf(anyOf ...Builder) *NumberBuilder {
+	return buildAnyOf(b, anyOf)
+}
+
+func (b *NumberBuilder) OneOf(oneOf ...Builder) *NumberBuilder {
+	return buildOneOf(b, oneOf)
+}
+
 func (b *NumberBuilder) Const(n json.Number) *NumberBuilder {
 	b.s.Const = n
 	return b

--- a/schema/objects.go
+++ b/schema/objects.go
@@ -25,6 +25,22 @@ func Record(m map[string]Builder) *ObjectBuilder {
 	return Object().Properties(m).Required(names...)
 }
 
+func (b *ObjectBuilder) Defs(defs map[string]Builder) *ObjectBuilder {
+	return buildDefs(b, defs)
+}
+
+func (b *ObjectBuilder) Ref(ref string) *ObjectBuilder {
+	return buildRef(b, ref)
+}
+
+func (b *ObjectBuilder) AnyOf(anyOf ...Builder) *ObjectBuilder {
+	return buildAnyOf(b, anyOf)
+}
+
+func (b *ObjectBuilder) OneOf(oneOf ...Builder) *ObjectBuilder {
+	return buildOneOf(b, oneOf)
+}
+
 func (b *ObjectBuilder) Properties(m map[string]Builder) *ObjectBuilder {
 	b.s.Properties = make(map[string]*Schema, len(m))
 	for k, v := range m {

--- a/schema/strings.go
+++ b/schema/strings.go
@@ -15,6 +15,18 @@ func String() *StringBuilder {
 	return &StringBuilder{}
 }
 
+func (b *StringBuilder) Ref(ref string) *StringBuilder {
+	return buildRef(b, ref)
+}
+
+func (b *StringBuilder) AnyOf(anyOf ...Builder) *StringBuilder {
+	return buildAnyOf(b, anyOf)
+}
+
+func (b *StringBuilder) OneOf(oneOf ...Builder) *StringBuilder {
+	return buildOneOf(b, oneOf)
+}
+
 func (b *StringBuilder) Const(n string) *StringBuilder {
 	b.s.Const = n
 	return b

--- a/schema/testdata/esc.json
+++ b/schema/testdata/esc.json
@@ -1,0 +1,789 @@
+{
+    "title": "Pulumi ESC Environment Schema",
+    "properties": {
+        "imports": {
+            "description": "The list of environments to import",
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "merge": {
+                                "description": "Controls whether or not this import participates in the JSON merge stack.",
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [ "merge" ]
+                    }
+                ]
+            }
+        },
+        "values": {
+            "description": "The configuration and secrets that make up the environment.",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/$defs/value"
+            }
+        }
+    },
+    "$defs": {
+        "value": {
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/value"
+                    }
+                },
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/value"
+                    }
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "fn::join": {
+                            "description": "Joins a list of strings to create a single string.",
+                            "type": "array",
+                            "minItems": 2,
+                            "maxItems": 2,
+                            "prefixItems": [
+                                {
+                                    "description": "The delimiter to place between elements. Must be a string.",
+                                    "$ref": "#/$defs/value"
+                                },
+                                {
+                                    "description": "The elements to join with the delimiter. Must be a list of strings.",
+                                    "$ref": "#/$defs/value"
+                                }
+                            ]
+                        }
+                    },
+                    "required": [ "fn::join" ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "fn::secret": {
+                            "description": "Marks its argument as secret. Downstream tools may use this information to e.g. redact secret values from logs.",
+                            "$ref": "#/$defs/value"
+                        }
+                    },
+                    "required": [ "fn::secret" ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "fn::toBase64": {
+                            "description": "Encodes a string as base64. Returns a string.",
+                            "$ref": "#/$defs/value"
+                        }
+                    },
+                    "required": [ "fn::toBase64" ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "fn::toJSON": {
+                            "description": "Encodes a value as JSON. Returns a string.",
+                            "$ref": "#/$defs/value"
+                        }
+                    },
+                    "required": [ "fn::toJSON" ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "fn::toString": {
+                            "description": "Encodes a value as a string.",
+                            "$ref": "#/$defs/value"
+                        }
+                    },
+                    "required": [ "fn::toString" ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "fn::open": {
+                            "oneOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "provider": {
+                                            "description": "Logs into an AWS account.",
+                                            "type": "string",
+                                            "const": "aws-login"
+                                        },
+                                        "inputs": {
+                                            "$ref": "#/$defs/aws-login"
+                                        }
+                                    },
+                                    "required": [ "provider", "inputs" ],
+                                    "additionalProperties": false
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "provider": {
+                                            "description": "Reads secrets from AWS Secrets Manager.",
+                                            "type": "string",
+                                            "const": "aws-secrets"
+                                        },
+                                        "inputs": {
+                                            "$ref": "#/$defs/aws-secrets"
+                                        }
+                                    },
+                                    "required": [ "provider", "inputs" ],
+                                    "additionalProperties": false
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "provider": {
+                                            "description": "Logs into Microsoft Azure.",
+                                            "type": "string",
+                                            "const": "azure-login"
+                                        },
+                                        "inputs": {
+                                            "$ref": "#/$defs/azure-login"
+                                        }
+                                    },
+                                    "required": [ "provider", "inputs" ],
+                                    "additionalProperties": false
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "provider": {
+                                            "description": "Reads secrets from Azure Key Vault.",
+                                            "type": "string",
+                                            "const": "azure-secrets"
+                                        },
+                                        "inputs": {
+                                            "$ref": "#/$defs/azure-secrets"
+                                        }
+                                    },
+                                    "required": [ "provider", "inputs" ],
+                                    "additionalProperties": false
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "provider": {
+                                            "description": "Logs into Google Cloud.",
+                                            "type": "string",
+                                            "const": "gcp-login"
+                                        },
+                                        "inputs": {
+                                            "$ref": "#/$defs/gcp-login"
+                                        }
+                                    },
+                                    "required": [ "provider", "inputs" ],
+                                    "additionalProperties": false
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "provider": {
+                                            "description": "Reads secrets from Google Secrets Manager.",
+                                            "type": "string",
+                                            "const": "gcp-secrets"
+                                        },
+                                        "inputs": {
+                                            "$ref": "#/$defs/gcp-secrets"
+                                        }
+                                    },
+                                    "required": [ "provider", "inputs" ],
+                                    "additionalProperties": false
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "provider": {
+                                            "description": "Logs into a Hashicorp Vault server.",
+                                            "type": "string",
+                                            "const": "vault-login"
+                                        },
+                                        "inputs": {
+                                            "$ref": "#/$defs/vault-login"
+                                        }
+                                    },
+                                    "required": [ "provider", "inputs" ],
+                                    "additionalProperties": false
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "provider": {
+                                            "description": "Reads secrets from a Hashicorp Vault server.",
+                                            "type": "string",
+                                            "const": "vault-secrets"
+                                        },
+                                        "inputs": {
+                                            "$ref": "#/$defs/vault-secrets"
+                                        }
+                                    },
+                                    "required": [ "provider", "inputs" ],
+                                    "additionalProperties": false
+                                }
+                            ]
+                        }
+                    },
+                    "required": [ "fn::open" ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "fn::open::aws-login": {
+                            "description": "Logs into an AWS account.",
+                            "$ref": "#/$defs/aws-login"
+                        }
+                    },
+                    "required": [ "fn::open::aws-login" ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "fn::open::aws-secrets": {
+                            "description": "Reads secrets from AWS Secrets Manager.",
+                            "$ref": "#/$defs/aws-secrets"
+                        }
+                    },
+                    "required": [ "fn::open::aws-secrets" ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "fn::open::azure-login": {
+                            "description": "Logs into Microsoft Azure.",
+                            "$ref": "#/$defs/azure-login"
+                        }
+                    },
+                    "required": [ "fn::open::azure-login" ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "fn::open::azure-secrets": {
+                            "description": "Reads secrets from Azure Key Vault.",
+                            "$ref": "#/$defs/azure-secrets"
+                        }
+                    },
+                    "required": [ "fn::open::azure-secrets" ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "fn::open::gcp-login": {
+                            "description": "Logs into Google Cloud.",
+                            "$ref": "#/$defs/gcp-login"
+                        }
+                    },
+                    "required": [ "fn::open::gcp-login" ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "fn::open::gcp-secrets": {
+                            "description": "Reads secrets from Google Secrets Manager.",
+                            "$ref": "#/$defs/gcp-secrets"
+                        }
+                    },
+                    "required": [ "fn::open::gcp-secrets" ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "fn::open::vault-login": {
+                            "description": "Logs into a Hashicorp Vault server.",
+                            "$ref": "#/$defs/vault-login"
+                        }
+                    },
+                    "required": [ "fn::open::vault-login" ],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "fn::open::vault-secrets": {
+                            "description": "Reads secrets from a Hashicorp Vault server.",
+                            "$ref": "#/$defs/vault-secrets"
+                        }
+                    },
+                    "required": [ "fn::open::vault-secrets" ],
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "aws-login": {
+            "properties": {
+                "oidc": {
+                    "properties": {
+                        "duration": {
+                            "type": "string",
+                            "pattern": "^([0-9]+h)?([0-9]+m)?([0-9]+s)?$",
+                            "description": "The duration of the role session."
+                        },
+                        "policyArns": {
+                            "items": {
+                                "type": "string",
+                                "maxLength": 2048,
+                                "minLength": 20
+                            },
+                            "type": "array",
+                            "description": "ARNs for additional policies to apply to the role session."
+                        },
+                        "roleArn": {
+                            "type": "string",
+                            "maxLength": 2048,
+                            "minLength": 20,
+                            "description": "The ARN of the role to assume."
+                        },
+                        "sessionName": {
+                            "type": "string",
+                            "maxLength": 64,
+                            "minLength": 2,
+                            "pattern": "[\\w+=,.@-]*",
+                            "description": "The name of the role session."
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "sessionName",
+                        "roleArn"
+                    ],
+                    "description": "Options for temporary OIDC credentials."
+                },
+                "static": {
+                    "properties": {
+                        "accessKeyId": {
+                            "type": "string",
+                            "description": "The AWS access key ID."
+                        },
+                        "secretAccessKey": {
+                            "type": "string",
+                            "description": "The AWS secret access key."
+                        },
+                        "sessionToken": {
+                            "type": "string",
+                            "description": "The AWS session token, if any."
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "accessKeyId",
+                        "secretAccessKey"
+                    ],
+                    "description": "Options for static credentials."
+                }
+            },
+            "type": "object"
+        },
+        "aws-secrets": {
+            "properties": {
+                "get": {
+                    "additionalProperties": {
+                        "properties": {
+                            "secretId": {
+                                "type": "string",
+                                "description": "The ID of the secret to get."
+                            },
+                            "versionId": {
+                                "type": "string",
+                                "description": "The version of the secret to get."
+                            },
+                            "versionStage": {
+                                "type": "string",
+                                "description": "The version stage of the secret to get."
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "secretId"
+                        ]
+                    },
+                    "type": "object",
+                    "minProperties": 1,
+                    "description": "The secrets to get."
+                },
+                "login": {
+                    "properties": {
+                        "accessKeyId": {
+                            "type": "string",
+                            "description": "The AWS access key ID."
+                        },
+                        "secretAccessKey": {
+                            "type": "string",
+                            "description": "The AWS secret access key."
+                        },
+                        "sessionToken": {
+                            "type": "string",
+                            "description": "The AWS session token, if any."
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "accessKeyId",
+                        "secretAccessKey"
+                    ],
+                    "description": "The credentials to use to get secrets."
+                }
+            },
+            "type": "object",
+            "required": [
+                "get",
+                "login"
+            ]
+        },
+        "azure-login": {
+            "properties": {
+                "clientId": {
+                    "type": "string",
+                    "description": "The client ID to use."
+                },
+                "clientSecret": {
+                    "type": "string",
+                    "description": "The client secret to use for authentication, if any."
+                },
+                "oidc": {
+                    "type": "boolean",
+                    "description": "True to use OIDC for authentication."
+                },
+                "subscriptionId": {
+                    "type": "string",
+                    "description": "The subscription ID to use."
+                },
+                "tenantId": {
+                    "type": "string",
+                    "description": "The tenant ID to use."
+                }
+            },
+            "type": "object",
+            "required": [
+                "clientId",
+                "tenantId",
+                "subscriptionId"
+            ]
+        },
+        "azure-secrets": {
+            "properties": {
+                "get": {
+                    "additionalProperties": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "The name of the secret to access."
+                            },
+                            "version": {
+                                "type": "string",
+                                "description": "The secret version to access."
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "type": "object",
+                    "minProperties": 1,
+                    "description": "A map from names to secrets to read from Azure Key Vault. The outputs will map each name to the secret's sensitive data."
+                },
+                "login": {
+                    "properties": {
+                        "clientId": {
+                            "type": "string",
+                            "description": "The client ID to use."
+                        },
+                        "clientSecret": {
+                            "type": "string",
+                            "description": "The client secret to use for authentication, if any."
+                        },
+                        "oidc": {
+                            "properties": {
+                                "token": {
+                                    "type": "string",
+                                    "description": "The OIDC token to use for authentication."
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "token"
+                            ],
+                            "description": "OIDC-related data, if OIDC is used for authentication."
+                        },
+                        "subscriptionId": {
+                            "type": "string",
+                            "description": "The subscription ID to use."
+                        },
+                        "tenantId": {
+                            "type": "string",
+                            "description": "The tenant ID to use."
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "clientId",
+                        "tenantId",
+                        "subscriptionId"
+                    ]
+                },
+                "vault": {
+                    "type": "string",
+                    "description": "The vault to read from"
+                }
+            },
+            "type": "object",
+            "required": [
+                "get",
+                "login",
+                "vault"
+            ]
+        },
+        "gcp-login": {
+            "properties": {
+                "accessToken": {
+                    "properties": {
+                        "accessToken": {
+                            "type": "string",
+                            "description": "The token used to authenticate with Google Cloud."
+                        },
+                        "serviceAccount": {
+                            "type": "string",
+                            "description": "The service account to impersonate, if any."
+                        },
+                        "tokenLifetime": {
+                            "type": "string",
+                            "pattern": "^([0-9]+h)?([0-9]+m)?([0-9]+s)?$",
+                            "description": "The lifetime of the temporary credentials when impersonating a service account."
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "accessToken"
+                    ],
+                    "description": "Options for access token login."
+                },
+                "oidc": {
+                    "properties": {
+                        "providerId": {
+                            "type": "string",
+                            "description": "The ID of the identity provider associated with the workload pool."
+                        },
+                        "region": {
+                            "type": "string",
+                            "description": "The region of the GCP project."
+                        },
+                        "serviceAccount": {
+                            "type": "string",
+                            "description": "The email address of the service account to use."
+                        },
+                        "tokenLifetime": {
+                            "type": "string",
+                            "pattern": "^([0-9]+h)?([0-9]+m)?([0-9]+s)?$",
+                            "description": "The lifetime of the temporary credentials."
+                        },
+                        "workloadPoolId": {
+                            "type": "string",
+                            "description": "The ID of the workload pool to use."
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "workloadPoolId",
+                        "providerId",
+                        "serviceAccount"
+                    ],
+                    "description": "Options for OIDC login."
+                },
+                "project": {
+                    "type": "number",
+                    "description": "The numerical ID of the GCP project"
+                }
+            },
+            "type": "object",
+            "required": [
+                "project"
+            ]
+        },
+        "gcp-secrets": {
+            "properties": {
+                "access": {
+                    "additionalProperties": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "The name of the secret to access."
+                            },
+                            "version": {
+                                "type": "number",
+                                "description": "The secret version to access."
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "type": "object",
+                    "minProperties": 1,
+                    "description": "A map from names to secrets to read from Google Cloud. The outputs will map each name to the secret's sensitive data."
+                },
+                "login": {
+                    "properties": {
+                        "accessToken": {
+                            "type": "string",
+                            "description": "The access token to use for authentication."
+                        },
+                        "project": {
+                            "type": "number",
+                            "description": "The numerical ID of the project to use."
+                        },
+                        "tokenType": {
+                            "type": "string",
+                            "description": "The type of the access token."
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "accessToken",
+                        "project",
+                        "tokenType"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "access",
+                "login"
+            ]
+        },
+        "vault-login": {
+            "properties": {
+                "address": {
+                    "type": "string",
+                    "description": "The URL of the Vault server. Must contain a scheme and hostname, but no path."
+                },
+                "jwt": {
+                    "properties": {
+                        "mount": {
+                            "type": "string",
+                            "description": "The name of the authentication engine mount."
+                        },
+                        "role": {
+                            "type": "string",
+                            "description": "The name of the role to use for login."
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "role"
+                    ],
+                    "description": "Options for JWT login. JWT login uses an OIDC token issued by the Pulumi Cloud to generate an ephemeral token."
+                },
+                "token": {
+                    "properties": {
+                        "displayName": {
+                            "type": "string",
+                            "description": "The display name of the ephemeral token. Defaults to 'pulumi'."
+                        },
+                        "maxTtl": {
+                            "type": "string",
+                            "pattern": "^([0-9]+h)?([0-9]+m)?([0-9]+s)?$",
+                            "description": "The maximum TTL of the ephemeral token."
+                        },
+                        "token": {
+                            "type": "string",
+                            "description": "The parent token."
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "token"
+                    ],
+                    "description": "Options for token login. Token login creates an ephemeral child token."
+                }
+            },
+            "type": "object",
+            "required": [
+                "address"
+            ]
+        },
+        "vault-secrets": {
+            "properties": {
+                "login": {
+                    "properties": {
+                        "address": {
+                            "type": "string",
+                            "description": "The URL of the Vault server. Must contain a scheme and hostname, but no path."
+                        },
+                        "token": {
+                            "type": "string",
+                            "description": "The token to use for authentication."
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "address",
+                        "token"
+                    ]
+                },
+                "read": {
+                    "additionalProperties": {
+                        "properties": {
+                            "field": {
+                                "type": "string",
+                                "description": "The field of the value to read."
+                            },
+                            "path": {
+                                "type": "string",
+                                "description": "The path to read."
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "path"
+                        ]
+                    },
+                    "type": "object",
+                    "minProperties": 1,
+                    "description": "A map from names to paths to read from the server. The outputs will map each name to the raw data for the value."
+                }
+            },
+            "type": "object",
+            "required": [
+                "login",
+                "read"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Add support to the schema package and the validator for anyOf, oneOf, $defs, and $ref.

When dealing with unknown values, the validator treats oneOf as if it were anyOf (i.e. it requires only that _some_ element of the oneOf validates the input, rather than _exactly one_ element). This is consistent with the generally liberal approach to validation taken by the evaluator when dealing with unknowns.

When dealing with concrete values, the usual JSON schema semantics apply.

These changes also add some additional tests to bring some additional coverage to the evaluator.