### PR TITLE
cli: add a `-f` flag to `env init`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,9 @@
 ### Improvements
 
+- Add a `-f` flag to `esc env init` that allows the specification of the initial definition
+  for an environment.
+  [#95](https://github.com/pulumi/esc/pull/95)
+
 ### Bug Fixes
 
 - Fix panics that could occur when no credentials are available or credentials were invalid.

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -587,7 +587,7 @@ func (c *testExec) runScript(script string, cmd *exec.Cmd) error {
 					return nil, os.ErrNotExist
 				}
 				f = &fstest.MapFile{Mode: perm}
-				c.fs.MapFS[path] = &fstest.MapFile{Mode: perm}
+				c.fs.MapFS[path] = f
 			}
 			if flag&os.O_TRUNC != 0 {
 				f.Data = f.Data[:0]

--- a/cmd/esc/cli/testdata/env-init-conflict.yaml
+++ b/cmd/esc/cli/testdata/env-init-conflict.yaml
@@ -6,4 +6,4 @@ stdout: |
   > esc env init dup
 stderr: |
   > esc env init dup
-  Error: already exists
+  Error: creating environment: already exists

--- a/cmd/esc/cli/testdata/env-init-diags.yaml
+++ b/cmd/esc/cli/testdata/env-init-diags.yaml
@@ -1,0 +1,15 @@
+run: |
+  echo '{"values":{"foo":"${bar}"}}' | esc env init test-stdin -f=-
+  esc env get test-stdin
+error: exit status 1
+stdout: |
+  > esc env init test-stdin -f=-
+  Environment created.
+stderr: |
+  > esc env init test-stdin -f=-
+  Error: unknown property "bar"
+
+    on test-stdin line 1:
+     1: {"values":{"foo":"${bar}"}}
+
+  Error: updating environment definition: too many errors

--- a/cmd/esc/cli/testdata/env-init-ok.yaml
+++ b/cmd/esc/cli/testdata/env-init-ok.yaml
@@ -1,5 +1,49 @@
-run: esc env init test-env
-stdout: |
+run: |
+  esc env init test-env
+  esc env get test-env
+  echo '{"values":{"foo":"bar"}}' | esc env init test-stdin -f=-
+  esc env get test-stdin
+  echo '{"values":{"foo":"bar"}}' >def.yaml
+  esc env init test-file -f def.yaml
+  esc env get test-file
+stdout: |+
   > esc env init test-env
+  Environment created.
+  > esc env get test-env
+  > esc env init test-stdin -f=-
+  Environment created.
+  > esc env get test-stdin
+  # Value
+  ```json
+  {
+    "foo": "bar"
+  }
+  ```
+  # Definition
+  ```yaml
+  {"values": {"foo": "bar"}}
+
+  ```
+
+  > esc env init test-file -f def.yaml
+  Environment created.
+  > esc env get test-file
+  # Value
+  ```json
+  {
+    "foo": "bar"
+  }
+  ```
+  # Definition
+  ```yaml
+  {"values": {"foo": "bar"}}
+
+  ```
+
 stderr: |
   > esc env init test-env
+  > esc env get test-env
+  > esc env init test-stdin -f=-
+  > esc env get test-stdin
+  > esc env init test-file -f def.yaml
+  > esc env get test-file

--- a/cmd/esc/cli/testdata/env-set-invalid.yaml
+++ b/cmd/esc/cli/testdata/env-set-invalid.yaml
@@ -8,6 +8,7 @@ run: |
   esc env set test array.foo bar || echo -n ""
 stdout: |
   > esc env init test
+  Environment created.
   > esc env set test string foo
   > esc env set test object {}
   > esc env set test array []

--- a/cmd/esc/cli/testdata/env-set-secret-error.yaml
+++ b/cmd/esc/cli/testdata/env-set-secret-error.yaml
@@ -4,6 +4,7 @@ run: |
 error: exit status 1
 stdout: |
   > esc env init test
+  Environment created.
   > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
 stderr: |
   > esc env init test

--- a/cmd/esc/cli/testdata/env-set-secret.yaml
+++ b/cmd/esc/cli/testdata/env-set-secret.yaml
@@ -6,6 +6,7 @@ run: |
   esc env get test
 stdout: |+
   > esc env init test
+  Environment created.
   > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret
   > esc env get test
   # Value

--- a/cmd/esc/cli/testdata/env-set.yaml
+++ b/cmd/esc/cli/testdata/env-set.yaml
@@ -16,6 +16,7 @@ run: |
   esc env set test 'imports[1]' test3 && esc env get test
 stdout: |+
   > esc env init test
+  Environment created.
   > esc env set test foo.bar.baz qux
   > esc env get test
   # Value
@@ -351,6 +352,7 @@ stdout: |+
   ```
 
   > esc env init test2
+  Environment created.
   > esc env set test imports[0] test2
   > esc env get test
   # Value
@@ -398,6 +400,7 @@ stdout: |+
   ```
 
   > esc env init test3
+  Environment created.
   > esc env set test imports[1] test3
   > esc env get test
   # Value


### PR DESCRIPTION
If this flag is specified, the initial definition of the environment is read from the given file. If the filename is `-`, contents are read from `stdin`. If the initial definition contains errors, the environment is still created but is left empty.

Related to #91.