### PR TITLE
cli: add top-level open/run aliases

### DIFF
--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -31,8 +31,17 @@ func newEnvCmd(esc *escCommand) *cobra.Command {
 		Long: "Manage environments\n" +
 			"\n" +
 			"An environment is a named collection of possibly-secret, possibly-dynamic data.\n" +
-			"Each environment has a definition and may be opened in order to access its contents." +
-			"Opening an environment may involve generating new dynamic data.\n",
+			"Each environment has a definition and may be opened in order to access its contents.\n" +
+			"Opening an environment may involve generating new dynamic data.\n" +
+			"\n" +
+			"To begin working with environments, run the `env init` command:\n" +
+			"\n" +
+			"    env init\n" +
+			"\n" +
+			"This will prompt you to create a new environment to hold secrets and configuration.\n" +
+			"\n" +
+			"For more information, please visit the project page: https://www.pulumi.com/docs/esc",
+
 		Args: cmdutil.NoArgs,
 	}
 

--- a/cmd/esc/cli/esc.go
+++ b/cmd/esc/cli/esc.go
@@ -87,9 +87,9 @@ func New(opts *Options) *cobra.Command {
 			"    - %[1]s env get  : Get a property in an environment definition\n"+
 			"    - %[1]s env set  : Set a property in an environment definition\n"+
 			"    - %[1]s env edit : Edit an environment definition\n"+
-			"    - %[1]s env run  : Run a command within the context of an environment\n"+
-			"    - %[1]s env open : Open an environment and access its contents\n"+
 			"    - %[1]s env ls   : List available environments\n"+
+			"    - %[1]s run      : Run a command within the context of an environment\n"+
+			"    - %[1]s open     : Open an environment and access its contents\n"+
 			"\n"+
 			"For more information, please visit the project page: https://www.pulumi.com/docs/esc", command),
 	}
@@ -113,14 +113,23 @@ func New(opts *Options) *cobra.Command {
 		esc.newClient = client.New
 	}
 
-	cmd.AddCommand(newEnvCmd(esc))
-
-	if opts.ParentPath == "" {
-		cmd.AddCommand(newLoginCmd(esc))
-		cmd.AddCommand(newVersionCmd(esc))
-	}
+	env := newEnvCmd(esc)
+	cmd.AddCommand(env)
+	cmd.AddCommand(getCommand(env, "open"))
+	cmd.AddCommand(getCommand(env, "run"))
+	cmd.AddCommand(newLoginCmd(esc))
+	cmd.AddCommand(newVersionCmd(esc))
 
 	return cmd
+}
+
+func getCommand(parent *cobra.Command, name string) *cobra.Command {
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
 }
 
 func valueOrDefault[T comparable](v, def T) T {

--- a/cmd/esc/cli/testdata/usage-esc.yaml
+++ b/cmd/esc/cli/testdata/usage-esc.yaml
@@ -12,9 +12,9 @@ stdout: |
         - esc env get  : Get a property in an environment definition
         - esc env set  : Set a property in an environment definition
         - esc env edit : Edit an environment definition
-        - esc env run  : Run a command within the context of an environment
-        - esc env open : Open an environment and access its contents
         - esc env ls   : List available environments
+        - esc run      : Run a command within the context of an environment
+        - esc open     : Open an environment and access its contents
 
     For more information, please visit the project page: https://www.pulumi.com/docs/esc
 
@@ -26,6 +26,8 @@ stdout: |
       env         Manage environments
       help        Help about any command
       login       Log in to the Pulumi Cloud
+      open        Open the environment with the given name.
+      run         Open the environment with the given name and runs a command.
       version     Print esc's version number
 
     Flags:

--- a/cmd/esc/cli/testdata/usage-parent.yaml
+++ b/cmd/esc/cli/testdata/usage-parent.yaml
@@ -14,9 +14,9 @@ stdout: |
         - parent esc env get  : Get a property in an environment definition
         - parent esc env set  : Set a property in an environment definition
         - parent esc env edit : Edit an environment definition
-        - parent esc env run  : Run a command within the context of an environment
-        - parent esc env open : Open an environment and access its contents
         - parent esc env ls   : List available environments
+        - parent esc run      : Run a command within the context of an environment
+        - parent esc open     : Open an environment and access its contents
 
     For more information, please visit the project page: https://www.pulumi.com/docs/esc
 
@@ -25,6 +25,10 @@ stdout: |
 
     Available Commands:
       env         Manage environments
+      login       Log in to the Pulumi Cloud
+      open        Open the environment with the given name.
+      run         Open the environment with the given name and runs a command.
+      version     Print esc's version number
 
     Flags:
       -h, --help   help for esc


### PR DESCRIPTION
- Add open and run to the top-level `esc` command
- When a new CLI is created for embedding, do not skip adding login/logout/etc. Instead, let the embedded pluck those out if necessary.
- Fix the help text for `esc env`

Fixes #24.
Fixes #34.