### PR TITLE
cli: add a --secret flag to esc env set

### DIFF
--- a/cmd/esc/cli/testdata/env-edit-editor-abort.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-abort.yaml
@@ -1,4 +1,4 @@
-run: env edit test
+run: esc env edit test
 process:
   environ:
     EDITOR: my-editor

--- a/cmd/esc/cli/testdata/env-edit-editor-invalid.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-invalid.yaml
@@ -1,4 +1,4 @@
-run: env edit test
+run: esc env edit test
 process:
   environ:
     EDITOR: my-editor

--- a/cmd/esc/cli/testdata/env-edit-editor-not-found.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-not-found.yaml
@@ -1,5 +1,5 @@
-run: env edit test
-error: 'finding "my-editor" on path: command not found'
+run: esc env edit test
+error: exit status 1
 process:
   environ:
     EDITOR: my-editor

--- a/cmd/esc/cli/testdata/env-edit-editor-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-ok.yaml
@@ -1,4 +1,6 @@
-run: env edit test
+run: |
+  esc env edit test
+  esc env get test
 process:
   environ:
     EDITOR: my-editor
@@ -11,3 +13,6 @@ environments:
       foo: bar
 stdout: |
   Environment updated.
+  {
+    "foo": "baz"
+  }

--- a/cmd/esc/cli/testdata/env-edit-env-not-found.yaml
+++ b/cmd/esc/cli/testdata/env-edit-env-not-found.yaml
@@ -1,5 +1,5 @@
-run: env edit test
-error: 'getting environment definition: not found'
+run: esc env edit test
+error: exit status 1
 process:
   environ:
     EDITOR: my-editor

--- a/cmd/esc/cli/testdata/env-edit-flag-code-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-code-ok.yaml
@@ -1,4 +1,6 @@
-run: env edit test --editor code
+run: |
+  esc env edit test --editor code
+  esc env get test
 process:
   commands:
     code: |
@@ -10,3 +12,6 @@ environments:
       foo: bar
 stdout: |
   Environment updated.
+  {
+    "foo": "baz"
+  }

--- a/cmd/esc/cli/testdata/env-edit-flag-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-ok.yaml
@@ -1,4 +1,6 @@
-run: env edit test --editor my-editor
+run: |
+  esc env edit test --editor my-editor
+  esc env get test
 process:
   commands:
     my-editor: |
@@ -9,3 +11,6 @@ environments:
       foo: bar
 stdout: |
   Environment updated.
+  {
+    "foo": "baz"
+  }

--- a/cmd/esc/cli/testdata/env-edit-none-not-found.yaml
+++ b/cmd/esc/cli/testdata/env-edit-none-not-found.yaml
@@ -1,4 +1,4 @@
-run: env edit test
-error: No available editor. Please use the --editor flag or set one of the VISUAL or EDITOR environment variables.
+run: esc env edit test
+error: exit status 1
 stderr: |
   Error: No available editor. Please use the --editor flag or set one of the VISUAL or EDITOR environment variables.

--- a/cmd/esc/cli/testdata/env-edit-none-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-none-ok.yaml
@@ -1,4 +1,6 @@
-run: env edit test
+run: |
+  esc env edit test
+  esc env get test
 process:
   commands:
     vi: |
@@ -9,3 +11,6 @@ environments:
       foo: bar
 stdout: |
   Environment updated.
+  {
+    "foo": "baz"
+  }

--- a/cmd/esc/cli/testdata/env-edit-visual-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-visual-ok.yaml
@@ -1,4 +1,6 @@
-run: env edit test
+run: |
+  esc env edit test
+  esc env get test
 process:
   environ:
     VISUAL: my-editor
@@ -11,3 +13,6 @@ environments:
       foo: bar
 stdout: |
   Environment updated.
+  {
+    "foo": "baz"
+  }

--- a/cmd/esc/cli/testdata/env-init-conflict.yaml
+++ b/cmd/esc/cli/testdata/env-init-conflict.yaml
@@ -1,5 +1,5 @@
-run: env init dup
-error: already exists
+run: esc env init dup
+error: exit status 1
 environments:
   test-user/dup: arbitrary
 stderr: |

--- a/cmd/esc/cli/testdata/env-init-ok.yaml
+++ b/cmd/esc/cli/testdata/env-init-ok.yaml
@@ -1,1 +1,1 @@
-run: env init test-env
+run: esc env init test-env

--- a/cmd/esc/cli/testdata/env-ls.yaml
+++ b/cmd/esc/cli/testdata/env-ls.yaml
@@ -1,4 +1,4 @@
-run: env ls
+run: esc env ls
 environments:
   test-org-2/env: true
   test-org/env: true

