### PR TITLE
cli: fix more login bugs

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
 ### Bug Fixes
+
+- Fix behavior for `esc login` when no existing credentials are present
+  [#111](https://github.com/pulumi/esc/pull/111)

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -262,7 +262,15 @@ func (lm *testLoginManager) Login(
 ) (*workspace.Account, error) {
 	acct, ok := lm.creds.Accounts[cloudURL]
 	if !ok {
-		return nil, errors.New("unauthorized")
+		if cloudURL != "https://api.pulumi.com" {
+			return nil, errors.New("unauthorized")
+		}
+		acct := workspace.Account{
+			Username:    "test-user",
+			AccessToken: "access-token",
+		}
+		lm.creds.Accounts[cloudURL] = acct
+		return &acct, nil
 	}
 	return &acct, nil
 }

--- a/cmd/esc/cli/logout.go
+++ b/cmd/esc/cli/logout.go
@@ -47,6 +47,10 @@ func newLogoutCmd(esc *escCommand) *cobra.Command {
 					if err != nil {
 						return fmt.Errorf("getting current account: %w", err)
 					}
+					if account == nil {
+						fmt.Fprintf(esc.stdout, "Already logged out.\n")
+						return nil
+					}
 					backendURL = account.BackendURL
 				}
 				if err := esc.workspace.DeleteAccount(backendURL); err != nil {

--- a/cmd/esc/cli/testdata/env-login-gh100.yaml
+++ b/cmd/esc/cli/testdata/env-login-gh100.yaml
@@ -1,0 +1,24 @@
+# This is a regression test for #100 that aims to capture issues logging in when no existing Pulumi
+# credentials exist.
+run: |
+  esc logout --all
+  esc login
+  esc env ls
+  esc logout
+  esc logout
+stdout: |
+  > esc logout --all
+  Logged out of all clouds
+  > esc login
+  Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
+  > esc env ls
+  > esc logout
+  Logged out of https://api.pulumi.com
+  > esc logout
+  Already logged out.
+stderr: |
+  > esc logout --all
+  > esc login
+  > esc env ls
+  > esc logout
+  > esc logout

--- a/cmd/esc/cli/workspace/credentials.go
+++ b/cmd/esc/cli/workspace/credentials.go
@@ -148,8 +148,18 @@ func (w *Workspace) DeleteAccount(backendURL string) error {
 
 // SetCurrentAccount sets the currently logged-in account.
 func (w *Workspace) SetCurrentAccount(account Account, shared bool) error {
+	// Read Pulumi creds.
+	pulumiCreds, err := w.pulumi.GetStoredCredentials()
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("reading Pulumi credentials: %w", err)
+	}
+
+	// If there is no current Pulumi account and we want to share the current Pulumi account, then we need to set the
+	// current Pulumi account.
+	setCurrent := shared && pulumiCreds.Current == ""
+
 	// Store the account in Pulumi creds.
-	if err := w.pulumi.StoreAccount(account.BackendURL, account.Account, false); err != nil {
+	if err := w.pulumi.StoreAccount(account.BackendURL, account.Account, setCurrent); err != nil {
 		return fmt.Errorf("writing Pulumi credentials: %w", err)
 	}
 


### PR DESCRIPTION
- When running `login` in an environment where there are no existing credentials, also set the current `pulumi` account if using shared creds
- When logging out, check to see if we're actually logged in before attempting to log out.

Fixes #100.