### PR TITLE
cli: add a test for errors from `open`

### DIFF
--- a/cmd/esc/cli/testdata/open-json-error.yaml
+++ b/cmd/esc/cli/testdata/open-json-error.yaml
@@ -1,0 +1,13 @@
+run: esc open test --format json
+environments:
+  test-user/test:
+    values:
+      object: {}
+      missing: ${foo}
+      invalid: {'fn::toBase64': "${object}"}
+stdout: |
+  > esc open test --format json
+stderr: |
+  > esc open test --format json
+  test:3:14: unknown property "foo"
+  test:4:31: expected string, got object


### PR DESCRIPTION
These errors should be infrequent, but we ought to validate that we're rendering them properly.