### PR TITLE
Surface API errors if they exist

### DIFF
--- a/cmd/esc/cli/client/apitype.go
+++ b/cmd/esc/cli/client/apitype.go
@@ -15,14 +15,32 @@ type EnvironmentDiagnostic struct {
 	Detail  string     `json:"detail,omitempty"`
 }
 
-type EnvironmentDiagnosticsResponse struct {
+type EnvironmentErrorResponse struct {
+	Code        int                     `json:"code,omitempty"`
+	Message     string                  `json:"message,omitempty"`
+	Diagnostics []EnvironmentDiagnostic `json:"diagnostics,omitempty"`
+}
+
+func (err EnvironmentErrorResponse) Error() string {
+	errString := fmt.Sprintf("[%d] %s", err.Code, err.Message)
+	if len(err.Diagnostics) > 0 {
+		errString += fmt.Sprintf("\nDiags: %s", diagsErrorString(err.Diagnostics))
+	}
+	return errString
+}
+
+type EnvironmentDiagnosticError struct {
 	Diagnostics []EnvironmentDiagnostic `json:"diagnostics,omitempty"`
 }
 
 // Error implements the Error interface.
-func (err EnvironmentDiagnosticsResponse) Error() string {
+func (err EnvironmentDiagnosticError) Error() string {
+	return diagsErrorString(err.Diagnostics)
+}
+
+func diagsErrorString(envDiags []EnvironmentDiagnostic) string {
 	var diags strings.Builder
-	for _, d := range err.Diagnostics {
+	for _, d := range envDiags {
 		fmt.Fprintf(&diags, "%v\n", d.Summary)
 	}
 	return diags.String()
@@ -39,7 +57,7 @@ type ListEnvironmentsResponse struct {
 }
 
 type UpdateEnvironmentResponse struct {
-	EnvironmentDiagnosticsResponse
+	EnvironmentDiagnosticError
 }
 
 type CheckEnvironmentResponse struct {

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -253,14 +253,14 @@ func (pc *client) UpdateEnvironment(
 		header.Set("ETag", tag)
 	}
 
-	var errResp EnvironmentDiagnosticsResponse
+	var errResp EnvironmentErrorResponse
 	path := fmt.Sprintf("/api/preview/environments/%v/%v", orgName, envName)
 	err := pc.restCallWithOptions(ctx, http.MethodPatch, path, nil, json.RawMessage(yaml), nil, httpCallOptions{
 		Header:        header,
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		var diags *EnvironmentDiagnosticsResponse
+		var diags *EnvironmentDiagnosticError
 		if errors.As(err, &diags) {
 			return diags.Diagnostics, nil
 		}
@@ -289,13 +289,13 @@ func (pc *client) OpenEnvironment(
 	var resp struct {
 		ID string `json:"id"`
 	}
-	var errResp EnvironmentDiagnosticsResponse
+	var errResp EnvironmentErrorResponse
 	path := fmt.Sprintf("/api/preview/environments/%v/%v/open", orgName, envName)
 	err := pc.restCallWithOptions(ctx, http.MethodPost, path, queryObj, nil, &resp, httpCallOptions{
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		var diags *EnvironmentDiagnosticsResponse
+		var diags *EnvironmentDiagnosticError
 		if errors.As(err, &diags) {
 			return "", diags.Diagnostics, nil
 		}
@@ -310,13 +310,13 @@ func (pc *client) CheckYAMLEnvironment(
 	yaml []byte,
 ) (*esc.Environment, []EnvironmentDiagnostic, error) {
 	var resp esc.Environment
-	var errResp EnvironmentDiagnosticsResponse
+	var errResp EnvironmentErrorResponse
 	path := fmt.Sprintf("/api/preview/environments/%v/yaml/check", orgName)
 	err := pc.restCallWithOptions(ctx, http.MethodPost, path, nil, json.RawMessage(yaml), &resp, httpCallOptions{
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		var diags *EnvironmentDiagnosticsResponse
+		var diags *EnvironmentDiagnosticError
 		if errors.As(err, &diags) {
 			return nil, diags.Diagnostics, nil
 		}
@@ -340,13 +340,13 @@ func (pc *client) OpenYAMLEnvironment(
 	var resp struct {
 		ID string `json:"id"`
 	}
-	var errResp EnvironmentDiagnosticsResponse
+	var errResp EnvironmentErrorResponse
 	path := fmt.Sprintf("/api/preview/environments/%v/yaml/open", orgName)
 	err := pc.restCallWithOptions(ctx, http.MethodPost, path, queryObj, json.RawMessage(yaml), &resp, httpCallOptions{
 		ErrorResponse: &errResp,
 	})
 	if err != nil {
-		var diags *EnvironmentDiagnosticsResponse
+		var diags *EnvironmentDiagnosticError
 		if errors.As(err, &diags) {
 			return "", diags.Diagnostics, nil
 		}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pulumi/pulumi/pkg/v3 v3.78.2-0.20230926151835-2b44cf6ec1be
 	github.com/pulumi/pulumi/sdk/v3 v3.85.1-0.20230926151835-2b44cf6ec1be
 	github.com/rivo/uniseg v0.4.4
-	github.com/rogpeppe/go-internal v1.10.1-0.20230524175051-ec119421bb97
+	github.com/rogpeppe/go-internal v1.11.0
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63

--- a/go.sum
+++ b/go.sum
@@ -1508,8 +1508,8 @@ github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rogpeppe/go-internal v1.10.1-0.20230524175051-ec119421bb97 h1:3RPlVWzZ/PDqmVuf/FKHARG5EMid/tl7cv54Sw/QRVY=
-github.com/rogpeppe/go-internal v1.10.1-0.20230524175051-ec119421bb97/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
+github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=


### PR DESCRIPTION
We were accidentally eating any API errors in some requests that could also return diags. This change fixes it so we also capture and surface the API errors

Fixes #49 