### PR TITLE
cli: fix generated CLI docs for pulumi/pulumi

### DIFF
--- a/cmd/esc/cli/esc.go
+++ b/cmd/esc/cli/esc.go
@@ -117,8 +117,15 @@ func New(opts *Options) *cobra.Command {
 
 	env := newEnvCmd(esc)
 	cmd.AddCommand(env)
-	cmd.AddCommand(getCommand(env, "open"))
-	cmd.AddCommand(getCommand(env, "run"))
+
+	// Add top-level open/run aliases. We copy the commands to new struct values because
+	// `AddCommand` mutates the command, modifying its parent, which can cause issues
+	// with generated docs.
+	openCmdCopy := *getCommand(env, "open")
+	runCmdCopy := *getCommand(env, "run")
+	cmd.AddCommand(&openCmdCopy)
+	cmd.AddCommand(&runCmdCopy)
+
 	cmd.AddCommand(newLoginCmd(esc))
 	cmd.AddCommand(newLogoutCmd(esc))
 	cmd.AddCommand(newVersionCmd(esc))


### PR DESCRIPTION
Create a copy of the open/run command structs before adding them as top-level aliases. This is done because `AddCommand` mutates fields on the Command struct, changing its parent, which causes docs to not be generated correctly from the pulumi/pulumi CLI.

Part of https://github.com/pulumi/pulumi/issues/14237