### PR TITLE
cli: fix login error messages

### DIFF
--- a/cmd/esc/cli/esc.go
+++ b/cmd/esc/cli/esc.go
@@ -49,7 +49,8 @@ type escCommand struct {
 	stdout io.Writer
 	stderr io.Writer
 
-	colors colors.Colorization
+	command string
+	colors  colors.Colorization
 
 	login     httpstate.LoginManager
 	workspace *workspace.Workspace
@@ -103,6 +104,7 @@ func New(opts *Options) *cobra.Command {
 		stdin:     valueOrDefault(opts.Stdin, io.Reader(os.Stdin)),
 		stdout:    valueOrDefault(opts.Stdout, io.Writer(os.Stdout)),
 		stderr:    valueOrDefault(opts.Stderr, io.Writer(os.Stderr)),
+		command:   valueOrDefault(opts.ParentPath, "esc"),
 		colors:    valueOrDefault(opts.Colors, cmdutil.GetGlobalColorization()),
 		login:     valueOrDefault(opts.Login, httpstate.NewLoginManager()),
 		workspace: workspace.New(fs, valueOrDefault(opts.PulumiWorkspace, workspace.DefaultPulumiWorkspace())),

--- a/cmd/esc/cli/login.go
+++ b/cmd/esc/cli/login.go
@@ -73,7 +73,7 @@ func newLoginCmd(esc *escCommand) *cobra.Command {
 				backendURL, shared = account.BackendURL, isShared
 			}
 
-			if err := checkBackendURL(backendURL); err != nil {
+			if err := esc.checkBackendURL(backendURL); err != nil {
 				return err
 			}
 
@@ -137,11 +137,11 @@ func isInvalidSelfHostedURL(url string) bool {
 	return strings.HasPrefix(url, "app.pulumi.com/") || strings.HasPrefix(url, "pulumi.com")
 }
 
-func checkBackendURL(url string) error {
+func (esc *escCommand) checkBackendURL(url string) error {
 	switch {
 	case isInvalidSelfHostedURL(url):
 		return fmt.Errorf("%s is not a valid self-hosted backend, "+
-			"use `esc login` without arguments to log into the Pulumi Cloud backend", url)
+			"use `%s login` without arguments to log into the Pulumi Cloud backend", url, esc.command)
 	case filestate.IsFileStateBackendURL(url):
 		return fmt.Errorf("%s does not support Pulumi ESC.", url)
 	default:
@@ -155,10 +155,10 @@ func (esc *escCommand) getCachedClient(ctx context.Context) error {
 		return fmt.Errorf("could not determine current cloud: %w", err)
 	}
 	if account == nil {
-		return fmt.Errorf("no credentials. Please run `esc login` to log in.")
+		return fmt.Errorf("no credentials. Please run `%v login` to log in.", esc.command)
 	}
 
-	if err := checkBackendURL(account.BackendURL); err != nil {
+	if err := esc.checkBackendURL(account.BackendURL); err != nil {
 		return err
 	}
 
@@ -167,7 +167,7 @@ func (esc *escCommand) getCachedClient(ctx context.Context) error {
 		return fmt.Errorf("getting credentials: %w", err)
 	}
 	if !ok {
-		return fmt.Errorf("no credentials. Please run `esc login` to log in.")
+		return fmt.Errorf("no credentials. Please run `%v login` to log in.", esc.command)
 	}
 
 	esc.client = esc.newClient(esc.userAgent, account.BackendURL, account.AccessToken, account.Insecure)

--- a/cmd/esc/cli/login_test.go
+++ b/cmd/esc/cli/login_test.go
@@ -16,6 +16,28 @@ func TestNoCreds(t *testing.T) {
 	esc := &escCommand{workspace: workspace.New(fs, &testPulumiWorkspace{})}
 	err := esc.getCachedClient(context.Background())
 	assert.ErrorContains(t, err, "no credentials")
+
+	esc.command = "pulumi"
+	err = esc.getCachedClient(context.Background())
+	assert.ErrorContains(t, err, "pulumi login")
+}
+
+func TestInvalidSelfHostedBackend(t *testing.T) {
+	fs := testFS{}
+	esc := &escCommand{workspace: workspace.New(fs, &testPulumiWorkspace{
+		credentials: pulumi_workspace.Credentials{
+			Current: "http://pulumi.com",
+			Accounts: map[string]pulumi_workspace.Account{
+				"http://pulumi.com": {},
+			},
+		},
+	})}
+	err := esc.getCachedClient(context.Background())
+	assert.ErrorContains(t, err, "not a valid self-hosted backend")
+
+	esc.command = "pulumi"
+	err = esc.getCachedClient(context.Background())
+	assert.ErrorContains(t, err, "pulumi login")
 }
 
 func TestFilestateBackend(t *testing.T) {


### PR DESCRIPTION
Do not reference the `esc` CLI when it is being embedded in another tool.