### PR TITLE
cli: do not panic in `env set foo bar ""`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
 ### Bug Fixes
+
+- Do not panic when `env set` is passed an empty value.
+  [#110](https://github.com/pulumi/esc/pull/110)

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -56,6 +56,12 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 			if err := yaml.Unmarshal([]byte(args[1]), &yamlValue); err != nil {
 				return fmt.Errorf("invalid value: %w", err)
 			}
+			if len(yamlValue.Content) == 0 {
+				// This can happen when the value is empty (e.g. when "" is present on the command line). Treat this
+				// as the empty string.
+				err = yaml.Unmarshal([]byte(`""`), &yamlValue)
+				contract.IgnoreError(err)
+			}
 			yamlValue = *yamlValue.Content[0]
 
 			if looksLikeSecret(path, yamlValue) && !secret && !plaintext {

--- a/cmd/esc/cli/testdata/env-set.yaml
+++ b/cmd/esc/cli/testdata/env-set.yaml
@@ -10,6 +10,7 @@ run: |
   esc env set test 'array[1]' esc && esc env get test
   esc env set test 'array[2]' '{}' && esc env get test
   esc env set test 'array[2].foo' bar && esc env get test
+  esc env set test 'array[2].foo' '' && esc env get test
   esc env init test2
   esc env set test 'imports[0]' test2 && esc env get test
   esc env init test3
@@ -351,9 +352,7 @@ stdout: |+
 
   ```
 
-  > esc env init test2
-  Environment created.
-  > esc env set test imports[0] test2
+  > esc env set test array[2].foo 
   > esc env get test
   # Value
   ```json
@@ -362,7 +361,7 @@ stdout: |+
       "hello",
       "esc",
       {
-        "foo": "bar"
+        "foo": ""
       }
     ],
     "foo": {
@@ -393,7 +392,53 @@ stdout: |+
     array:
       - hello
       - esc
-      - {foo: bar}
+      - {foo: ""}
+
+  ```
+
+  > esc env init test2
+  Environment created.
+  > esc env set test imports[0] test2
+  > esc env get test
+  # Value
+  ```json
+  {
+    "array": [
+      "hello",
+      "esc",
+      {
+        "foo": ""
+      }
+    ],
+    "foo": {
+      "bar": {
+        "alpha": "zed",
+        "baz": "qux"
+      },
+      "beta": [
+        "gamma",
+        42
+      ]
+    },
+    "open": "[unknown]"
+  }
+  ```
+  # Definition
+  ```yaml
+  values:
+    foo:
+      bar:
+        baz: qux
+        alpha: zed
+      beta:
+        - gamma
+        - 42
+    open:
+      "fn::open::test": "cse"
+    array:
+      - hello
+      - esc
+      - {foo: ""}
   imports:
     - test2
 
@@ -410,7 +455,7 @@ stdout: |+
       "hello",
       "esc",
       {
-        "foo": "bar"
+        "foo": ""
       }
     ],
     "foo": {
@@ -441,7 +486,7 @@ stdout: |+
     array:
       - hello
       - esc
-      - {foo: bar}
+      - {foo: ""}
   imports:
     - test2
     - test3
@@ -469,6 +514,8 @@ stderr: |
   > esc env set test array[2] {}
   > esc env get test
   > esc env set test array[2].foo bar
+  > esc env get test
+  > esc env set test array[2].foo 
   > esc env get test
   > esc env init test2
   > esc env set test imports[0] test2


### PR DESCRIPTION
After interpretation by the shell, `env set foo bar ""` passes an empty string as the value to set. The YAML parser treats the empty string as "no document" and doesn't return any content from Unmarshal. Work around this by treating "no document" as an empty string _literal_ (which is likely the intent).

Fixes #109.