### PR TITLE
cli: default to api.pulumi.com for login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+CHANGELOG
+=========
+
+## 0.5.2
+
+### Improvements
+
+- Add a `-f` flag to `esc env init` that allows the specification of the initial definition
+  for an environment.
+  [#95](https://github.com/pulumi/esc/pull/95)
+
+### Bug Fixes
+
+- Fix panics that could occur when no credentials are available or credentials were invalid.
+  [#93](https://github.com/pulumi/esc/pull/93)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,10 +1,6 @@
 ### Improvements
 
-- Add a `-f` flag to `esc env init` that allows the specification of the initial definition
-  for an environment.
-  [#95](https://github.com/pulumi/esc/pull/95)
-
 ### Bug Fixes
 
-- Fix panics that could occur when no credentials are available or credentials were invalid.
-  [#93](https://github.com/pulumi/esc/pull/93)
+- Fix behavior for `esc login` when no backend is provided
+  [#105](https://github.com/pulumi/esc/pull/105)

--- a/cmd/esc/cli/login.go
+++ b/cmd/esc/cli/login.go
@@ -68,9 +68,11 @@ func newLoginCmd(esc *escCommand) *cobra.Command {
 					return fmt.Errorf("could not determine current cloud: %w", err)
 				}
 				if account == nil {
-					return fmt.Errorf("not currently logged in")
+					backendURL = "https://api.pulumi.com"
+				} else {
+					backendURL = account.BackendURL
 				}
-				backendURL, shared = account.BackendURL, isShared
+				shared = isShared
 			}
 
 			if err := esc.checkBackendURL(backendURL); err != nil {

--- a/cmd/esc/cli/testdata/login-logout.yaml
+++ b/cmd/esc/cli/testdata/login-logout.yaml
@@ -17,21 +17,19 @@ stdout: |
   > esc logout
   Logged out of http://fake.pulumi.api
   > esc login
-  ok
+  Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
   > esc login https://api.pulumi.com
   Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
   > esc logout --all
   Logged out of all clouds
   > esc login
-  ok
+  Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
 stderr: |
   > esc login
   > esc login https://api.pulumi.com
   > esc login http://fake.pulumi.api
   > esc logout
   > esc login
-  Error: not currently logged in
   > esc login https://api.pulumi.com
   > esc logout --all
   > esc login
-  Error: not currently logged in


### PR DESCRIPTION
If no backend is specified or available via existing Pulumi creds, default to https://api.pulumi.com.

Fixes #100.