### PR TITLE
eval: reserve the 'context' top-level key

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -262,6 +262,15 @@ func (e *evalContext) declare(path string, x ast.Expr, base *value) *expr {
 	}
 }
 
+func (e *evalContext) isReserveTopLevelKey(k string) bool {
+	switch k {
+	case "imports", "context":
+		return true
+	default:
+		return false
+	}
+}
+
 // evaluate drives the evaluation of the evalContext's environment.
 func (e *evalContext) evaluate() (*value, syntax.Diagnostics) {
 	// Evaluate imports. We do this prior to declaration so that we can plumb base values as part of declaration.
@@ -282,8 +291,8 @@ func (e *evalContext) evaluate() (*value, syntax.Diagnostics) {
 	for _, entry := range e.env.Values.GetEntries() {
 		key := entry.Key.GetValue()
 
-		if key == "imports" {
-			e.errorf(entry.Key, "imports is a reserved key")
+		if e.isReserveTopLevelKey(key) {
+			e.errorf(entry.Key, "%q is a reserved key", key)
 		} else if _, ok := properties[key]; ok {
 			e.errorf(entry.Key, "duplicate key %q", key)
 		} else {

--- a/eval/testdata/eval/reserved-keys/env.yaml
+++ b/eval/testdata/eval/reserved-keys/env.yaml
@@ -1,0 +1,3 @@
+values:
+  imports: foo
+  context: bar

--- a/eval/testdata/eval/reserved-keys/expected.json
+++ b/eval/testdata/eval/reserved-keys/expected.json
@@ -1,0 +1,103 @@
+{
+    "checkDiags": [
+        {
+            "Severity": 1,
+            "Summary": "\"imports\" is a reserved key",
+            "Detail": "",
+            "Subject": {
+                "Filename": "reserved-keys",
+                "Start": {
+                    "Line": 2,
+                    "Column": 3,
+                    "Byte": 10
+                },
+                "End": {
+                    "Line": 2,
+                    "Column": 10,
+                    "Byte": 17
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Shown": false
+        },
+        {
+            "Severity": 1,
+            "Summary": "\"context\" is a reserved key",
+            "Detail": "",
+            "Subject": {
+                "Filename": "reserved-keys",
+                "Start": {
+                    "Line": 3,
+                    "Column": 3,
+                    "Byte": 25
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 10,
+                    "Byte": 32
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Shown": false
+        }
+    ],
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "\"imports\" is a reserved key",
+            "Detail": "",
+            "Subject": {
+                "Filename": "reserved-keys",
+                "Start": {
+                    "Line": 2,
+                    "Column": 3,
+                    "Byte": 10
+                },
+                "End": {
+                    "Line": 2,
+                    "Column": 10,
+                    "Byte": 17
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Shown": false
+        },
+        {
+            "Severity": 1,
+            "Summary": "\"context\" is a reserved key",
+            "Detail": "",
+            "Subject": {
+                "Filename": "reserved-keys",
+                "Start": {
+                    "Line": 3,
+                    "Column": 3,
+                    "Byte": 25
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 10,
+                    "Byte": 32
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Shown": false
+        }
+    ],
+    "environment": {
+        "schema": {
+            "type": "object"
+        }
+    }
+}


### PR DESCRIPTION
In the future, we may want to use this key to refer to values passed in from the evaluation host. Reserve it for now.

Fixes #9.