--- a/cmd/esc/cli/testdata/env-set-invalid.yaml
+++ b/cmd/esc/cli/testdata/env-set-invalid.yaml
@@ -1,0 +1,12 @@
+run: |
+  esc env init test
+  esc env set test string foo
+  esc env set test object '{}'
+  esc env set test array '[]'
+  esc env set test string.bar baz || echo -n ""
+  esc env set test 'object[0]' foo || echo -n ""
+  esc env set test array.foo bar || echo -n ""
+stderr: |
+  Error: string.bar: expected an array or an object
+  Error: object[0]: key for a map must be a string
+  Error: array.foo: key for an array must be an int

--- a/cmd/esc/cli/testdata/env-set-secret-error.yaml
+++ b/cmd/esc/cli/testdata/env-set-secret-error.yaml
@@ -1,0 +1,6 @@
+run: |
+  esc env init test
+  esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+error: exit status 1
+stderr: |
+  Error: value looks like a secret; rerun with --secret to mark it as such, or --plaintext if you meant to leave it as plaintext

--- a/cmd/esc/cli/testdata/env-set-secret.yaml
+++ b/cmd/esc/cli/testdata/env-set-secret.yaml
@@ -1,0 +1,13 @@
+run: |
+  esc env init test
+  esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret
+  esc env get test
+  esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
+  esc env get test
+stdout: |
+  {
+    "password": "[secret]"
+  }
+  {
+    "password": "YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M="
+  }

--- a/cmd/esc/cli/testdata/env-set.yaml
+++ b/cmd/esc/cli/testdata/env-set.yaml
@@ -1,0 +1,193 @@
+run: |
+  esc env init test
+  esc env set test foo.bar.baz qux && esc env get test
+  esc env set test foo.bar.alpha zed && esc env get test
+  esc env set test 'foo.beta[0]' gamma && esc env get test
+  esc env set test 'foo.beta[1]' 42 && esc env get test
+  esc env set test open '{"fn::open::test": "esc"}' && esc env get test
+  esc env set test 'open["fn::open::test"]' cse && esc env get test
+  esc env set test array '[hello, world]' && esc env get test
+  esc env set test 'array[1]' esc && esc env get test
+  esc env set test 'array[2]' '{}' && esc env get test
+  esc env set test 'array[2].foo' bar && esc env get test
+  esc env init test2
+  esc env set test 'imports[0]' test2 && esc env get test
+  esc env init test3
+  esc env set test 'imports[1]' test3 && esc env get test
+stdout: |
+  {
+    "foo": {
+      "bar": {
+        "baz": "qux"
+      }
+    }
+  }
+  {
+    "foo": {
+      "bar": {
+        "alpha": "zed",
+        "baz": "qux"
+      }
+    }
+  }
+  {
+    "foo": {
+      "bar": {
+        "alpha": "zed",
+        "baz": "qux"
+      },
+      "beta": [
+        "gamma"
+      ]
+    }
+  }
+  {
+    "foo": {
+      "bar": {
+        "alpha": "zed",
+        "baz": "qux"
+      },
+      "beta": [
+        "gamma",
+        42
+      ]
+    }
+  }
+  {
+    "foo": {
+      "bar": {
+        "alpha": "zed",
+        "baz": "qux"
+      },
+      "beta": [
+        "gamma",
+        42
+      ]
+    },
+    "open": "[unknown]"
+  }
+  {
+    "foo": {
+      "bar": {
+        "alpha": "zed",
+        "baz": "qux"
+      },
+      "beta": [
+        "gamma",
+        42
+      ]
+    },
+    "open": "[unknown]"
+  }
+  {
+    "array": [
+      "hello",
+      "world"
+    ],
+    "foo": {
+      "bar": {
+        "alpha": "zed",
+        "baz": "qux"
+      },
+      "beta": [
+        "gamma",
+        42
+      ]
+    },
+    "open": "[unknown]"
+  }
+  {
+    "array": [
+      "hello",
+      "esc"
+    ],
+    "foo": {
+      "bar": {
+        "alpha": "zed",
+        "baz": "qux"
+      },
+      "beta": [
+        "gamma",
+        42
+      ]
+    },
+    "open": "[unknown]"
+  }
+  {
+    "array": [
+      "hello",
+      "esc",
+      {}
+    ],
+    "foo": {
+      "bar": {
+        "alpha": "zed",
+        "baz": "qux"
+      },
+      "beta": [
+        "gamma",
+        42
+      ]
+    },
+    "open": "[unknown]"
+  }
+  {
+    "array": [
+      "hello",
+      "esc",
+      {
+        "foo": "bar"
+      }
+    ],
+    "foo": {
+      "bar": {
+        "alpha": "zed",
+        "baz": "qux"
+      },
+      "beta": [
+        "gamma",
+        42
+      ]
+    },
+    "open": "[unknown]"
+  }
+  {
+    "array": [
+      "hello",
+      "esc",
+      {
+        "foo": "bar"
+      }
+    ],
+    "foo": {
+      "bar": {
+        "alpha": "zed",
+        "baz": "qux"
+      },
+      "beta": [
+        "gamma",
+        42
+      ]
+    },
+    "open": "[unknown]"
+  }
+  {
+    "array": [
+      "hello",
+      "esc",
+      {
+        "foo": "bar"
+      }
+    ],
+    "foo": {
+      "bar": {
+        "alpha": "zed",
+        "baz": "qux"
+      },
+      "beta": [
+        "gamma",
+        42
+      ]
+    },
+    "open": "[unknown]"
+  }

