### PR TITLE
cli: env get fixes 

### DIFF
--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -189,7 +189,7 @@ func (n yamlNode) get(path resource.PropertyPath) (_ *yaml.Node, ok bool) {
 		if !ok || index < 0 || index >= len(n.Content) {
 			return nil, false
 		}
-		return yamlNode{n.Content[index]}.get(path)
+		return yamlNode{n.Content[index]}.get(path[1:])
 	case yaml.MappingNode:
 		key, ok := path[0].(string)
 		if !ok {

--- a/cmd/esc/cli/templates.go
+++ b/cmd/esc/cli/templates.go
@@ -1,0 +1,31 @@
+// Copyright 2023, Pulumi Corporation.
+
+package cli
+
+import (
+	"embed"
+	"fmt"
+	"text/template"
+)
+
+//go:embed templates
+var templatesFS embed.FS
+
+var (
+	envGetTemplate *template.Template
+)
+
+func init() {
+	mustLookup := func(t *template.Template, name string) *template.Template {
+		tt := t.Lookup(name)
+		if tt == nil {
+			panic(fmt.Errorf("missing template %v", name))
+		}
+		return tt
+	}
+
+	root := template.New("templates")
+
+	templates := template.Must(root.ParseFS(templatesFS, "templates/*.tmpl"))
+	envGetTemplate = mustLookup(templates, "env-get.tmpl")
+}

--- a/cmd/esc/cli/templates/env-get.tmpl
+++ b/cmd/esc/cli/templates/env-get.tmpl
@@ -1,0 +1,12 @@
+{{ if .Value }}# Value
+```json
+{{.Value}}
+```
+{{ end -}}{{ if .Definition }}# Definition
+```yaml
+{{.Definition}}
+```
+{{ end -}}{{ if .Stack }}
+# Stack
+{{ range .Stack }}- {{ . }}
+{{ end }}{{ end }}

--- a/cmd/esc/cli/testdata/env-edit-editor-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-ok.yaml
@@ -11,8 +11,18 @@ environments:
   test-user/test:
     values:
       foo: bar
-stdout: |
+stdout: |+
   Environment updated.
+  # Value
+  ```json
   {
     "foo": "baz"
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo: baz
+
+  ```
+

--- a/cmd/esc/cli/testdata/env-edit-flag-code-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-code-ok.yaml
@@ -10,8 +10,18 @@ environments:
   test-user/test:
     values:
       foo: bar
-stdout: |
+stdout: |+
   Environment updated.
+  # Value
+  ```json
   {
     "foo": "baz"
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo: baz
+
+  ```
+

--- a/cmd/esc/cli/testdata/env-edit-flag-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-ok.yaml
@@ -9,8 +9,18 @@ environments:
   test-user/test:
     values:
       foo: bar
-stdout: |
+stdout: |+
   Environment updated.
+  # Value
+  ```json
   {
     "foo": "baz"
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo: baz
+
+  ```
+

--- a/cmd/esc/cli/testdata/env-edit-none-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-none-ok.yaml
@@ -9,8 +9,18 @@ environments:
   test-user/test:
     values:
       foo: bar
-stdout: |
+stdout: |+
   Environment updated.
+  # Value
+  ```json
   {
     "foo": "baz"
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo: baz
+
+  ```
+

--- a/cmd/esc/cli/testdata/env-edit-visual-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-visual-ok.yaml
@@ -11,8 +11,18 @@ environments:
   test-user/test:
     values:
       foo: bar
-stdout: |
+stdout: |+
   Environment updated.
+  # Value
+  ```json
   {
     "foo": "baz"
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo: baz
+
+  ```
+

--- a/cmd/esc/cli/testdata/env-get-all-value-dotenv.yaml
+++ b/cmd/esc/cli/testdata/env-get-all-value-dotenv.yaml
@@ -1,0 +1,24 @@
+run: esc env get test --value=dotenv
+environments:
+  test-user/a: {}
+  test-user/b: {}
+  test-user/test:
+    imports:
+      - a
+      - b
+    values:
+      # comment
+      "null": null
+      boolean: true
+      number: 42
+      string: esc
+      array: [hello, world]
+      object: {hello: world}
+      open:
+        fn::open::test: echo
+      environmentVariables:
+        STRING: ${string}
+        OBJECT: {'fn::toJSON': "${object}"}
+stdout: |
+  OBJECT="{\"hello\":\"world\"}"
+  STRING="esc"

--- a/cmd/esc/cli/testdata/env-get-all-value-shell.yaml
+++ b/cmd/esc/cli/testdata/env-get-all-value-shell.yaml
@@ -1,0 +1,24 @@
+run: esc env get test --value=shell
+environments:
+  test-user/a: {}
+  test-user/b: {}
+  test-user/test:
+    imports:
+      - a
+      - b
+    values:
+      # comment
+      "null": null
+      boolean: true
+      number: 42
+      string: esc
+      array: [hello, world]
+      object: {hello: world}
+      open:
+        fn::open::test: echo
+      environmentVariables:
+        STRING: ${string}
+        OBJECT: {'fn::toJSON': "${object}"}
+stdout: |
+  export OBJECT="{\"hello\":\"world\"}"
+  export STRING="esc"

--- a/cmd/esc/cli/testdata/env-get-all.yaml
+++ b/cmd/esc/cli/testdata/env-get-all.yaml
@@ -1,0 +1,54 @@
+run: esc env get test
+environments:
+  test-user/a: {}
+  test-user/b: {}
+  test-user/test:
+    imports:
+      - a
+      - b
+    values:
+      # comment
+      "null": null
+      boolean: true
+      number: 42
+      string: esc
+      array: [hello, world]
+      object: {hello: world}
+      open:
+        fn::open::test: echo
+stdout: |+
+  # Value
+  ```json
+  {
+    "array": [
+      "hello",
+      "world"
+    ],
+    "boolean": true,
+    "null": null,
+    "number": 42,
+    "object": {
+      "hello": "world"
+    },
+    "open": "[unknown]",
+    "string": "esc"
+  }
+  ```
+  # Definition
+  ```yaml
+  imports:
+    - a
+    - b
+  values:
+    # comment
+    "null": null
+    boolean: true
+    number: 42
+    string: esc
+    array: [hello, world]
+    object: {hello: world}
+    open:
+      fn::open::test: echo
+
+  ```
+

--- a/cmd/esc/cli/testdata/env-get-each-import.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-import.yaml
@@ -1,0 +1,47 @@
+run: |
+  esc env get test imports
+  esc env get test 'imports[0]'
+  esc env get test 'imports[1]'
+environments:
+  test-user/a:
+    values:
+      object: {hello: esc, goodbye: world}
+  test-user/b:
+    values:
+      string: foo
+      object: {goodbye: all}
+  test-user/test:
+    imports:
+      - a
+      - b
+    values:
+      # comment
+      "null": null
+      boolean: true
+      number: 42
+      string: esc
+      array: [hello, world]
+      object: {hello: world}
+      open:
+        fn::open::test:
+          foo: bar
+stdout: |+
+  # Definition
+  ```yaml
+  - a
+  - b
+
+  ```
+
+  # Definition
+  ```yaml
+  a
+
+  ```
+
+  # Definition
+  ```yaml
+  b
+
+  ```
+

--- a/cmd/esc/cli/testdata/env-get-each-value-detailed.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-value-detailed.yaml
@@ -1,0 +1,524 @@
+run: |
+  esc env get test --value detailed null
+  esc env get test --value detailed boolean
+  esc env get test --value detailed number
+  esc env get test --value detailed string
+  esc env get test --value detailed array
+  esc env get test --value detailed 'array[0]'
+  esc env get test --value detailed 'array[1]'
+  esc env get test --value detailed object
+  esc env get test --value detailed object.hello
+  esc env get test --value detailed object.goodbye
+  esc env get test --value detailed open
+environments:
+  test-user/a:
+    values:
+      object: {hello: esc, goodbye: world}
+  test-user/b:
+    values:
+      string: foo
+      object: {goodbye: all}
+  test-user/test:
+    imports:
+      - a
+      - b
+    values:
+      # comment
+      "null": null
+      boolean: true
+      number: 42
+      string: esc
+      array: [hello, world]
+      object: {hello: world}
+      open:
+        fn::open::test: echo
+stdout: |
+  {
+    "trace": {
+      "def": {
+        "environment": "\u003cyaml\u003e",
+        "begin": {
+          "line": 6,
+          "column": 13,
+          "byte": 59
+        },
+        "end": {
+          "line": 6,
+          "column": 17,
+          "byte": 63
+        }
+      }
+    }
+  }
+  {
+    "value": true,
+    "trace": {
+      "def": {
+        "environment": "\u003cyaml\u003e",
+        "begin": {
+          "line": 7,
+          "column": 14,
+          "byte": 77
+        },
+        "end": {
+          "line": 7,
+          "column": 18,
+          "byte": 81
+        }
+      }
+    }
+  }
+  {
+    "value": 42,
+    "trace": {
+      "def": {
+        "environment": "\u003cyaml\u003e",
+        "begin": {
+          "line": 8,
+          "column": 13,
+          "byte": 94
+        },
+        "end": {
+          "line": 8,
+          "column": 15,
+          "byte": 96
+        }
+      }
+    }
+  }
+  {
+    "value": "esc",
+    "trace": {
+      "def": {
+        "environment": "\u003cyaml\u003e",
+        "begin": {
+          "line": 9,
+          "column": 13,
+          "byte": 109
+        },
+        "end": {
+          "line": 9,
+          "column": 16,
+          "byte": 112
+        }
+      },
+      "base": {
+        "value": "foo",
+        "trace": {
+          "def": {
+            "environment": "b",
+            "begin": {
+              "line": 2,
+              "column": 13,
+              "byte": 20
+            },
+            "end": {
+              "line": 2,
+              "column": 16,
+              "byte": 23
+            }
+          }
+        }
+      }
+    }
+  }
+  {
+    "value": [
+      {
+        "value": "hello",
+        "trace": {
+          "def": {
+            "environment": "\u003cyaml\u003e",
+            "begin": {
+              "line": 10,
+              "column": 13,
+              "byte": 125
+            },
+            "end": {
+              "line": 10,
+              "column": 18,
+              "byte": 130
+            }
+          }
+        }
+      },
+      {
+        "value": "world",
+        "trace": {
+          "def": {
+            "environment": "\u003cyaml\u003e",
+            "begin": {
+              "line": 10,
+              "column": 20,
+              "byte": 132
+            },
+            "end": {
+              "line": 10,
+              "column": 25,
+              "byte": 137
+            }
+          }
+        }
+      }
+    ],
+    "trace": {
+      "def": {
+        "environment": "\u003cyaml\u003e",
+        "begin": {
+          "line": 10,
+          "column": 12,
+          "byte": 124
+        },
+        "end": {
+          "line": 10,
+          "column": 25,
+          "byte": 137
+        }
+      }
+    }
+  }
+  {
+    "value": "hello",
+    "trace": {
+      "def": {
+        "environment": "\u003cyaml\u003e",
+        "begin": {
+          "line": 10,
+          "column": 13,
+          "byte": 125
+        },
+        "end": {
+          "line": 10,
+          "column": 18,
+          "byte": 130
+        }
+      }
+    }
+  }
+  {
+    "value": "world",
+    "trace": {
+      "def": {
+        "environment": "\u003cyaml\u003e",
+        "begin": {
+          "line": 10,
+          "column": 20,
+          "byte": 132
+        },
+        "end": {
+          "line": 10,
+          "column": 25,
+          "byte": 137
+        }
+      }
+    }
+  }
+  {
+    "value": {
+      "goodbye": {
+        "value": "all",
+        "trace": {
+          "def": {
+            "environment": "b",
+            "begin": {
+              "line": 3,
+              "column": 23,
+              "byte": 46
+            },
+            "end": {
+              "line": 3,
+              "column": 26,
+              "byte": 49
+            }
+          },
+          "base": {
+            "value": "world",
+            "trace": {
+              "def": {
+                "environment": "a",
+                "begin": {
+                  "line": 2,
+                  "column": 35,
+                  "byte": 42
+                },
+                "end": {
+                  "line": 2,
+                  "column": 40,
+                  "byte": 47
+                }
+              }
+            }
+          }
+        }
+      },
+      "hello": {
+        "value": "world",
+        "trace": {
+          "def": {
+            "environment": "\u003cyaml\u003e",
+            "begin": {
+              "line": 11,
+              "column": 21,
+              "byte": 159
+            },
+            "end": {
+              "line": 11,
+              "column": 26,
+              "byte": 164
+            }
+          },
+          "base": {
+            "value": "esc",
+            "trace": {
+              "def": {
+                "environment": "a",
+                "begin": {
+                  "line": 2,
+                  "column": 21,
+                  "byte": 28
+                },
+                "end": {
+                  "line": 2,
+                  "column": 24,
+                  "byte": 31
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "trace": {
+      "def": {
+        "environment": "\u003cyaml\u003e",
+        "begin": {
+          "line": 11,
+          "column": 13,
+          "byte": 151
+        },
+        "end": {
+          "line": 11,
+          "column": 26,
+          "byte": 164
+        }
+      },
+      "base": {
+        "value": {
+          "goodbye": {
+            "value": "all",
+            "trace": {
+              "def": {
+                "environment": "b",
+                "begin": {
+                  "line": 3,
+                  "column": 23,
+                  "byte": 46
+                },
+                "end": {
+                  "line": 3,
+                  "column": 26,
+                  "byte": 49
+                }
+              },
+              "base": {
+                "value": "world",
+                "trace": {
+                  "def": {
+                    "environment": "a",
+                    "begin": {
+                      "line": 2,
+                      "column": 35,
+                      "byte": 42
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 40,
+                      "byte": 47
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "hello": {
+            "value": "esc",
+            "trace": {
+              "def": {
+                "environment": "a",
+                "begin": {
+                  "line": 2,
+                  "column": 21,
+                  "byte": 28
+                },
+                "end": {
+                  "line": 2,
+                  "column": 24,
+                  "byte": 31
+                }
+              }
+            }
+          }
+        },
+        "trace": {
+          "def": {
+            "environment": "b",
+            "begin": {
+              "line": 3,
+              "column": 13,
+              "byte": 36
+            },
+            "end": {
+              "line": 3,
+              "column": 26,
+              "byte": 49
+            }
+          },
+          "base": {
+            "value": {
+              "goodbye": {
+                "value": "world",
+                "trace": {
+                  "def": {
+                    "environment": "a",
+                    "begin": {
+                      "line": 2,
+                      "column": 35,
+                      "byte": 42
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 40,
+                      "byte": 47
+                    }
+                  }
+                }
+              },
+              "hello": {
+                "value": "esc",
+                "trace": {
+                  "def": {
+                    "environment": "a",
+                    "begin": {
+                      "line": 2,
+                      "column": 21,
+                      "byte": 28
+                    },
+                    "end": {
+                      "line": 2,
+                      "column": 24,
+                      "byte": 31
+                    }
+                  }
+                }
+              }
+            },
+            "trace": {
+              "def": {
+                "environment": "a",
+                "begin": {
+                  "line": 2,
+                  "column": 13,
+                  "byte": 20
+                },
+                "end": {
+                  "line": 2,
+                  "column": 40,
+                  "byte": 47
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  {
+    "value": "world",
+    "trace": {
+      "def": {
+        "environment": "\u003cyaml\u003e",
+        "begin": {
+          "line": 11,
+          "column": 21,
+          "byte": 159
+        },
+        "end": {
+          "line": 11,
+          "column": 26,
+          "byte": 164
+        }
+      },
+      "base": {
+        "value": "esc",
+        "trace": {
+          "def": {
+            "environment": "a",
+            "begin": {
+              "line": 2,
+              "column": 21,
+              "byte": 28
+            },
+            "end": {
+              "line": 2,
+              "column": 24,
+              "byte": 31
+            }
+          }
+        }
+      }
+    }
+  }
+  {
+    "value": "all",
+    "trace": {
+      "def": {
+        "environment": "b",
+        "begin": {
+          "line": 3,
+          "column": 23,
+          "byte": 46
+        },
+        "end": {
+          "line": 3,
+          "column": 26,
+          "byte": 49
+        }
+      },
+      "base": {
+        "value": "world",
+        "trace": {
+          "def": {
+            "environment": "a",
+            "begin": {
+              "line": 2,
+              "column": 35,
+              "byte": 42
+            },
+            "end": {
+              "line": 2,
+              "column": 40,
+              "byte": 47
+            }
+          }
+        }
+      }
+    }
+  }
+  {
+    "unknown": true,
+    "trace": {
+      "def": {
+        "environment": "\u003cyaml\u003e",
+        "begin": {
+          "line": 13,
+          "column": 9,
+          "byte": 184
+        },
+        "end": {
+          "line": 13,
+          "column": 29,
+          "byte": 204
+        }
+      }
+    }
+  }

--- a/cmd/esc/cli/testdata/env-get-each-value-json.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-value-json.yaml
@@ -1,0 +1,52 @@
+run: |
+  esc env get test --value json null
+  esc env get test --value json boolean
+  esc env get test --value json number
+  esc env get test --value json string
+  esc env get test --value json array
+  esc env get test --value json 'array[0]'
+  esc env get test --value json 'array[1]'
+  esc env get test --value json object
+  esc env get test --value json object.hello
+  esc env get test --value json object.goodbye
+  esc env get test --value json open
+environments:
+  test-user/a:
+    values:
+      object: {hello: esc, goodbye: world}
+  test-user/b:
+    values:
+      string: foo
+      object: {goodbye: all}
+  test-user/test:
+    imports:
+      - a
+      - b
+    values:
+      # comment
+      "null": null
+      boolean: true
+      number: 42
+      string: esc
+      array: [hello, world]
+      object: {hello: world}
+      open:
+        fn::open::test: echo
+stdout: |
+  null
+  true
+  42
+  "esc"
+  [
+    "hello",
+    "world"
+  ]
+  "hello"
+  "world"
+  {
+    "goodbye": "all",
+    "hello": "world"
+  }
+  "world"
+  "all"
+  "[unknown]"

--- a/cmd/esc/cli/testdata/env-get-each-value-string.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-value-string.yaml
@@ -1,0 +1,46 @@
+run: |
+  echo \"$(esc env get test --value string null)\"
+  esc env get test --value string boolean
+  esc env get test --value string number
+  esc env get test --value string string
+  esc env get test --value string array
+  esc env get test --value string 'array[0]'
+  esc env get test --value string 'array[1]'
+  esc env get test --value string object
+  esc env get test --value string object.hello
+  esc env get test --value string object.goodbye
+  esc env get test --value string open
+environments:
+  test-user/a:
+    values:
+      object: {hello: esc, goodbye: world}
+  test-user/b:
+    values:
+      string: foo
+      object: {goodbye: all}
+  test-user/test:
+    imports:
+      - a
+      - b
+    values:
+      # comment
+      "null": null
+      boolean: true
+      number: 42
+      string: esc
+      array: [hello, world]
+      object: {hello: world}
+      open:
+        fn::open::test: echo
+stdout: |
+  ""
+  true
+  42
+  esc
+  "hello","world"
+  hello
+  world
+  "goodbye"="all","hello"="world"
+  world
+  all
+  [unknown]

--- a/cmd/esc/cli/testdata/env-get-each.yaml
+++ b/cmd/esc/cli/testdata/env-get-each.yaml
@@ -1,0 +1,205 @@
+run: |
+  esc env get test null
+  esc env get test boolean
+  esc env get test number
+  esc env get test string
+  esc env get test array
+  esc env get test 'array[0]'
+  esc env get test 'array[1]'
+  esc env get test object
+  esc env get test object.hello
+  esc env get test object.goodbye
+  esc env get test open
+  esc env get test 'open["fn::open::test"]'
+  esc env get test 'open["fn::open::test"].foo'
+environments:
+  test-user/a:
+    values:
+      object: {hello: esc, goodbye: world}
+  test-user/b:
+    values:
+      string: foo
+      object: {goodbye: all}
+  test-user/test:
+    imports:
+      - a
+      - b
+    values:
+      # comment
+      "null": null
+      boolean: true
+      number: 42
+      string: esc
+      array: [hello, world]
+      object: {hello: world}
+      open:
+        fn::open::test:
+          foo: bar
+stdout: |+
+  # Value
+  ```json
+  null
+  ```
+  # Definition
+  ```yaml
+  null
+
+  ```
+
+  # Stack
+  - test:6:13
+
+  # Value
+  ```json
+  true
+  ```
+  # Definition
+  ```yaml
+  true
+
+  ```
+
+  # Stack
+  - test:7:14
+
+  # Value
+  ```json
+  42
+  ```
+  # Definition
+  ```yaml
+  42
+
+  ```
+
+  # Stack
+  - test:8:13
+
+  # Value
+  ```json
+  "esc"
+  ```
+  # Definition
+  ```yaml
+  esc
+
+  ```
+
+  # Stack
+  - test:9:13
+  - b:2:13
+
+  # Value
+  ```json
+  [
+    "hello",
+    "world"
+  ]
+  ```
+  # Definition
+  ```yaml
+  [hello, world]
+
+  ```
+
+  # Stack
+  - test:10:12
+
+  # Value
+  ```json
+  "hello"
+  ```
+  # Definition
+  ```yaml
+  hello
+
+  ```
+
+  # Stack
+  - test:10:13
+
+  # Value
+  ```json
+  "world"
+  ```
+  # Definition
+  ```yaml
+  world
+
+  ```
+
+  # Stack
+  - test:10:20
+
+  # Value
+  ```json
+  {
+    "goodbye": "all",
+    "hello": "world"
+  }
+  ```
+  # Definition
+  ```yaml
+  {hello: world}
+
+  ```
+
+  # Stack
+  - test:11:13
+  - b:3:13
+
+  # Value
+  ```json
+  "world"
+  ```
+  # Definition
+  ```yaml
+  world
+
+  ```
+
+  # Stack
+  - test:11:21
+  - a:2:21
+
+  # Value
+  ```json
+  "all"
+  ```
+
+  # Stack
+  - b:3:23
+  - a:2:35
+
+  # Value
+  ```json
+  "[unknown]"
+  ```
+  # Definition
+  ```yaml
+  fn::open::test:
+    foo: bar
+
+  ```
+
+  # Stack
+  - test:13:9
+
+  # Definition
+  ```yaml
+  foo: bar
+
+  ```
+
+  # Stack
+  - test:14:13
+
+  # Definition
+  ```yaml
+  bar
+
+  ```
+
+  # Stack
+  - test:14:18
+

--- a/cmd/esc/cli/testdata/env-set-secret.yaml
+++ b/cmd/esc/cli/testdata/env-set-secret.yaml
@@ -4,10 +4,31 @@ run: |
   esc env get test
   esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
   esc env get test
-stdout: |
+stdout: |+
+  # Value
+  ```json
   {
     "password": "[secret]"
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    password:
+      fn::secret: YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+
+  ```
+
+  # Value
+  ```json
   {
     "password": "YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M="
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    password: YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+
+  ```
+

--- a/cmd/esc/cli/testdata/env-set.yaml
+++ b/cmd/esc/cli/testdata/env-set.yaml
@@ -14,7 +14,9 @@ run: |
   esc env set test 'imports[0]' test2 && esc env get test
   esc env init test3
   esc env set test 'imports[1]' test3 && esc env get test
-stdout: |
+stdout: |+
+  # Value
+  ```json
   {
     "foo": {
       "bar": {
@@ -22,6 +24,18 @@ stdout: |
       }
     }
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo:
+      bar:
+        baz: qux
+
+  ```
+
+  # Value
+  ```json
   {
     "foo": {
       "bar": {
@@ -30,6 +44,19 @@ stdout: |
       }
     }
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo:
+      bar:
+        baz: qux
+        alpha: zed
+
+  ```
+
+  # Value
+  ```json
   {
     "foo": {
       "bar": {
@@ -41,6 +68,21 @@ stdout: |
       ]
     }
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo:
+      bar:
+        baz: qux
+        alpha: zed
+      beta:
+        - gamma
+
+  ```
+
+  # Value
+  ```json
   {
     "foo": {
       "bar": {
@@ -53,6 +95,22 @@ stdout: |
       ]
     }
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo:
+      bar:
+        baz: qux
+        alpha: zed
+      beta:
+        - gamma
+        - 42
+
+  ```
+
+  # Value
+  ```json
   {
     "foo": {
       "bar": {
@@ -66,6 +124,24 @@ stdout: |
     },
     "open": "[unknown]"
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo:
+      bar:
+        baz: qux
+        alpha: zed
+      beta:
+        - gamma
+        - 42
+    open:
+      "fn::open::test": "esc"
+
+  ```
+
+  # Value
+  ```json
   {
     "foo": {
       "bar": {
@@ -79,6 +155,24 @@ stdout: |
     },
     "open": "[unknown]"
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo:
+      bar:
+        baz: qux
+        alpha: zed
+      beta:
+        - gamma
+        - 42
+    open:
+      "fn::open::test": "cse"
+
+  ```
+
+  # Value
+  ```json
   {
     "array": [
       "hello",
@@ -96,6 +190,27 @@ stdout: |
     },
     "open": "[unknown]"
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo:
+      bar:
+        baz: qux
+        alpha: zed
+      beta:
+        - gamma
+        - 42
+    open:
+      "fn::open::test": "cse"
+    array:
+      - hello
+      - world
+
+  ```
+
+  # Value
+  ```json
   {
     "array": [
       "hello",
@@ -113,6 +228,27 @@ stdout: |
     },
     "open": "[unknown]"
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo:
+      bar:
+        baz: qux
+        alpha: zed
+      beta:
+        - gamma
+        - 42
+    open:
+      "fn::open::test": "cse"
+    array:
+      - hello
+      - esc
+
+  ```
+
+  # Value
+  ```json
   {
     "array": [
       "hello",
@@ -131,6 +267,28 @@ stdout: |
     },
     "open": "[unknown]"
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo:
+      bar:
+        baz: qux
+        alpha: zed
+      beta:
+        - gamma
+        - 42
+    open:
+      "fn::open::test": "cse"
+    array:
+      - hello
+      - esc
+      - {}
+
+  ```
+
+  # Value
+  ```json
   {
     "array": [
       "hello",
@@ -151,6 +309,28 @@ stdout: |
     },
     "open": "[unknown]"
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo:
+      bar:
+        baz: qux
+        alpha: zed
+      beta:
+        - gamma
+        - 42
+    open:
+      "fn::open::test": "cse"
+    array:
+      - hello
+      - esc
+      - {foo: bar}
+
+  ```
+
+  # Value
+  ```json
   {
     "array": [
       "hello",
@@ -171,6 +351,30 @@ stdout: |
     },
     "open": "[unknown]"
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo:
+      bar:
+        baz: qux
+        alpha: zed
+      beta:
+        - gamma
+        - 42
+    open:
+      "fn::open::test": "cse"
+    array:
+      - hello
+      - esc
+      - {foo: bar}
+  imports:
+    - test2
+
+  ```
+
+  # Value
+  ```json
   {
     "array": [
       "hello",
@@ -191,3 +395,26 @@ stdout: |
     },
     "open": "[unknown]"
   }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo:
+      bar:
+        baz: qux
+        alpha: zed
+      beta:
+        - gamma
+        - 42
+    open:
+      "fn::open::test": "cse"
+    array:
+      - hello
+      - esc
+      - {foo: bar}
+  imports:
+    - test2
+    - test3
+
+  ```
+

--- a/eval/expr.go
+++ b/eval/expr.go
@@ -131,39 +131,54 @@ func (x *expr) export(environment string) esc.Expr {
 		}
 	case *joinExpr:
 		ex.Builtin = &esc.BuiltinExpr{
+			Name:      repr.node.Name().Value,
 			ArgSchema: schema.Tuple(schema.String(), schema.Array().Items(schema.String())).Schema(),
 			Arg:       esc.Expr{List: []esc.Expr{repr.delimiter.export(environment), repr.values.export(environment)}},
 		}
 	case *openExpr:
-		ex.Builtin = &esc.BuiltinExpr{
-			ArgSchema: schema.Record(map[string]schema.Builder{
-				"provider": schema.String(),
-				"inputs":   repr.inputSchema,
-			}).Schema(),
-			Arg: esc.Expr{
-				Object: map[string]esc.Expr{
-					"provider": repr.provider.export(environment),
-					"inputs":   repr.inputs.export(environment),
+		name := repr.node.Name().Value
+		if name == "fn::open" {
+			ex.Builtin = &esc.BuiltinExpr{
+				Name: name,
+				ArgSchema: schema.Record(map[string]schema.Builder{
+					"provider": schema.String(),
+					"inputs":   repr.inputSchema,
+				}).Schema(),
+				Arg: esc.Expr{
+					Object: map[string]esc.Expr{
+						"provider": repr.provider.export(environment),
+						"inputs":   repr.inputs.export(environment),
+					},
 				},
-			},
+			}
+		} else {
+			ex.Builtin = &esc.BuiltinExpr{
+				Name:      name,
+				ArgSchema: repr.inputSchema,
+				Arg:       repr.inputs.export(environment),
+			}
 		}
 	case *secretExpr:
 		ex.Builtin = &esc.BuiltinExpr{
+			Name:      repr.node.Name().Value,
 			ArgSchema: schema.Always().Schema(),
 			Arg:       repr.value.export(environment),
 		}
 	case *toBase64Expr:
 		ex.Builtin = &esc.BuiltinExpr{
+			Name:      repr.node.Name().Value,
 			ArgSchema: schema.String().Schema(),
 			Arg:       repr.value.export(environment),
 		}
 	case *toJSONExpr:
 		ex.Builtin = &esc.BuiltinExpr{
+			Name:      repr.node.Name().Value,
 			ArgSchema: schema.Always().Schema(),
 			Arg:       repr.value.export(environment),
 		}
 	case *toStringExpr:
 		ex.Builtin = &esc.BuiltinExpr{
+			Name:      repr.node.Name().Value,
 			ArgSchema: schema.Always().Schema(),
 			Arg:       repr.value.export(environment),
 		}

--- a/eval/testdata/eval/omnibus/expected.json
+++ b/eval/testdata/eval/omnibus/expected.json
@@ -113,7 +113,7 @@
                     "type": "string"
                 },
                 "builtin": {
-                    "name": "",
+                    "name": "fn::join",
                     "argSchema": {
                         "prefixItems": [
                             {
@@ -295,41 +295,42 @@
                     }
                 },
                 "builtin": {
-                    "name": "",
-                    "argSchema": {
-                        "properties": {
-                            "inputs": true,
-                            "provider": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object",
-                        "required": [
-                            "inputs",
-                            "provider"
-                        ]
-                    },
+                    "name": "fn::open::test",
+                    "argSchema": true,
                     "arg": {
                         "range": {
+                            "environment": "omnibus",
                             "begin": {
-                                "line": 0,
-                                "column": 0,
-                                "byte": 0
+                                "line": 8,
+                                "column": 7,
+                                "byte": 101
                             },
                             "end": {
-                                "line": 0,
-                                "column": 0,
-                                "byte": 0
+                                "line": 8,
+                                "column": 15,
+                                "byte": 109
                             }
                         },
+                        "schema": {
+                            "properties": {
+                                "baz": {
+                                    "type": "string",
+                                    "const": "qux"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "baz"
+                            ]
+                        },
                         "object": {
-                            "inputs": {
+                            "baz": {
                                 "range": {
                                     "environment": "omnibus",
                                     "begin": {
                                         "line": 8,
-                                        "column": 7,
-                                        "byte": 101
+                                        "column": 12,
+                                        "byte": 106
                                     },
                                     "end": {
                                         "line": 8,
@@ -338,59 +339,10 @@
                                     }
                                 },
                                 "schema": {
-                                    "properties": {
-                                        "baz": {
-                                            "type": "string",
-                                            "const": "qux"
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "baz"
-                                    ]
-                                },
-                                "object": {
-                                    "baz": {
-                                        "range": {
-                                            "environment": "omnibus",
-                                            "begin": {
-                                                "line": 8,
-                                                "column": 12,
-                                                "byte": 106
-                                            },
-                                            "end": {
-                                                "line": 8,
-                                                "column": 15,
-                                                "byte": 109
-                                            }
-                                        },
-                                        "schema": {
-                                            "type": "string",
-                                            "const": "qux"
-                                        },
-                                        "literal": "qux"
-                                    }
-                                }
-                            },
-                            "provider": {
-                                "range": {
-                                    "environment": "omnibus",
-                                    "begin": {
-                                        "line": 7,
-                                        "column": 5,
-                                        "byte": 79
-                                    },
-                                    "end": {
-                                        "line": 7,
-                                        "column": 19,
-                                        "byte": 93
-                                    }
-                                },
-                                "schema": {
                                     "type": "string",
-                                    "const": "test"
+                                    "const": "qux"
                                 },
-                                "literal": "test"
+                                "literal": "qux"
                             }
                         }
                     }
@@ -428,105 +380,57 @@
                     ]
                 },
                 "builtin": {
-                    "name": "",
-                    "argSchema": {
-                        "properties": {
-                            "inputs": true,
-                            "provider": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object",
-                        "required": [
-                            "inputs",
-                            "provider"
-                        ]
-                    },
+                    "name": "fn::open::test",
+                    "argSchema": true,
                     "arg": {
                         "range": {
+                            "environment": "omnibus",
                             "begin": {
-                                "line": 0,
-                                "column": 0,
-                                "byte": 0
+                                "line": 19,
+                                "column": 21,
+                                "byte": 289
                             },
                             "end": {
-                                "line": 0,
-                                "column": 0,
-                                "byte": 0
+                                "line": 19,
+                                "column": 28,
+                                "byte": 296
                             }
                         },
-                        "object": {
-                            "inputs": {
-                                "range": {
-                                    "environment": "omnibus",
-                                    "begin": {
-                                        "line": 19,
-                                        "column": 21,
-                                        "byte": 289
-                                    },
-                                    "end": {
-                                        "line": 19,
-                                        "column": 28,
-                                        "byte": 296
-                                    }
-                                },
-                                "schema": {
-                                    "properties": {
-                                        "baz": {
-                                            "type": "string",
-                                            "const": "qux"
-                                        },
-                                        "foo": {
-                                            "type": "string",
-                                            "const": "bar"
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "baz",
-                                        "foo"
-                                    ]
-                                },
-                                "symbol": [
-                                    {
-                                        "key": "open",
-                                        "value": {
-                                            "environment": "omnibus",
-                                            "begin": {
-                                                "line": 7,
-                                                "column": 5,
-                                                "byte": 79
-                                            },
-                                            "end": {
-                                                "line": 8,
-                                                "column": 15,
-                                                "byte": 109
-                                            }
-                                        }
-                                    }
-                                ]
-                            },
-                            "provider": {
-                                "range": {
-                                    "environment": "omnibus",
-                                    "begin": {
-                                        "line": 19,
-                                        "column": 5,
-                                        "byte": 273
-                                    },
-                                    "end": {
-                                        "line": 19,
-                                        "column": 19,
-                                        "byte": 287
-                                    }
-                                },
-                                "schema": {
+                        "schema": {
+                            "properties": {
+                                "baz": {
                                     "type": "string",
-                                    "const": "test"
+                                    "const": "qux"
                                 },
-                                "literal": "test"
+                                "foo": {
+                                    "type": "string",
+                                    "const": "bar"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "baz",
+                                "foo"
+                            ]
+                        },
+                        "symbol": [
+                            {
+                                "key": "open",
+                                "value": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 5,
+                                        "byte": 79
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 15,
+                                        "byte": 109
+                                    }
+                                }
                             }
-                        }
+                        ]
                     }
                 }
             },
@@ -549,7 +453,7 @@
                     "const": "hunter2"
                 },
                 "builtin": {
-                    "name": "",
+                    "name": "fn::secret",
                     "argSchema": true,
                     "arg": {
                         "range": {
@@ -591,7 +495,7 @@
                     "type": "string"
                 },
                 "builtin": {
-                    "name": "",
+                    "name": "fn::toBase64",
                     "argSchema": {
                         "type": "string"
                     },
@@ -651,7 +555,7 @@
                     "type": "string"
                 },
                 "builtin": {
-                    "name": "",
+                    "name": "fn::toJSON",
                     "argSchema": true,
                     "arg": {
                         "range": {
@@ -723,7 +627,7 @@
                     "type": "string"
                 },
                 "builtin": {
-                    "name": "",
+                    "name": "fn::toString",
                     "argSchema": true,
                     "arg": {
                         "range": {

--- a/eval/testdata/eval/open-unknown/expected.json
+++ b/eval/testdata/eval/open-unknown/expected.json
@@ -42,51 +42,49 @@
                 },
                 "schema": true,
                 "builtin": {
-                    "name": "",
+                    "name": "fn::open::error",
                     "argSchema": {
                         "properties": {
-                            "inputs": {
-                                "properties": {
-                                    "why": {
-                                        "type": "string"
-                                    }
-                                },
-                                "type": "object",
-                                "required": [
-                                    "why"
-                                ]
-                            },
-                            "provider": {
+                            "why": {
                                 "type": "string"
                             }
                         },
                         "type": "object",
                         "required": [
-                            "inputs",
-                            "provider"
+                            "why"
                         ]
                     },
                     "arg": {
                         "range": {
+                            "environment": "open-unknown",
                             "begin": {
-                                "line": 0,
-                                "column": 0,
-                                "byte": 0
+                                "line": 7,
+                                "column": 7,
+                                "byte": 97
                             },
                             "end": {
-                                "line": 0,
-                                "column": 0,
-                                "byte": 0
+                                "line": 7,
+                                "column": 20,
+                                "byte": 110
                             }
                         },
+                        "schema": {
+                            "properties": {
+                                "why": true
+                            },
+                            "type": "object",
+                            "required": [
+                                "why"
+                            ]
+                        },
                         "object": {
-                            "inputs": {
+                            "why": {
                                 "range": {
                                     "environment": "open-unknown",
                                     "begin": {
                                         "line": 7,
-                                        "column": 7,
-                                        "byte": 97
+                                        "column": 12,
+                                        "byte": 102
                                     },
                                     "end": {
                                         "line": 7,
@@ -94,71 +92,25 @@
                                         "byte": 110
                                     }
                                 },
-                                "schema": {
-                                    "properties": {
-                                        "why": true
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "why"
-                                    ]
-                                },
-                                "object": {
-                                    "why": {
-                                        "range": {
+                                "schema": true,
+                                "symbol": [
+                                    {
+                                        "key": "error",
+                                        "value": {
                                             "environment": "open-unknown",
                                             "begin": {
-                                                "line": 7,
-                                                "column": 12,
-                                                "byte": 102
+                                                "line": 3,
+                                                "column": 5,
+                                                "byte": 21
                                             },
                                             "end": {
-                                                "line": 7,
-                                                "column": 20,
-                                                "byte": 110
+                                                "line": 4,
+                                                "column": 19,
+                                                "byte": 56
                                             }
-                                        },
-                                        "schema": true,
-                                        "symbol": [
-                                            {
-                                                "key": "error",
-                                                "value": {
-                                                    "environment": "open-unknown",
-                                                    "begin": {
-                                                        "line": 3,
-                                                        "column": 5,
-                                                        "byte": 21
-                                                    },
-                                                    "end": {
-                                                        "line": 4,
-                                                        "column": 19,
-                                                        "byte": 56
-                                                    }
-                                                }
-                                            }
-                                        ]
+                                        }
                                     }
-                                }
-                            },
-                            "provider": {
-                                "range": {
-                                    "environment": "open-unknown",
-                                    "begin": {
-                                        "line": 6,
-                                        "column": 5,
-                                        "byte": 74
-                                    },
-                                    "end": {
-                                        "line": 6,
-                                        "column": 20,
-                                        "byte": 89
-                                    }
-                                },
-                                "schema": {
-                                    "type": "string",
-                                    "const": "error"
-                                },
-                                "literal": "error"
+                                ]
                             }
                         }
                     }
@@ -180,51 +132,52 @@
                 },
                 "schema": true,
                 "builtin": {
-                    "name": "",
+                    "name": "fn::open::error",
                     "argSchema": {
                         "properties": {
-                            "inputs": {
-                                "properties": {
-                                    "why": {
-                                        "type": "string"
-                                    }
-                                },
-                                "type": "object",
-                                "required": [
-                                    "why"
-                                ]
-                            },
-                            "provider": {
+                            "why": {
                                 "type": "string"
                             }
                         },
                         "type": "object",
                         "required": [
-                            "inputs",
-                            "provider"
+                            "why"
                         ]
                     },
                     "arg": {
                         "range": {
+                            "environment": "open-unknown",
                             "begin": {
-                                "line": 0,
-                                "column": 0,
-                                "byte": 0
+                                "line": 4,
+                                "column": 7,
+                                "byte": 44
                             },
                             "end": {
-                                "line": 0,
-                                "column": 0,
-                                "byte": 0
+                                "line": 4,
+                                "column": 19,
+                                "byte": 56
                             }
                         },
+                        "schema": {
+                            "properties": {
+                                "why": {
+                                    "type": "string",
+                                    "const": "testing"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "why"
+                            ]
+                        },
                         "object": {
-                            "inputs": {
+                            "why": {
                                 "range": {
                                     "environment": "open-unknown",
                                     "begin": {
                                         "line": 4,
-                                        "column": 7,
-                                        "byte": 44
+                                        "column": 12,
+                                        "byte": 49
                                     },
                                     "end": {
                                         "line": 4,
@@ -233,59 +186,10 @@
                                     }
                                 },
                                 "schema": {
-                                    "properties": {
-                                        "why": {
-                                            "type": "string",
-                                            "const": "testing"
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "why"
-                                    ]
-                                },
-                                "object": {
-                                    "why": {
-                                        "range": {
-                                            "environment": "open-unknown",
-                                            "begin": {
-                                                "line": 4,
-                                                "column": 12,
-                                                "byte": 49
-                                            },
-                                            "end": {
-                                                "line": 4,
-                                                "column": 19,
-                                                "byte": 56
-                                            }
-                                        },
-                                        "schema": {
-                                            "type": "string",
-                                            "const": "testing"
-                                        },
-                                        "literal": "testing"
-                                    }
-                                }
-                            },
-                            "provider": {
-                                "range": {
-                                    "environment": "open-unknown",
-                                    "begin": {
-                                        "line": 3,
-                                        "column": 5,
-                                        "byte": 21
-                                    },
-                                    "end": {
-                                        "line": 3,
-                                        "column": 20,
-                                        "byte": 36
-                                    }
-                                },
-                                "schema": {
                                     "type": "string",
-                                    "const": "error"
+                                    "const": "testing"
                                 },
-                                "literal": "error"
+                                "literal": "testing"
                             }
                         }
                     }

--- a/eval/testdata/eval/open/expected.json
+++ b/eval/testdata/eval/open/expected.json
@@ -415,7 +415,7 @@
                     ]
                 },
                 "builtin": {
-                    "name": "",
+                    "name": "fn::open",
                     "argSchema": {
                         "properties": {
                             "inputs": true,

--- a/eval/testdata/eval/schema/expected.json
+++ b/eval/testdata/eval/schema/expected.json
@@ -661,345 +661,297 @@
                     ]
                 },
                 "builtin": {
-                    "name": "",
+                    "name": "fn::open::schema",
                     "argSchema": {
-                        "properties": {
-                            "inputs": {
-                                "$defs": {
-                                    "defRecord": {
-                                        "properties": {
-                                            "baz": {
-                                                "type": "string",
-                                                "const": "qux"
-                                            }
-                                        },
-                                        "type": "object",
-                                        "required": [
-                                            "baz"
-                                        ]
+                        "$defs": {
+                            "defRecord": {
+                                "properties": {
+                                    "baz": {
+                                        "type": "string",
+                                        "const": "qux"
                                     }
                                 },
+                                "type": "object",
+                                "required": [
+                                    "baz"
+                                ]
+                            }
+                        },
+                        "properties": {
+                            "anyOf": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "number"
+                                    }
+                                ],
+                                "type": ""
+                            },
+                            "array": {
+                                "items": true,
+                                "type": "array"
+                            },
+                            "boolean": {
+                                "type": "boolean"
+                            },
+                            "false": {
+                                "type": "boolean",
+                                "const": false
+                            },
+                            "hello": {
+                                "type": "string",
+                                "const": "hello"
+                            },
+                            "map": {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            "null": {
+                                "type": "null"
+                            },
+                            "number": {
+                                "type": "number"
+                            },
+                            "oneOf": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "number"
+                                    }
+                                ],
+                                "type": ""
+                            },
+                            "pi": {
+                                "type": "number",
+                                "const": 3.14
+                            },
+                            "record": {
                                 "properties": {
-                                    "anyOf": {
-                                        "anyOf": [
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "type": "number"
-                                            }
-                                        ],
-                                        "type": ""
-                                    },
-                                    "array": {
-                                        "items": true,
-                                        "type": "array"
-                                    },
-                                    "boolean": {
-                                        "type": "boolean"
-                                    },
-                                    "false": {
-                                        "type": "boolean",
-                                        "const": false
-                                    },
-                                    "hello": {
+                                    "foo": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "foo"
+                                ]
+                            },
+                            "ref": {
+                                "$ref": "#/$defs/defRecord",
+                                "type": ""
+                            },
+                            "string": {
+                                "type": "string"
+                            },
+                            "true": {
+                                "type": "boolean",
+                                "const": true
+                            },
+                            "tuple": {
+                                "prefixItems": [
+                                    {
                                         "type": "string",
                                         "const": "hello"
                                     },
-                                    "map": {
-                                        "additionalProperties": true,
-                                        "type": "object"
-                                    },
-                                    "null": {
-                                        "type": "null"
-                                    },
-                                    "number": {
-                                        "type": "number"
-                                    },
-                                    "oneOf": {
-                                        "oneOf": [
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "type": "number"
-                                            }
-                                        ],
-                                        "type": ""
-                                    },
-                                    "pi": {
-                                        "type": "number",
-                                        "const": 3.14
-                                    },
-                                    "record": {
-                                        "properties": {
-                                            "foo": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "type": "object",
-                                        "required": [
-                                            "foo"
-                                        ]
-                                    },
-                                    "ref": {
-                                        "$ref": "#/$defs/defRecord",
-                                        "type": ""
-                                    },
-                                    "string": {
-                                        "type": "string"
-                                    },
-                                    "true": {
-                                        "type": "boolean",
-                                        "const": true
-                                    },
-                                    "tuple": {
-                                        "prefixItems": [
-                                            {
-                                                "type": "string",
-                                                "const": "hello"
-                                            },
-                                            {
-                                                "type": "string",
-                                                "const": "world"
-                                            }
-                                        ],
-                                        "items": false,
-                                        "type": "array"
+                                    {
+                                        "type": "string",
+                                        "const": "world"
                                     }
-                                },
-                                "type": "object"
-                            },
-                            "provider": {
-                                "type": "string"
+                                ],
+                                "items": false,
+                                "type": "array"
                             }
                         },
-                        "type": "object",
-                        "required": [
-                            "inputs",
-                            "provider"
-                        ]
+                        "type": "object"
                     },
                     "arg": {
                         "range": {
+                            "environment": "schema",
                             "begin": {
-                                "line": 0,
-                                "column": 0,
-                                "byte": 0
+                                "line": 20,
+                                "column": 23,
+                                "byte": 427
                             },
                             "end": {
-                                "line": 0,
-                                "column": 0,
-                                "byte": 0
+                                "line": 20,
+                                "column": 32,
+                                "byte": 436
                             }
                         },
-                        "object": {
-                            "inputs": {
-                                "range": {
-                                    "environment": "schema",
-                                    "begin": {
-                                        "line": 20,
-                                        "column": 23,
-                                        "byte": 427
-                                    },
-                                    "end": {
-                                        "line": 20,
-                                        "column": 32,
-                                        "byte": 436
-                                    }
+                        "schema": {
+                            "properties": {
+                                "anyOf": {
+                                    "type": "string",
+                                    "const": "hello"
                                 },
-                                "schema": {
-                                    "properties": {
-                                        "anyOf": {
-                                            "type": "string",
-                                            "const": "hello"
+                                "array": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 2
                                         },
-                                        "array": {
+                                        {
+                                            "type": "string",
+                                            "const": "items"
+                                        },
+                                        {
+                                            "properties": {
+                                                "some": {
+                                                    "type": "string",
+                                                    "const": "object"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "some"
+                                            ]
+                                        },
+                                        {
                                             "prefixItems": [
                                                 {
-                                                    "type": "number",
-                                                    "const": 2
-                                                },
-                                                {
                                                     "type": "string",
-                                                    "const": "items"
-                                                },
-                                                {
-                                                    "properties": {
-                                                        "some": {
-                                                            "type": "string",
-                                                            "const": "object"
-                                                        }
-                                                    },
-                                                    "type": "object",
-                                                    "required": [
-                                                        "some"
-                                                    ]
-                                                },
-                                                {
-                                                    "prefixItems": [
-                                                        {
-                                                            "type": "string",
-                                                            "const": "array"
-                                                        }
-                                                    ],
-                                                    "items": false,
-                                                    "type": "array"
+                                                    "const": "array"
                                                 }
                                             ],
                                             "items": false,
                                             "type": "array"
-                                        },
-                                        "boolean": {
-                                            "type": "boolean",
-                                            "const": true
-                                        },
-                                        "false": {
-                                            "type": "boolean",
-                                            "const": false
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "boolean": {
+                                    "type": "boolean",
+                                    "const": true
+                                },
+                                "false": {
+                                    "type": "boolean",
+                                    "const": false
+                                },
+                                "hello": {
+                                    "type": "string",
+                                    "const": "hello"
+                                },
+                                "map": {
+                                    "properties": {
+                                        "blue": {
+                                            "type": "number",
+                                            "const": 42
                                         },
                                         "hello": {
                                             "type": "string",
-                                            "const": "hello"
-                                        },
-                                        "map": {
-                                            "properties": {
-                                                "blue": {
-                                                    "type": "number",
-                                                    "const": 42
-                                                },
-                                                "hello": {
-                                                    "type": "string",
-                                                    "const": "world"
-                                                }
-                                            },
-                                            "type": "object",
-                                            "required": [
-                                                "blue",
-                                                "hello"
-                                            ]
-                                        },
-                                        "null": {
-                                            "type": "null"
-                                        },
-                                        "number": {
-                                            "type": "number",
-                                            "const": 42
-                                        },
-                                        "oneOf": {
-                                            "type": "number",
-                                            "const": 42
-                                        },
-                                        "pi": {
-                                            "type": "number",
-                                            "const": 3.14
-                                        },
-                                        "record": {
-                                            "properties": {
-                                                "foo": {
-                                                    "type": "string",
-                                                    "const": "bar"
-                                                }
-                                            },
-                                            "type": "object",
-                                            "required": [
-                                                "foo"
-                                            ]
-                                        },
-                                        "ref": {
-                                            "properties": {
-                                                "baz": {
-                                                    "type": "string",
-                                                    "const": "qux"
-                                                }
-                                            },
-                                            "type": "object",
-                                            "required": [
-                                                "baz"
-                                            ]
-                                        },
-                                        "string": {
-                                            "type": "string",
-                                            "const": "esc"
-                                        },
-                                        "true": {
-                                            "type": "boolean",
-                                            "const": true
-                                        },
-                                        "tuple": {
-                                            "prefixItems": [
-                                                {
-                                                    "type": "string",
-                                                    "const": "hello"
-                                                },
-                                                {
-                                                    "type": "string",
-                                                    "const": "world"
-                                                }
-                                            ],
-                                            "items": false,
-                                            "type": "array"
+                                            "const": "world"
                                         }
                                     },
                                     "type": "object",
                                     "required": [
-                                        "anyOf",
-                                        "array",
-                                        "boolean",
-                                        "false",
-                                        "hello",
-                                        "map",
-                                        "null",
-                                        "number",
-                                        "oneOf",
-                                        "pi",
-                                        "record",
-                                        "ref",
-                                        "string",
-                                        "true",
-                                        "tuple"
+                                        "blue",
+                                        "hello"
                                     ]
                                 },
-                                "symbol": [
-                                    {
-                                        "key": "source",
-                                        "value": {
-                                            "environment": "schema",
-                                            "begin": {
-                                                "line": 3,
-                                                "column": 5,
-                                                "byte": 22
-                                            },
-                                            "end": {
-                                                "line": 18,
-                                                "column": 22,
-                                                "byte": 394
-                                            }
+                                "null": {
+                                    "type": "null"
+                                },
+                                "number": {
+                                    "type": "number",
+                                    "const": 42
+                                },
+                                "oneOf": {
+                                    "type": "number",
+                                    "const": 42
+                                },
+                                "pi": {
+                                    "type": "number",
+                                    "const": 3.14
+                                },
+                                "record": {
+                                    "properties": {
+                                        "foo": {
+                                            "type": "string",
+                                            "const": "bar"
                                         }
-                                    }
-                                ]
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "foo"
+                                    ]
+                                },
+                                "ref": {
+                                    "properties": {
+                                        "baz": {
+                                            "type": "string",
+                                            "const": "qux"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "baz"
+                                    ]
+                                },
+                                "string": {
+                                    "type": "string",
+                                    "const": "esc"
+                                },
+                                "true": {
+                                    "type": "boolean",
+                                    "const": true
+                                },
+                                "tuple": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "const": "world"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
                             },
-                            "provider": {
-                                "range": {
+                            "type": "object",
+                            "required": [
+                                "anyOf",
+                                "array",
+                                "boolean",
+                                "false",
+                                "hello",
+                                "map",
+                                "null",
+                                "number",
+                                "oneOf",
+                                "pi",
+                                "record",
+                                "ref",
+                                "string",
+                                "true",
+                                "tuple"
+                            ]
+                        },
+                        "symbol": [
+                            {
+                                "key": "source",
+                                "value": {
                                     "environment": "schema",
                                     "begin": {
-                                        "line": 20,
+                                        "line": 3,
                                         "column": 5,
-                                        "byte": 409
+                                        "byte": 22
                                     },
                                     "end": {
-                                        "line": 20,
-                                        "column": 21,
-                                        "byte": 425
+                                        "line": 18,
+                                        "column": 22,
+                                        "byte": 394
                                     }
-                                },
-                                "schema": {
-                                    "type": "string",
-                                    "const": "schema"
-                                },
-                                "literal": "schema"
+                                }
                             }
-                        }
+                        ]
                     }
                 }
             },
@@ -1170,333 +1122,447 @@
                     ]
                 },
                 "builtin": {
-                    "name": "",
+                    "name": "fn::open::schema",
                     "argSchema": {
-                        "properties": {
-                            "inputs": {
-                                "$defs": {
-                                    "defRecord": {
-                                        "properties": {
-                                            "baz": {
-                                                "type": "string",
-                                                "const": "qux"
-                                            }
-                                        },
-                                        "type": "object",
-                                        "required": [
-                                            "baz"
-                                        ]
+                        "$defs": {
+                            "defRecord": {
+                                "properties": {
+                                    "baz": {
+                                        "type": "string",
+                                        "const": "qux"
                                     }
                                 },
+                                "type": "object",
+                                "required": [
+                                    "baz"
+                                ]
+                            }
+                        },
+                        "properties": {
+                            "anyOf": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "number"
+                                    }
+                                ],
+                                "type": ""
+                            },
+                            "array": {
+                                "items": true,
+                                "type": "array"
+                            },
+                            "boolean": {
+                                "type": "boolean"
+                            },
+                            "false": {
+                                "type": "boolean",
+                                "const": false
+                            },
+                            "hello": {
+                                "type": "string",
+                                "const": "hello"
+                            },
+                            "map": {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            "null": {
+                                "type": "null"
+                            },
+                            "number": {
+                                "type": "number"
+                            },
+                            "oneOf": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "number"
+                                    }
+                                ],
+                                "type": ""
+                            },
+                            "pi": {
+                                "type": "number",
+                                "const": 3.14
+                            },
+                            "record": {
                                 "properties": {
-                                    "anyOf": {
-                                        "anyOf": [
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "type": "number"
-                                            }
-                                        ],
-                                        "type": ""
-                                    },
-                                    "array": {
-                                        "items": true,
-                                        "type": "array"
-                                    },
-                                    "boolean": {
-                                        "type": "boolean"
-                                    },
-                                    "false": {
-                                        "type": "boolean",
-                                        "const": false
-                                    },
-                                    "hello": {
+                                    "foo": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "foo"
+                                ]
+                            },
+                            "ref": {
+                                "$ref": "#/$defs/defRecord",
+                                "type": ""
+                            },
+                            "string": {
+                                "type": "string"
+                            },
+                            "true": {
+                                "type": "boolean",
+                                "const": true
+                            },
+                            "tuple": {
+                                "prefixItems": [
+                                    {
                                         "type": "string",
                                         "const": "hello"
                                     },
-                                    "map": {
-                                        "additionalProperties": true,
-                                        "type": "object"
-                                    },
-                                    "null": {
-                                        "type": "null"
-                                    },
-                                    "number": {
-                                        "type": "number"
-                                    },
-                                    "oneOf": {
-                                        "oneOf": [
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "type": "number"
-                                            }
-                                        ],
-                                        "type": ""
-                                    },
-                                    "pi": {
-                                        "type": "number",
-                                        "const": 3.14
-                                    },
-                                    "record": {
-                                        "properties": {
-                                            "foo": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "type": "object",
-                                        "required": [
-                                            "foo"
-                                        ]
-                                    },
-                                    "ref": {
-                                        "$ref": "#/$defs/defRecord",
-                                        "type": ""
-                                    },
-                                    "string": {
-                                        "type": "string"
-                                    },
-                                    "true": {
-                                        "type": "boolean",
-                                        "const": true
-                                    },
-                                    "tuple": {
-                                        "prefixItems": [
-                                            {
-                                                "type": "string",
-                                                "const": "hello"
-                                            },
-                                            {
-                                                "type": "string",
-                                                "const": "world"
-                                            }
-                                        ],
-                                        "items": false,
-                                        "type": "array"
+                                    {
+                                        "type": "string",
+                                        "const": "world"
                                     }
-                                },
-                                "type": "object"
-                            },
-                            "provider": {
-                                "type": "string"
+                                ],
+                                "items": false,
+                                "type": "array"
                             }
                         },
-                        "type": "object",
-                        "required": [
-                            "inputs",
-                            "provider"
-                        ]
+                        "type": "object"
                     },
                     "arg": {
                         "range": {
+                            "environment": "schema",
                             "begin": {
-                                "line": 0,
-                                "column": 0,
-                                "byte": 0
+                                "line": 4,
+                                "column": 7,
+                                "byte": 46
                             },
                             "end": {
-                                "line": 0,
-                                "column": 0,
-                                "byte": 0
+                                "line": 18,
+                                "column": 22,
+                                "byte": 394
                             }
                         },
-                        "object": {
-                            "inputs": {
-                                "range": {
-                                    "environment": "schema",
-                                    "begin": {
-                                        "line": 4,
-                                        "column": 7,
-                                        "byte": 46
-                                    },
-                                    "end": {
-                                        "line": 18,
-                                        "column": 22,
-                                        "byte": 394
-                                    }
+                        "schema": {
+                            "properties": {
+                                "anyOf": {
+                                    "type": "string",
+                                    "const": "hello"
                                 },
-                                "schema": {
-                                    "properties": {
-                                        "anyOf": {
+                                "array": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        {
                                             "type": "string",
-                                            "const": "hello"
+                                            "const": "items"
                                         },
-                                        "array": {
-                                            "prefixItems": [
-                                                {
-                                                    "type": "number",
-                                                    "const": 2
-                                                },
-                                                {
-                                                    "type": "string",
-                                                    "const": "items"
-                                                },
-                                                {
-                                                    "properties": {
-                                                        "some": {
-                                                            "type": "string",
-                                                            "const": "object"
-                                                        }
-                                                    },
-                                                    "type": "object",
-                                                    "required": [
-                                                        "some"
-                                                    ]
-                                                },
-                                                {
-                                                    "prefixItems": [
-                                                        {
-                                                            "type": "string",
-                                                            "const": "array"
-                                                        }
-                                                    ],
-                                                    "items": false,
-                                                    "type": "array"
-                                                }
-                                            ],
-                                            "items": false,
-                                            "type": "array"
-                                        },
-                                        "boolean": {
-                                            "type": "boolean",
-                                            "const": true
-                                        },
-                                        "false": {
-                                            "type": "boolean",
-                                            "const": false
-                                        },
-                                        "hello": {
-                                            "type": "string",
-                                            "const": "hello"
-                                        },
-                                        "map": {
+                                        {
                                             "properties": {
-                                                "blue": {
-                                                    "type": "number",
-                                                    "const": 42
-                                                },
-                                                "hello": {
+                                                "some": {
                                                     "type": "string",
-                                                    "const": "world"
+                                                    "const": "object"
                                                 }
                                             },
                                             "type": "object",
                                             "required": [
-                                                "blue",
-                                                "hello"
+                                                "some"
                                             ]
                                         },
-                                        "null": {
-                                            "type": "null"
-                                        },
-                                        "number": {
-                                            "type": "number",
-                                            "const": 42
-                                        },
-                                        "oneOf": {
-                                            "type": "number",
-                                            "const": 42
-                                        },
-                                        "pi": {
-                                            "type": "number",
-                                            "const": 3.14
-                                        },
-                                        "record": {
-                                            "properties": {
-                                                "foo": {
-                                                    "type": "string",
-                                                    "const": "bar"
-                                                }
-                                            },
-                                            "type": "object",
-                                            "required": [
-                                                "foo"
-                                            ]
-                                        },
-                                        "ref": {
-                                            "properties": {
-                                                "baz": {
-                                                    "type": "string",
-                                                    "const": "qux"
-                                                }
-                                            },
-                                            "type": "object",
-                                            "required": [
-                                                "baz"
-                                            ]
-                                        },
-                                        "string": {
-                                            "type": "string",
-                                            "const": "esc"
-                                        },
-                                        "true": {
-                                            "type": "boolean",
-                                            "const": true
-                                        },
-                                        "tuple": {
+                                        {
                                             "prefixItems": [
                                                 {
                                                     "type": "string",
-                                                    "const": "hello"
-                                                },
-                                                {
-                                                    "type": "string",
-                                                    "const": "world"
+                                                    "const": "array"
                                                 }
                                             ],
                                             "items": false,
                                             "type": "array"
                                         }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "boolean": {
+                                    "type": "boolean",
+                                    "const": true
+                                },
+                                "false": {
+                                    "type": "boolean",
+                                    "const": false
+                                },
+                                "hello": {
+                                    "type": "string",
+                                    "const": "hello"
+                                },
+                                "map": {
+                                    "properties": {
+                                        "blue": {
+                                            "type": "number",
+                                            "const": 42
+                                        },
+                                        "hello": {
+                                            "type": "string",
+                                            "const": "world"
+                                        }
                                     },
                                     "type": "object",
                                     "required": [
-                                        "anyOf",
-                                        "array",
-                                        "boolean",
-                                        "false",
-                                        "hello",
-                                        "map",
-                                        "null",
-                                        "number",
-                                        "oneOf",
-                                        "pi",
-                                        "record",
-                                        "ref",
-                                        "string",
-                                        "true",
-                                        "tuple"
+                                        "blue",
+                                        "hello"
                                     ]
                                 },
-                                "object": {
-                                    "anyOf": {
-                                        "range": {
-                                            "environment": "schema",
-                                            "begin": {
-                                                "line": 16,
-                                                "column": 14,
-                                                "byte": 351
-                                            },
-                                            "end": {
-                                                "line": 16,
-                                                "column": 19,
-                                                "byte": 356
-                                            }
-                                        },
-                                        "schema": {
+                                "null": {
+                                    "type": "null"
+                                },
+                                "number": {
+                                    "type": "number",
+                                    "const": 42
+                                },
+                                "oneOf": {
+                                    "type": "number",
+                                    "const": 42
+                                },
+                                "pi": {
+                                    "type": "number",
+                                    "const": 3.14
+                                },
+                                "record": {
+                                    "properties": {
+                                        "foo": {
+                                            "type": "string",
+                                            "const": "bar"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "foo"
+                                    ]
+                                },
+                                "ref": {
+                                    "properties": {
+                                        "baz": {
+                                            "type": "string",
+                                            "const": "qux"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "baz"
+                                    ]
+                                },
+                                "string": {
+                                    "type": "string",
+                                    "const": "esc"
+                                },
+                                "true": {
+                                    "type": "boolean",
+                                    "const": true
+                                },
+                                "tuple": {
+                                    "prefixItems": [
+                                        {
                                             "type": "string",
                                             "const": "hello"
                                         },
-                                        "literal": "hello"
+                                        {
+                                            "type": "string",
+                                            "const": "world"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "anyOf",
+                                "array",
+                                "boolean",
+                                "false",
+                                "hello",
+                                "map",
+                                "null",
+                                "number",
+                                "oneOf",
+                                "pi",
+                                "record",
+                                "ref",
+                                "string",
+                                "true",
+                                "tuple"
+                            ]
+                        },
+                        "object": {
+                            "anyOf": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 16,
+                                        "column": 14,
+                                        "byte": 351
                                     },
-                                    "array": {
+                                    "end": {
+                                        "line": 16,
+                                        "column": 19,
+                                        "byte": 356
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "hello"
+                                },
+                                "literal": "hello"
+                            },
+                            "array": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 14,
+                                        "byte": 201
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 51,
+                                        "byte": 238
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        {
+                                            "type": "string",
+                                            "const": "items"
+                                        },
+                                        {
+                                            "properties": {
+                                                "some": {
+                                                    "type": "string",
+                                                    "const": "object"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "some"
+                                            ]
+                                        },
+                                        {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "string",
+                                                    "const": "array"
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
                                         "range": {
                                             "environment": "schema",
                                             "begin": {
                                                 "line": 12,
-                                                "column": 14,
-                                                "byte": 201
+                                                "column": 16,
+                                                "byte": 203
+                                            },
+                                            "end": {
+                                                "line": 12,
+                                                "column": 17,
+                                                "byte": 204
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        "literal": 2
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 12,
+                                                "column": 19,
+                                                "byte": 206
+                                            },
+                                            "end": {
+                                                "line": 12,
+                                                "column": 24,
+                                                "byte": 211
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "items"
+                                        },
+                                        "literal": "items"
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 12,
+                                                "column": 26,
+                                                "byte": 213
+                                            },
+                                            "end": {
+                                                "line": 12,
+                                                "column": 40,
+                                                "byte": 227
+                                            }
+                                        },
+                                        "schema": {
+                                            "properties": {
+                                                "some": {
+                                                    "type": "string",
+                                                    "const": "object"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "some"
+                                            ]
+                                        },
+                                        "object": {
+                                            "some": {
+                                                "range": {
+                                                    "environment": "schema",
+                                                    "begin": {
+                                                        "line": 12,
+                                                        "column": 34,
+                                                        "byte": 221
+                                                    },
+                                                    "end": {
+                                                        "line": 12,
+                                                        "column": 40,
+                                                        "byte": 227
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "object"
+                                                },
+                                                "literal": "object"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 12,
+                                                "column": 44,
+                                                "byte": 231
                                             },
                                             "end": {
                                                 "line": 12,
@@ -1507,34 +1573,8 @@
                                         "schema": {
                                             "prefixItems": [
                                                 {
-                                                    "type": "number",
-                                                    "const": 2
-                                                },
-                                                {
                                                     "type": "string",
-                                                    "const": "items"
-                                                },
-                                                {
-                                                    "properties": {
-                                                        "some": {
-                                                            "type": "string",
-                                                            "const": "object"
-                                                        }
-                                                    },
-                                                    "type": "object",
-                                                    "required": [
-                                                        "some"
-                                                    ]
-                                                },
-                                                {
-                                                    "prefixItems": [
-                                                        {
-                                                            "type": "string",
-                                                            "const": "array"
-                                                        }
-                                                    ],
-                                                    "items": false,
-                                                    "type": "array"
+                                                    "const": "array"
                                                 }
                                             ],
                                             "items": false,
@@ -1546,97 +1586,8 @@
                                                     "environment": "schema",
                                                     "begin": {
                                                         "line": 12,
-                                                        "column": 16,
-                                                        "byte": 203
-                                                    },
-                                                    "end": {
-                                                        "line": 12,
-                                                        "column": 17,
-                                                        "byte": 204
-                                                    }
-                                                },
-                                                "schema": {
-                                                    "type": "number",
-                                                    "const": 2
-                                                },
-                                                "literal": 2
-                                            },
-                                            {
-                                                "range": {
-                                                    "environment": "schema",
-                                                    "begin": {
-                                                        "line": 12,
-                                                        "column": 19,
-                                                        "byte": 206
-                                                    },
-                                                    "end": {
-                                                        "line": 12,
-                                                        "column": 24,
-                                                        "byte": 211
-                                                    }
-                                                },
-                                                "schema": {
-                                                    "type": "string",
-                                                    "const": "items"
-                                                },
-                                                "literal": "items"
-                                            },
-                                            {
-                                                "range": {
-                                                    "environment": "schema",
-                                                    "begin": {
-                                                        "line": 12,
-                                                        "column": 26,
-                                                        "byte": 213
-                                                    },
-                                                    "end": {
-                                                        "line": 12,
-                                                        "column": 40,
-                                                        "byte": 227
-                                                    }
-                                                },
-                                                "schema": {
-                                                    "properties": {
-                                                        "some": {
-                                                            "type": "string",
-                                                            "const": "object"
-                                                        }
-                                                    },
-                                                    "type": "object",
-                                                    "required": [
-                                                        "some"
-                                                    ]
-                                                },
-                                                "object": {
-                                                    "some": {
-                                                        "range": {
-                                                            "environment": "schema",
-                                                            "begin": {
-                                                                "line": 12,
-                                                                "column": 34,
-                                                                "byte": 221
-                                                            },
-                                                            "end": {
-                                                                "line": 12,
-                                                                "column": 40,
-                                                                "byte": 227
-                                                            }
-                                                        },
-                                                        "schema": {
-                                                            "type": "string",
-                                                            "const": "object"
-                                                        },
-                                                        "literal": "object"
-                                                    }
-                                                }
-                                            },
-                                            {
-                                                "range": {
-                                                    "environment": "schema",
-                                                    "begin": {
-                                                        "line": 12,
-                                                        "column": 44,
-                                                        "byte": 231
+                                                        "column": 46,
+                                                        "byte": 233
                                                     },
                                                     "end": {
                                                         "line": 12,
@@ -1645,107 +1596,114 @@
                                                     }
                                                 },
                                                 "schema": {
-                                                    "prefixItems": [
-                                                        {
-                                                            "type": "string",
-                                                            "const": "array"
-                                                        }
-                                                    ],
-                                                    "items": false,
-                                                    "type": "array"
+                                                    "type": "string",
+                                                    "const": "array"
                                                 },
-                                                "list": [
-                                                    {
-                                                        "range": {
-                                                            "environment": "schema",
-                                                            "begin": {
-                                                                "line": 12,
-                                                                "column": 46,
-                                                                "byte": 233
-                                                            },
-                                                            "end": {
-                                                                "line": 12,
-                                                                "column": 51,
-                                                                "byte": 238
-                                                            }
-                                                        },
-                                                        "schema": {
-                                                            "type": "string",
-                                                            "const": "array"
-                                                        },
-                                                        "literal": "array"
-                                                    }
-                                                ]
+                                                "literal": "array"
                                             }
                                         ]
+                                    }
+                                ]
+                            },
+                            "boolean": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 16,
+                                        "byte": 74
                                     },
-                                    "boolean": {
-                                        "range": {
-                                            "environment": "schema",
-                                            "begin": {
-                                                "line": 5,
-                                                "column": 16,
-                                                "byte": 74
-                                            },
-                                            "end": {
-                                                "line": 5,
-                                                "column": 20,
-                                                "byte": 78
-                                            }
-                                        },
-                                        "schema": {
-                                            "type": "boolean",
-                                            "const": true
-                                        },
-                                        "literal": true
+                                    "end": {
+                                        "line": 5,
+                                        "column": 20,
+                                        "byte": 78
+                                    }
+                                },
+                                "schema": {
+                                    "type": "boolean",
+                                    "const": true
+                                },
+                                "literal": true
+                            },
+                            "false": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 16,
+                                        "byte": 94
                                     },
-                                    "false": {
-                                        "range": {
-                                            "environment": "schema",
-                                            "begin": {
-                                                "line": 6,
-                                                "column": 16,
-                                                "byte": 94
-                                            },
-                                            "end": {
-                                                "line": 6,
-                                                "column": 21,
-                                                "byte": 99
-                                            }
-                                        },
-                                        "schema": {
-                                            "type": "boolean",
-                                            "const": false
-                                        },
-                                        "literal": false
+                                    "end": {
+                                        "line": 6,
+                                        "column": 21,
+                                        "byte": 99
+                                    }
+                                },
+                                "schema": {
+                                    "type": "boolean",
+                                    "const": false
+                                },
+                                "literal": false
+                            },
+                            "hello": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 14,
+                                        "byte": 182
                                     },
-                                    "hello": {
-                                        "range": {
-                                            "environment": "schema",
-                                            "begin": {
-                                                "line": 11,
-                                                "column": 14,
-                                                "byte": 182
-                                            },
-                                            "end": {
-                                                "line": 11,
-                                                "column": 19,
-                                                "byte": 187
-                                            }
+                                    "end": {
+                                        "line": 11,
+                                        "column": 19,
+                                        "byte": 187
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "hello"
+                                },
+                                "literal": "hello"
+                            },
+                            "map": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 14,
+                                        "column": 12,
+                                        "byte": 284
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 36,
+                                        "byte": 308
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "blue": {
+                                            "type": "number",
+                                            "const": 42
                                         },
-                                        "schema": {
+                                        "hello": {
                                             "type": "string",
-                                            "const": "hello"
-                                        },
-                                        "literal": "hello"
+                                            "const": "world"
+                                        }
                                     },
-                                    "map": {
+                                    "type": "object",
+                                    "required": [
+                                        "blue",
+                                        "hello"
+                                    ]
+                                },
+                                "object": {
+                                    "blue": {
                                         "range": {
                                             "environment": "schema",
                                             "begin": {
                                                 "line": 14,
-                                                "column": 12,
-                                                "byte": 284
+                                                "column": 34,
+                                                "byte": 306
                                             },
                                             "end": {
                                                 "line": 14,
@@ -1754,150 +1712,145 @@
                                             }
                                         },
                                         "schema": {
-                                            "properties": {
-                                                "blue": {
-                                                    "type": "number",
-                                                    "const": 42
-                                                },
-                                                "hello": {
-                                                    "type": "string",
-                                                    "const": "world"
-                                                }
-                                            },
-                                            "type": "object",
-                                            "required": [
-                                                "blue",
-                                                "hello"
-                                            ]
-                                        },
-                                        "object": {
-                                            "blue": {
-                                                "range": {
-                                                    "environment": "schema",
-                                                    "begin": {
-                                                        "line": 14,
-                                                        "column": 34,
-                                                        "byte": 306
-                                                    },
-                                                    "end": {
-                                                        "line": 14,
-                                                        "column": 36,
-                                                        "byte": 308
-                                                    }
-                                                },
-                                                "schema": {
-                                                    "type": "number",
-                                                    "const": 42
-                                                },
-                                                "literal": 42
-                                            },
-                                            "hello": {
-                                                "range": {
-                                                    "environment": "schema",
-                                                    "begin": {
-                                                        "line": 14,
-                                                        "column": 21,
-                                                        "byte": 293
-                                                    },
-                                                    "end": {
-                                                        "line": 14,
-                                                        "column": 26,
-                                                        "byte": 298
-                                                    }
-                                                },
-                                                "schema": {
-                                                    "type": "string",
-                                                    "const": "world"
-                                                },
-                                                "literal": "world"
-                                            }
-                                        }
-                                    },
-                                    "null": {
-                                        "range": {
-                                            "environment": "schema",
-                                            "begin": {
-                                                "line": 4,
-                                                "column": 15,
-                                                "byte": 54
-                                            },
-                                            "end": {
-                                                "line": 4,
-                                                "column": 19,
-                                                "byte": 58
-                                            }
-                                        },
-                                        "schema": {
-                                            "type": "null"
-                                        }
-                                    },
-                                    "number": {
-                                        "range": {
-                                            "environment": "schema",
-                                            "begin": {
-                                                "line": 8,
-                                                "column": 15,
-                                                "byte": 133
-                                            },
-                                            "end": {
-                                                "line": 8,
-                                                "column": 17,
-                                                "byte": 135
-                                            }
-                                        },
-                                        "schema": {
                                             "type": "number",
                                             "const": 42
                                         },
                                         "literal": 42
                                     },
-                                    "oneOf": {
+                                    "hello": {
                                         "range": {
                                             "environment": "schema",
                                             "begin": {
-                                                "line": 17,
-                                                "column": 14,
-                                                "byte": 370
+                                                "line": 14,
+                                                "column": 21,
+                                                "byte": 293
                                             },
                                             "end": {
-                                                "line": 17,
-                                                "column": 16,
-                                                "byte": 372
+                                                "line": 14,
+                                                "column": 26,
+                                                "byte": 298
                                             }
                                         },
                                         "schema": {
-                                            "type": "number",
-                                            "const": 42
+                                            "type": "string",
+                                            "const": "world"
                                         },
-                                        "literal": 42
+                                        "literal": "world"
+                                    }
+                                }
+                            },
+                            "null": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 15,
+                                        "byte": 54
                                     },
-                                    "pi": {
-                                        "range": {
-                                            "environment": "schema",
-                                            "begin": {
-                                                "line": 9,
-                                                "column": 11,
-                                                "byte": 146
-                                            },
-                                            "end": {
-                                                "line": 9,
-                                                "column": 15,
-                                                "byte": 150
-                                            }
-                                        },
-                                        "schema": {
-                                            "type": "number",
-                                            "const": 3.14
-                                        },
-                                        "literal": 3.14
+                                    "end": {
+                                        "line": 4,
+                                        "column": 19,
+                                        "byte": 58
+                                    }
+                                },
+                                "schema": {
+                                    "type": "null"
+                                }
+                            },
+                            "number": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 15,
+                                        "byte": 133
                                     },
-                                    "record": {
+                                    "end": {
+                                        "line": 8,
+                                        "column": 17,
+                                        "byte": 135
+                                    }
+                                },
+                                "schema": {
+                                    "type": "number",
+                                    "const": 42
+                                },
+                                "literal": 42
+                            },
+                            "oneOf": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 17,
+                                        "column": 14,
+                                        "byte": 370
+                                    },
+                                    "end": {
+                                        "line": 17,
+                                        "column": 16,
+                                        "byte": 372
+                                    }
+                                },
+                                "schema": {
+                                    "type": "number",
+                                    "const": 42
+                                },
+                                "literal": 42
+                            },
+                            "pi": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 9,
+                                        "column": 11,
+                                        "byte": 146
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 15,
+                                        "byte": 150
+                                    }
+                                },
+                                "schema": {
+                                    "type": "number",
+                                    "const": 3.14
+                                },
+                                "literal": 3.14
+                            },
+                            "record": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 15,
+                                        "column": 15,
+                                        "byte": 325
+                                    },
+                                    "end": {
+                                        "line": 15,
+                                        "column": 25,
+                                        "byte": 335
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "foo": {
+                                            "type": "string",
+                                            "const": "bar"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "foo"
+                                    ]
+                                },
+                                "object": {
+                                    "foo": {
                                         "range": {
                                             "environment": "schema",
                                             "begin": {
                                                 "line": 15,
-                                                "column": 15,
-                                                "byte": 325
+                                                "column": 22,
+                                                "byte": 332
                                             },
                                             "end": {
                                                 "line": 15,
@@ -1906,47 +1859,47 @@
                                             }
                                         },
                                         "schema": {
-                                            "properties": {
-                                                "foo": {
-                                                    "type": "string",
-                                                    "const": "bar"
-                                                }
-                                            },
-                                            "type": "object",
-                                            "required": [
-                                                "foo"
-                                            ]
+                                            "type": "string",
+                                            "const": "bar"
                                         },
-                                        "object": {
-                                            "foo": {
-                                                "range": {
-                                                    "environment": "schema",
-                                                    "begin": {
-                                                        "line": 15,
-                                                        "column": 22,
-                                                        "byte": 332
-                                                    },
-                                                    "end": {
-                                                        "line": 15,
-                                                        "column": 25,
-                                                        "byte": 335
-                                                    }
-                                                },
-                                                "schema": {
-                                                    "type": "string",
-                                                    "const": "bar"
-                                                },
-                                                "literal": "bar"
-                                            }
+                                        "literal": "bar"
+                                    }
+                                }
+                            },
+                            "ref": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 18,
+                                        "column": 12,
+                                        "byte": 384
+                                    },
+                                    "end": {
+                                        "line": 18,
+                                        "column": 22,
+                                        "byte": 394
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "baz": {
+                                            "type": "string",
+                                            "const": "qux"
                                         }
                                     },
-                                    "ref": {
+                                    "type": "object",
+                                    "required": [
+                                        "baz"
+                                    ]
+                                },
+                                "object": {
+                                    "baz": {
                                         "range": {
                                             "environment": "schema",
                                             "begin": {
                                                 "line": 18,
-                                                "column": 12,
-                                                "byte": 384
+                                                "column": 19,
+                                                "byte": 391
                                             },
                                             "end": {
                                                 "line": 18,
@@ -1955,87 +1908,109 @@
                                             }
                                         },
                                         "schema": {
-                                            "properties": {
-                                                "baz": {
-                                                    "type": "string",
-                                                    "const": "qux"
-                                                }
-                                            },
-                                            "type": "object",
-                                            "required": [
-                                                "baz"
-                                            ]
-                                        },
-                                        "object": {
-                                            "baz": {
-                                                "range": {
-                                                    "environment": "schema",
-                                                    "begin": {
-                                                        "line": 18,
-                                                        "column": 19,
-                                                        "byte": 391
-                                                    },
-                                                    "end": {
-                                                        "line": 18,
-                                                        "column": 22,
-                                                        "byte": 394
-                                                    }
-                                                },
-                                                "schema": {
-                                                    "type": "string",
-                                                    "const": "qux"
-                                                },
-                                                "literal": "qux"
-                                            }
-                                        }
-                                    },
-                                    "string": {
-                                        "range": {
-                                            "environment": "schema",
-                                            "begin": {
-                                                "line": 10,
-                                                "column": 15,
-                                                "byte": 165
-                                            },
-                                            "end": {
-                                                "line": 10,
-                                                "column": 18,
-                                                "byte": 168
-                                            }
-                                        },
-                                        "schema": {
                                             "type": "string",
-                                            "const": "esc"
+                                            "const": "qux"
                                         },
-                                        "literal": "esc"
+                                        "literal": "qux"
+                                    }
+                                }
+                            },
+                            "string": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 15,
+                                        "byte": 165
                                     },
-                                    "true": {
-                                        "range": {
-                                            "environment": "schema",
-                                            "begin": {
-                                                "line": 7,
-                                                "column": 15,
-                                                "byte": 114
-                                            },
-                                            "end": {
-                                                "line": 7,
-                                                "column": 19,
-                                                "byte": 118
-                                            }
-                                        },
-                                        "schema": {
-                                            "type": "boolean",
-                                            "const": true
-                                        },
-                                        "literal": true
+                                    "end": {
+                                        "line": 10,
+                                        "column": 18,
+                                        "byte": 168
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "esc"
+                                },
+                                "literal": "esc"
+                            },
+                            "true": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 15,
+                                        "byte": 114
                                     },
-                                    "tuple": {
+                                    "end": {
+                                        "line": 7,
+                                        "column": 19,
+                                        "byte": 118
+                                    }
+                                },
+                                "schema": {
+                                    "type": "boolean",
+                                    "const": true
+                                },
+                                "literal": true
+                            },
+                            "tuple": {
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 13,
+                                        "column": 14,
+                                        "byte": 256
+                                    },
+                                    "end": {
+                                        "line": 13,
+                                        "column": 28,
+                                        "byte": 270
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "const": "world"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
                                         "range": {
                                             "environment": "schema",
                                             "begin": {
                                                 "line": 13,
-                                                "column": 14,
-                                                "byte": 256
+                                                "column": 16,
+                                                "byte": 258
+                                            },
+                                            "end": {
+                                                "line": 13,
+                                                "column": 21,
+                                                "byte": 263
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        "literal": "hello"
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "schema",
+                                            "begin": {
+                                                "line": 13,
+                                                "column": 23,
+                                                "byte": 265
                                             },
                                             "end": {
                                                 "line": 13,
@@ -2044,83 +2019,12 @@
                                             }
                                         },
                                         "schema": {
-                                            "prefixItems": [
-                                                {
-                                                    "type": "string",
-                                                    "const": "hello"
-                                                },
-                                                {
-                                                    "type": "string",
-                                                    "const": "world"
-                                                }
-                                            ],
-                                            "items": false,
-                                            "type": "array"
+                                            "type": "string",
+                                            "const": "world"
                                         },
-                                        "list": [
-                                            {
-                                                "range": {
-                                                    "environment": "schema",
-                                                    "begin": {
-                                                        "line": 13,
-                                                        "column": 16,
-                                                        "byte": 258
-                                                    },
-                                                    "end": {
-                                                        "line": 13,
-                                                        "column": 21,
-                                                        "byte": 263
-                                                    }
-                                                },
-                                                "schema": {
-                                                    "type": "string",
-                                                    "const": "hello"
-                                                },
-                                                "literal": "hello"
-                                            },
-                                            {
-                                                "range": {
-                                                    "environment": "schema",
-                                                    "begin": {
-                                                        "line": 13,
-                                                        "column": 23,
-                                                        "byte": 265
-                                                    },
-                                                    "end": {
-                                                        "line": 13,
-                                                        "column": 28,
-                                                        "byte": 270
-                                                    }
-                                                },
-                                                "schema": {
-                                                    "type": "string",
-                                                    "const": "world"
-                                                },
-                                                "literal": "world"
-                                            }
-                                        ]
+                                        "literal": "world"
                                     }
-                                }
-                            },
-                            "provider": {
-                                "range": {
-                                    "environment": "schema",
-                                    "begin": {
-                                        "line": 3,
-                                        "column": 5,
-                                        "byte": 22
-                                    },
-                                    "end": {
-                                        "line": 3,
-                                        "column": 21,
-                                        "byte": 38
-                                    }
-                                },
-                                "schema": {
-                                    "type": "string",
-                                    "const": "schema"
-                                },
-                                "literal": "schema"
+                                ]
                             }
                         }
                     }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21.0
 
 require (
 	github.com/ccojocar/zxcvbn-go v1.0.1
+	github.com/charmbracelet/glamour v0.6.0
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/google/go-querystring v1.1.0
 	github.com/hashicorp/hcl/v2 v2.17.0
@@ -51,6 +52,7 @@ require (
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/armon/go-metrics v0.4.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
@@ -76,6 +78,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.10 // indirect
 	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/charmbracelet/bubbles v0.16.1 // indirect
@@ -87,6 +90,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/djherbis/times v1.5.0 // indirect
+	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
@@ -107,6 +111,7 @@ require (
 	github.com/google/wire v0.5.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.11.0 // indirect
+	github.com/gorilla/css v1.0.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -144,6 +149,7 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
+	github.com/microcosm-cc/bluemonday v1.0.21 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
@@ -159,6 +165,7 @@ require (
 	github.com/muesli/termenv v0.15.1 // indirect
 	github.com/natefinch/atomic v1.0.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pgavlin/diff v0.0.0-20230503175810-113847418e2e // indirect
@@ -186,6 +193,8 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	github.com/yuin/goldmark v1.5.2 // indirect
+	github.com/yuin/goldmark-emoji v1.0.1 // indirect
 	github.com/zclconf/go-cty v1.13.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSi
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
+github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -305,8 +307,11 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.16.10/go.mod h1:cftkHYN6tCDNfkSasAmc
 github.com/aws/smithy-go v1.12.0/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/aymanbagabas/go-osc52 v1.0.3/go.mod h1:zT8H+Rk4VSabYN90pWyugflM3ZhpTZNC7cASDfUCdT4=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
+github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -349,6 +354,8 @@ github.com/charmbracelet/bubbles v0.16.1 h1:6uzpAAaT9ZqKssntbvZMlksWHruQLNxg49H5
 github.com/charmbracelet/bubbles v0.16.1/go.mod h1:2QCp9LFlEsBQMvIYERr7Ww2H2bA7xen1idUDIzm/+Xc=
 github.com/charmbracelet/bubbletea v0.24.2 h1:uaQIKx9Ai6Gdh5zpTbGiWpytMU+CfsPp06RaW2cx/SY=
 github.com/charmbracelet/bubbletea v0.24.2/go.mod h1:XdrNrV4J8GiyshTtx3DNuYkR1FDaJmO3l2nejekbsgg=
+github.com/charmbracelet/glamour v0.6.0 h1:wi8fse3Y7nfcabbbDuwolqTqMQPMnVPeZhDM273bISc=
+github.com/charmbracelet/glamour v0.6.0/go.mod h1:taqWV4swIMMbWALc0m7AfE9JkPSU8om2538k9ITBxOc=
 github.com/charmbracelet/lipgloss v0.7.1 h1:17WMwi7N1b1rVWOjMT+rCh7sQkvDU75B2hbZpc5Kc1E=
 github.com/charmbracelet/lipgloss v0.7.1/go.mod h1:yG0k3giv8Qj8edTCbbg6AlQ5e8KNWpFujkNawKNhE2c=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
@@ -539,6 +546,8 @@ github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
 github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
+github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
+github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
@@ -896,6 +905,8 @@ github.com/gophercloud/gophercloud v0.24.0/go.mod h1:Q8fZtyi5zZxPS/j9aj3sSxtvj41
 github.com/gophercloud/gophercloud v0.25.0/go.mod h1:Q8fZtyi5zZxPS/j9aj3sSxtvj41AdQMDwyo1myduD5c=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
+github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
@@ -1201,12 +1212,14 @@ github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcME
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
 github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -1218,6 +1231,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/microcosm-cc/bluemonday v1.0.21 h1:dNH3e4PSyE4vNX+KlRGHT5KrSvjeUkoNPwEORjffHJg=
+github.com/microcosm-cc/bluemonday v1.0.21/go.mod h1:ytNkv4RrDrLJ2pqlsSI46O6IVXmZOBBD4SaJyDwwTkM=
 github.com/microsoft/ApplicationInsights-Go v0.4.4/go.mod h1:fKRUseBqkw6bDiXTs3ESTiU/4YTIHsQS4W3fP2ieF4U=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
@@ -1286,6 +1301,7 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
+github.com/muesli/termenv v0.13.0/go.mod h1:sP1+uffeLaEYpyOTb8pLCUctGcGLnoFjSn4YJK5e2bc=
 github.com/muesli/termenv v0.15.1 h1:UzuTb/+hhlBugQz28rpzey4ZuKcZ03MeKsoG7IJZIxs=
 github.com/muesli/termenv v0.15.1/go.mod h1:HeAQPTzpfs016yGtA4g00CsdYnVLJvxsS4ANqrZs2sQ=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
@@ -1312,6 +1328,8 @@ github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -1654,6 +1672,10 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark v1.5.2 h1:ALmeCk/px5FSm1MAcFBAsVKZjDuMVj8Tm7FFIlMJnqU=
+github.com/yuin/goldmark v1.5.2/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/goldmark-emoji v1.0.1 h1:ctuWEyzGBwiucEqxzwe0SOYDXPAucOrE9NQC18Wa1os=
+github.com/yuin/goldmark-emoji v1.0.1/go.mod h1:2w1E6FEWLcDQkoTE+7HU6QF1F6SLlNGjRIBbIZQFqkQ=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
@@ -1922,6 +1944,7 @@ golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220802222814-0bcc04d9c69b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20221002022538-bcab6841153b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
@@ -2111,6 +2134,7 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220731174439-a90be440212d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
- Improve the display by defaulting to the "explain" view, which
  includes the value (if available), the definition (if available), and
  the def stack
- Add the option to show _just_ the value in a given format. The set of
  formats is the same as that supported by `env open`

Fixes https://github.com/pulumi/esc/issues/28.