### PR TITLE
chore: enable code coverage

### DIFF
--- a/.github/workflows/publish-prerelease.yaml
+++ b/.github/workflows/publish-prerelease.yaml
@@ -13,6 +13,8 @@ jobs:
     uses: ./.github/workflows/stage-lint.yml
   test:
     uses: ./.github/workflows/stage-test.yml
+    with:
+      enable-coverage: true
   publish:
     needs: [test, lint]
     uses: ./.github/workflows/stage-publish.yml

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -14,6 +14,8 @@ jobs:
     uses: ./.github/workflows/stage-lint.yml
   test:
     uses: ./.github/workflows/stage-test.yml
+    with:
+      enable-coverage: true
   publish:
     needs: [test, lint]
     uses: ./.github/workflows/stage-publish.yml

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -16,6 +16,8 @@ jobs:
     uses: ./.github/workflows/stage-lint.yml
   test:
     uses: ./.github/workflows/stage-test.yml
+    with:
+      enable-coverage: true
   publish:
     needs: [test, lint]
     uses: ./.github/workflows/stage-publish.yml

--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -9,6 +9,12 @@ on:
         required: false
         type: string
 
+      enable-coverage:
+        description: Collects coverage data from tests.
+        default: false
+        required: false
+        type: boolean
+
 jobs:
   test:
     name: Test
@@ -25,8 +31,19 @@ jobs:
           stable: ${{ matrix.go-stable }}
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v2
+      - name: Test w/coverage
+        if: ${{ inputs.enable-coverage }}
+        run: make test_cover
       - name: Test
+        if: ${{ ! inputs.enable-coverate }}
         run: make test
+      - name: Upload code coverage
+        if: ${{ inputs.enable-coverage }}
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: false
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,6 @@ build_debug:: ensure
 
 test:: build
 	${GO} test --timeout 30m -short -count 1 -parallel ${CONCURRENCY} ./...
+
+test_cover:: build
+	${GO} test --timeout 30m -count 1 -coverpkg=github.com/pulumi/esc/... -race -coverprofile=coverage.out -parallel ${CONCURRENCY} ./...

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+coverage:
+  status:
+
+    # Project tracks and reports the project-level coverage.
+    project:
+      default:
+        informational: true
+
+    # Patch tracks the coverage of the changes in a single patch.
+    patch:
+      default:
+        informational: true
+
+ignore:
+  # None of the test data should count against coverage.
+  - "**/testdata"
+
+# Don't comment on PRs.
+comment: false
+
+# Don't post annotations to GitHub.
+github_checks:
+    annotations: false


### PR DESCRIPTION
Add a Makefile target that will run tests with coverage profiling enabled. Upload coverage data as part of the various publish jobs.