### PR TITLE
Support for file projection in `run` command

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,8 @@
 - Add two new builtins, `fn::fromBase64` and `fn::fromJSON`. The former decodes a base64-encoded
   string into a binary string and the latter decodes a JSON string into a value.
   [#117](https://github.com/pulumi/esc/pull/117)
-
+- Add support for file projection in run command.
+  [#141](https://github.com/pulumi/esc/pull/141)
+  
 ### Bug Fixes
 

--- a/cmd/esc/cli/testdata/run.yaml
+++ b/cmd/esc/cli/testdata/run.yaml
@@ -3,12 +3,17 @@ run: |
   esc env run -i test dump-env
   esc env run test echo "secret: \${secret}, plain: \${plain}"
   esc env run -i test echo "secret: \${secret}, plain: \${plain}"
+  esc env run test source-file
+  esc env run -i test source-file
 process:
   commands:
     dump-env: |
       echo "secret: $SECRET, plain: $PLAIN"
     echo: |
       echo $*
+    source-file: |
+      source $FILE
+      echo "secret: $F_SECRET, plain: $F_PLAIN"
 environments:
   test-user/test:
     values:
@@ -17,6 +22,10 @@ environments:
       environmentVariables:
         SECRET: ${secret}
         PLAIN: ${plain}
+      files:
+        FILE: |
+          export F_SECRET=${secret}
+          export F_PLAIN=${plain}
 stdout: |
   > esc env run test dump-env
   secret: [secret], plain: plaintext
@@ -26,8 +35,14 @@ stdout: |
   secret: [secret], plain: plaintext
   > esc env run -i test echo secret: ${secret}, plain: ${plain}
   secret: hunter2, plain: plaintext
+  > esc env run test source-file
+  secret: [secret], plain: plaintext
+  > esc env run -i test source-file
+  secret: hunter2, plain: plaintext
 stderr: |
   > esc env run test dump-env
   > esc env run -i test dump-env
   > esc env run test echo secret: ${secret}, plain: ${plain}
   > esc env run -i test echo secret: ${secret}, plain: ${plain}
+  > esc env run test source-file
+  > esc env run -i test source-file


### PR DESCRIPTION
## Overview
This PR adds support for projecting configuration properties as temporary files, based on a new well-known block called `files`. For each property, a temporary file is created containing the property value, and an environment variable is set pointing to the temporary file. Note that the file contents may be dynamically generated using interpolation.

## Example
This feature is designed for a key scenario of projecting a `kubeconfig` file based on a Pulumi environment. Here's how that would work:

Define an environment:
```yaml
# import an environment that provides AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`).
imports:
  - dev-sandbox

# define a kubeconfig file.
values:
  files:
    KUBECONFIG: |
      apiVersion: v1
      clusters:
      - cluster:
          certificate-authority-data: LS0tLS1...
          server: https://....gr7.us-west-2.eks.amazonaws.com
        name: arn:aws:eks:us-west-2:616138583583:cluster/mycluster
      contexts:
      - context:
          cluster: arn:aws:eks:us-west-2:616138583583:cluster/mycluster
          user: arn:aws:eks:us-west-2:616138583583:cluster/mycluster
        name: arn:aws:eks:us-west-2:616138583583:cluster/mycluster
      current-context: arn:aws:eks:us-west-2:616138583583:cluster/mycluster
      kind: Config
      preferences: {}
      users:
      - name: arn:aws:eks:us-west-2:616138583583:cluster/mycluster
        user:
          exec:
            apiVersion: client.authentication.k8s.io/v1beta1
            args:
            - --region
            - us-west-2
            - eks
            - get-token
            - --cluster-name
            - mycluster
            - --output
            - json
            command: aws
```

Run the environment and observe there's a `KUBECONFIG` environment variable that points to a temporary file containing the desired configuration:

```sh
$ esc run -i eron-kubernetes-test -- sh -c 'cat $KUBECONFIG'
apiVersion: v1
clusters:
- cluster:
...
```

This enables:
```sh
$ esc run -i eron-kubernetes-test -- kubectl get ns
NAME              STATUS   AGE
default           Active   46d
kube-node-lease   Active   46d
kube-public       Active   46d
kube-system       Active   46d
```
