### PR TITLE
Check that both values and imports are empty

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -92,7 +92,7 @@ func evalEnvironment(
 	providers ProviderLoader,
 	envs EnvironmentLoader,
 ) (*esc.Environment, syntax.Diagnostics) {
-	if env == nil || len(env.Values.GetEntries()) == 0 {
+	if env == nil || (len(env.Values.GetEntries()) == 0 && len(env.Imports.GetElements()) == 0) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
I incorrectly assumed that an environment without values is an empty environment. In fact, in the pulumi config yaml, an environment is valid with only imports. This change checks that both values and imports is empty before returning an empty (nil) environment.