### PR TITLE
cli: do not panic on missing/invalid creds

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,3 +2,5 @@
 
 ### Bug Fixes
 
+- Fix panics that could occur when no credentials are available or credentials were invalid.
+  [#93](https://github.com/pulumi/esc/pull/93)

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -430,8 +430,11 @@ func (c *testPulumiClient) UpdateEnvironment(
 
 	_, diags, err := c.checkEnvironment(ctx, orgName, envName, yaml)
 	if err == nil && len(diags) == 0 {
+		h := fnv.New32()
+		h.Write(yaml)
+
 		env.yaml = yaml
-		env.tag = base64.StdEncoding.EncodeToString(fnv.New32().Sum(yaml))
+		env.tag = base64.StdEncoding.EncodeToString(h.Sum(nil))
 	}
 
 	return diags, err

--- a/cmd/esc/cli/login_test.go
+++ b/cmd/esc/cli/login_test.go
@@ -1,0 +1,33 @@
+// Copyright 2023, Pulumi Corporation.
+
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/esc/cmd/esc/cli/workspace"
+	pulumi_workspace "github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoCreds(t *testing.T) {
+	fs := testFS{}
+	esc := &escCommand{workspace: workspace.New(fs, &testPulumiWorkspace{})}
+	err := esc.getCachedClient(context.Background())
+	assert.ErrorContains(t, err, "no credentials")
+}
+
+func TestFilestateBackend(t *testing.T) {
+	fs := testFS{}
+	esc := &escCommand{workspace: workspace.New(fs, &testPulumiWorkspace{
+		credentials: pulumi_workspace.Credentials{
+			Current: "gs://foo",
+			Accounts: map[string]pulumi_workspace.Account{
+				"gs://foo": {},
+			},
+		},
+	})}
+	err := esc.getCachedClient(context.Background())
+	assert.ErrorContains(t, err, "does not support Pulumi ESC")
+}


### PR DESCRIPTION
- If creds are missing, return a friendly message instructing the user to log in
- If the active account is not a cloud account, return a message indicating that the backend is not supported

Fixes #89.