--- a/cmd/esc/cli/testdata/open-detailed.yaml
+++ b/cmd/esc/cli/testdata/open-detailed.yaml
@@ -1,4 +1,4 @@
-run: open test --format detailed
+run: esc open test --format detailed
 environments:
   test-user/test:
     imports:

--- a/cmd/esc/cli/testdata/open-dotenv.yaml
+++ b/cmd/esc/cli/testdata/open-dotenv.yaml
@@ -1,4 +1,4 @@
-run: open test --format dotenv
+run: esc open test --format dotenv
 environments:
   test-user/test:
     imports:

--- a/cmd/esc/cli/testdata/open-invalid.yaml
+++ b/cmd/esc/cli/testdata/open-invalid.yaml
@@ -1,4 +1,4 @@
-run: open test --format=flat
-error: unknown output format "flat"
+run: esc open test --format=flat
+error: exit status 1
 stderr: |
   Error: unknown output format "flat"

--- a/cmd/esc/cli/testdata/open-json.yaml
+++ b/cmd/esc/cli/testdata/open-json.yaml
@@ -1,4 +1,4 @@
-run: open test --format json
+run: esc open test --format json
 environments:
   test-user/test:
     imports:

--- a/cmd/esc/cli/testdata/open-shell.yaml
+++ b/cmd/esc/cli/testdata/open-shell.yaml
@@ -1,4 +1,4 @@
-run: open test --format shell
+run: esc open test --format shell
 environments:
   test-user/test:
     imports:

--- a/cmd/esc/cli/testdata/open-string.yaml
+++ b/cmd/esc/cli/testdata/open-string.yaml
@@ -1,4 +1,4 @@
-run: open test --format string
+run: esc open test --format string
 environments:
   test-user/test:
     imports:

--- a/cmd/esc/cli/testdata/usage-esc.yaml
+++ b/cmd/esc/cli/testdata/usage-esc.yaml
@@ -1,3 +1,4 @@
+run: esc
 stdout: |
   Pulumi ESC - Manage environments, secrets, and configuration
 

--- a/cmd/esc/cli/testdata/usage-parent.yaml
+++ b/cmd/esc/cli/testdata/usage-parent.yaml
@@ -1,5 +1,5 @@
 parent: parent
-run: esc
+run: parent esc
 stdout: |
   Pulumi ESC - Manage environments, secrets, and configuration
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pulumi/esc
 go 1.21.0
 
 require (
+	github.com/ccojocar/zxcvbn-go v1.0.1
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/google/go-querystring v1.1.0
 	github.com/hashicorp/hcl/v2 v2.17.0

--- a/go.sum
+++ b/go.sum
@@ -329,6 +329,8 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
+github.com/ccojocar/zxcvbn-go v1.0.1 h1:+sxrANSCj6CdadkcMnvde/GWU1vZiiXRbqYSCalV4/4=
+github.com/ccojocar/zxcvbn-go v1.0.1/go.mod h1:g1qkXtUSvHP8lhHp5GrSmTz6uWALGRMQdw6Qnz/hi60=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=


### PR DESCRIPTION
This flag marks the value as secret by automatically wrapping it in a call to `fn::secret`. These changes also autodetect secret-ish values using the same method as the Pulumi CLI.

These changes also tweak the test harness so that the value of `run` is a shell script rather than a single `esc` command. This allows for richer tests by chaining commands.

Fixes #29.