### PR TITLE
analysis: add a package for static analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ lint-golang:
 lint-copyright:
 	pulumictl copyright
 
+.phony: format
+format:
+	find . -iname "*.go" -print0 | xargs -r0 gofmt -s -w
+
 build:: ensure
 	${GO} install -ldflags "-X github.com/pulumi/esc/cmd/internal/version.Version=${VERSION}" ./cmd/esc
 

--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -1,0 +1,33 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"github.com/pulumi/esc"
+	"github.com/pulumi/esc/schema"
+)
+
+type Analysis struct {
+	env       esc.Environment
+	providers map[string]*schema.Schema
+}
+
+// New creates a new Analysis from the given source, environment, and provider map.
+func New(env esc.Environment, providers map[string]*schema.Schema) *Analysis {
+	return &Analysis{
+		env:       env,
+		providers: providers,
+	}
+}

--- a/analysis/common_test.go
+++ b/analysis/common_test.go
@@ -1,0 +1,145 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/pulumi/esc"
+	"github.com/pulumi/esc/schema"
+	"golang.org/x/exp/maps"
+)
+
+var testProviderSchema = schema.Object().
+	Properties(map[string]schema.Builder{
+		"address": schema.String().
+			Description("The URL of the Vault server. Must contain a scheme and hostname, but no path."),
+		"jwt": schema.Object().
+			Properties(map[string]schema.Builder{
+				"mount": schema.String().Description("The name of the authentication engine mount."),
+				"role":  schema.String().Description("The name of the role to use for login."),
+			}).
+			Required("role").
+			Description("Options for JWT login. JWT login uses an OIDC token issued by the Pulumi Cloud to generate an ephemeral token."),
+		"token": schema.Object().
+			Properties(map[string]schema.Builder{
+				"displayName": schema.String().Description("The display name of the ephemeral token. Defaults to 'pulumi'."),
+				"token":       schema.String().Description("The parent token."),
+				"maxTtl": schema.String().
+					Pattern(`^([0-9]+h)?([0-9]+m)?([0-9]+s)?$`).
+					Description("The maximum TTL of the ephemeral token."),
+			}).
+			Required("token").
+			Description("Options for token login. Token login creates an ephemeral child token."),
+	}).
+	Required("address").
+	Schema()
+
+type testProvider struct{}
+
+func (testProvider) Schema() (*schema.Schema, *schema.Schema) {
+	return testProviderSchema, schema.Always()
+}
+
+func (testProvider) Open(ctx context.Context, inputs map[string]esc.Value) (esc.Value, error) {
+	return esc.NewValue(inputs), nil
+}
+
+type testProviders struct{}
+
+func (testProviders) LoadProvider(ctx context.Context, name string) (esc.Provider, error) {
+	switch name {
+	case "test":
+		return testProvider{}, nil
+	}
+	return nil, fmt.Errorf("unknown provider %q", name)
+}
+
+type testEnvironments struct{}
+
+func (testEnvironments) LoadEnvironment(ctx context.Context, name string) ([]byte, error) {
+	if name != "a" {
+		return nil, errors.New("not found")
+	}
+	return []byte(`{"values": {}}`), nil
+}
+
+const def = `imports:
+  - a
+values:
+  fromBase64:
+    fn::fromBase64: ${toBase64}
+  fromJSON:
+    fn::fromJSON: ${toJSON}
+  join:
+    fn::join: [ ",", "${strings}" ]
+  open:
+    fn::open::test:
+      address: some-url
+      jwt:
+        mount: foo
+        role: bar
+      token:
+        displayName: foo
+        token: bar
+        maxTtl: 2h
+  secret:
+    fn::secret:
+      hunter2
+  toBase64:
+    fn::toBase64: ${join}
+  toJSON:
+    fn::toJSON: ${open}
+  toString:
+    fn::toString: ${open}
+  open2:
+    fn::open::test: ${open}
+  interp: hello, ${toString}
+  access: ${open["baz"]}
+  strings: [ hello, world ]
+`
+
+func sortedKeys[T any](m map[string]T) []string {
+	keys := maps.Keys(m)
+	sort.Strings(keys)
+	return keys
+}
+
+func visitExprs(env *esc.Environment, visitor func(path string, x esc.Expr)) {
+	var visit func(root esc.Expr, path string)
+	visit = func(root esc.Expr, path string) {
+		visitor(path, root)
+
+		switch {
+		case len(root.List) != 0:
+			for i, element := range root.List {
+				visit(element, fmt.Sprintf("%v/%v", path, i))
+			}
+		case len(root.Object) != 0:
+			for _, key := range sortedKeys(root.Object) {
+				visit(root.Object[key], fmt.Sprintf("%v/%v", path, key))
+			}
+		case root.Builtin != nil:
+			visit(root.Builtin.Arg, fmt.Sprintf("%v/%v", path, root.Builtin.Name))
+		}
+	}
+
+	for _, key := range sortedKeys(env.Exprs) {
+		visit(env.Exprs[key], key)
+	}
+}

--- a/analysis/describe.go
+++ b/analysis/describe.go
@@ -1,0 +1,109 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"strings"
+
+	"github.com/pulumi/esc"
+)
+
+// Describe returns a Markdown-formatted description of the entity at the indicated position.
+func (a *Analysis) Describe(pos esc.Pos) (string, bool) {
+	// Fetch the expression (if any) at pos.
+	x, where, ok := a.expressionAtPos(pos)
+	if !ok {
+		return "", false
+	}
+
+	// The description we return depends on the type of the expression and where the position lies inside that
+	// expression.
+	//
+	// - If the position is within a builtin (but not within its argument), we return a description of the builtin
+	// - If the position is within a symbol, we return the type of the symbol
+	switch {
+	case x.Builtin != nil:
+		return a.describeBuiltin(x.Builtin)
+	case len(x.Symbol) != 0:
+		return a.describeSymbol(x)
+	}
+
+	// Find the nearest builtin in the traversal. If a builtin is found, return the description of the argument on
+	// the path from the builtin.
+	for i := len(where) - 1; i >= 0; i-- {
+		r := where[i].receiver
+		if r.Builtin != nil {
+			return a.describeArgument(r.Builtin, where[i+1:], x, pos)
+		}
+	}
+
+	return "", false
+}
+
+func (a *Analysis) describeBuiltin(builtin *esc.BuiltinExpr) (string, bool) {
+	switch builtin.Name {
+	case "fn::fromJSON":
+		return "Decodes a value from its JSON representation.", true
+	case "fn::fromBase64":
+		return "Decodes a string from its Base64 representation.", true
+	case "fn::join":
+		return "Concatenates the elements of its second argument to create a single string. The first argument is " +
+			"placed between each element in the result.", true
+	case "fn::open":
+		return "Fetches values from an external source when the environment is opened.", true
+	case "fn::secret":
+		return "Marks a value as secret.", true
+	case "fn::toBase64":
+		return "Encodes a string into its Base64 representation.", true
+	case "fn::toJSON":
+		return "Encodes a value into its JSON representation.", true
+	case "fn::toString":
+		return "Encodes a value into its string representation.", true
+	default:
+		if strings.HasPrefix(builtin.Name, "fn::open::") {
+			return "Fetches values from an external source when the environment is opened.", true
+		}
+		return "", false
+	}
+}
+
+func (a *Analysis) describeSymbol(x *esc.Expr) (string, bool) {
+	if x.Schema.Always {
+		return "any", true
+	}
+	return x.Schema.Type, x.Schema.Type != ""
+}
+
+func (a *Analysis) describeArgument(builtin *esc.BuiltinExpr, path []traverser, x *esc.Expr, pos esc.Pos) (string, bool) {
+	// If the last element is an object expression, extend the path with the key associated with pos.
+	if len(x.Object) != 0 {
+		for k, rng := range x.KeyRanges {
+			if rng.Contains(pos) {
+				path = append(path, newObjectTraverser(*x, k))
+				break
+			}
+		}
+	}
+
+	s := builtin.ArgSchema
+	for _, t := range path {
+		if t.key != "" {
+			s = s.Property(t.key)
+		} else {
+			s = s.Item(t.index)
+		}
+	}
+	return s.Description, s.Description != ""
+}

--- a/analysis/describe_test.go
+++ b/analysis/describe_test.go
@@ -1,0 +1,114 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pulumi/esc"
+	"github.com/pulumi/esc/eval"
+	"github.com/pulumi/esc/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescribe(t *testing.T) {
+	syntax, diags, err := eval.LoadYAMLBytes("def", []byte(def))
+	require.NoError(t, err)
+	require.Empty(t, diags)
+
+	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{})
+	require.Empty(t, diags)
+
+	analysis := New(*env, map[string]*schema.Schema{"test": testProviderSchema})
+
+	expected := map[esc.Pos]string{
+		{Line: 5, Column: 5}:   "Decodes a string from its Base64 representation.",
+		{Line: 5, Column: 21}:  "string",
+		{Line: 7, Column: 5}:   "Decodes a value from its JSON representation.",
+		{Line: 7, Column: 19}:  "string",
+		{Line: 9, Column: 5}:   "Concatenates the elements of its second argument to create a single string. The first argument is placed between each element in the result.",
+		{Line: 9, Column: 22}:  "array",
+		{Line: 11, Column: 5}:  "Fetches values from an external source when the environment is opened.",
+		{Line: 12, Column: 7}:  "The URL of the Vault server. Must contain a scheme and hostname, but no path.",
+		{Line: 12, Column: 16}: "The URL of the Vault server. Must contain a scheme and hostname, but no path.",
+		{Line: 13, Column: 7}:  "Options for JWT login. JWT login uses an OIDC token issued by the Pulumi Cloud to generate an ephemeral token.",
+		{Line: 14, Column: 9}:  "The name of the authentication engine mount.",
+		{Line: 14, Column: 16}: "The name of the authentication engine mount.",
+		{Line: 15, Column: 9}:  "The name of the role to use for login.",
+		{Line: 15, Column: 15}: "The name of the role to use for login.",
+		{Line: 16, Column: 7}:  "Options for token login. Token login creates an ephemeral child token.",
+		{Line: 17, Column: 9}:  "The display name of the ephemeral token. Defaults to 'pulumi'.",
+		{Line: 17, Column: 22}: "The display name of the ephemeral token. Defaults to 'pulumi'.",
+		{Line: 18, Column: 9}:  "The parent token.",
+		{Line: 18, Column: 16}: "The parent token.",
+		{Line: 19, Column: 9}:  "The maximum TTL of the ephemeral token.",
+		{Line: 19, Column: 17}: "The maximum TTL of the ephemeral token.",
+		{Line: 21, Column: 5}:  "Marks a value as secret.",
+		{Line: 24, Column: 5}:  "Encodes a string into its Base64 representation.",
+		{Line: 24, Column: 19}: "string",
+		{Line: 26, Column: 5}:  "Encodes a value into its JSON representation.",
+		{Line: 26, Column: 17}: "any",
+		{Line: 28, Column: 5}:  "Encodes a value into its string representation.",
+		{Line: 28, Column: 19}: "any",
+		{Line: 30, Column: 5}:  "Fetches values from an external source when the environment is opened.",
+		{Line: 30, Column: 21}: "any",
+		{Line: 32, Column: 11}: "any",
+	}
+
+	check := func(pos esc.Pos) {
+		pos.Byte = 0
+		t.Run(fmt.Sprintf("%v:%v", pos.Line, pos.Column), func(t *testing.T) {
+			expectedDescription, expectedOK := expected[pos]
+			actualDescription, actualOK := analysis.Describe(pos)
+			require.Equal(t, expectedOK, actualOK)
+			assert.Equal(t, expectedDescription, actualDescription)
+		})
+	}
+
+	visitExprs(env, func(path string, x esc.Expr) {
+		check(x.Range.Begin)
+		for _, rng := range x.KeyRanges {
+			check(rng.Begin)
+		}
+		if x.Builtin != nil {
+			check(x.Builtin.NameRange.Begin)
+		}
+	})
+
+	t.Run("none", func(t *testing.T) {
+		actual, ok := analysis.Describe(esc.Pos{})
+		require.False(t, ok)
+		assert.Equal(t, "", actual)
+	})
+}
+
+func TestDescribeOpen(t *testing.T) {
+	syntax, diags, err := eval.LoadYAMLBytes("def", []byte(`{"values": {"open": {"fn::open": {"provider": "test", "inputs": {"address": "foo"}}}}}`))
+	require.NoError(t, err)
+	require.Empty(t, diags)
+
+	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{})
+	require.Empty(t, diags)
+
+	analysis := New(*env, map[string]*schema.Schema{"test": testProviderSchema})
+
+	expected := "Fetches values from an external source when the environment is opened."
+	actual, ok := analysis.Describe(esc.Pos{Line: 1, Column: 23})
+	require.True(t, ok)
+	assert.Equal(t, expected, actual)
+}

--- a/analysis/traversal.go
+++ b/analysis/traversal.go
@@ -1,0 +1,85 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import "github.com/pulumi/esc"
+
+// A traverser represents part of a path through a document.
+type traverser struct {
+	receiver esc.Expr
+	index    int
+	key      string
+}
+
+func newRootTraverser(key string) traverser {
+	return traverser{key: key}
+}
+
+func newArrayTraverser(receiver esc.Expr, index int) traverser {
+	return traverser{receiver: receiver, index: index}
+}
+
+func newObjectTraverser(receiver esc.Expr, key string) traverser {
+	return traverser{receiver: receiver, key: key}
+}
+
+// ExpressionAtPos returns the expression that contains pos. If no such expression exists, expressionAtPos returns
+// (nil, false). The returned expression is the "smallest" expression that contains pos.
+func (a *Analysis) ExpressionAtPos(pos esc.Pos) (*esc.Expr, bool) {
+	x, _, ok := a.expressionAtPos(pos)
+	return x, ok
+}
+
+// expressionAtPos returns the expression that contains pos. If no such expression exists, expressionAtPos returns
+// (nil, nil, false). The returned expression is the "smallest" expression that contains pos. The path to the given
+// expression is also returned.
+func (a *Analysis) expressionAtPos(pos esc.Pos) (*esc.Expr, []traverser, bool) {
+	for key, x := range a.env.Exprs {
+		if x, where, ok := expressionAtPos(x, []traverser{newRootTraverser(key)}, pos); ok {
+			return x, where, true
+		}
+	}
+	return nil, nil, false
+}
+
+func expressionAtPos(root esc.Expr, where []traverser, pos esc.Pos) (*esc.Expr, []traverser, bool) {
+	if !root.Range.Contains(pos) {
+		return nil, nil, false
+	}
+
+	switch {
+	case len(root.List) != 0:
+		for i, element := range root.List {
+			here := append(where, newArrayTraverser(root, i))
+			if x, where, ok := expressionAtPos(element, here, pos); ok {
+				return x, where, true
+			}
+		}
+	case len(root.Object) != 0:
+		for key, property := range root.Object {
+			here := append(where, newObjectTraverser(root, key))
+			if x, where, ok := expressionAtPos(property, here, pos); ok {
+				return x, where, true
+			}
+		}
+	case root.Builtin != nil:
+		here := append(where, newObjectTraverser(root, root.Builtin.Name))
+		if x, where, ok := expressionAtPos(root.Builtin.Arg, here, pos); ok {
+			return x, where, true
+		}
+	}
+
+	return &root, where, true
+}

--- a/analysis/traversal_test.go
+++ b/analysis/traversal_test.go
@@ -1,0 +1,54 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analysis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/esc"
+	"github.com/pulumi/esc/eval"
+	"github.com/pulumi/esc/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpressionAt(t *testing.T) {
+	syntax, diags, err := eval.LoadYAMLBytes("def", []byte(def))
+	require.NoError(t, err)
+	require.Empty(t, diags)
+
+	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{})
+	require.Empty(t, diags)
+
+	analysis := New(*env, map[string]*schema.Schema{"test": testProviderSchema})
+
+	visitExprs(env, func(path string, x esc.Expr) {
+		t.Run(path, func(t *testing.T) {
+			pos := x.Range.Begin
+			pos.Byte = 0
+
+			actual, ok := analysis.ExpressionAtPos(pos)
+			require.True(t, ok)
+			assert.Equal(t, x, *actual)
+		})
+	})
+
+	t.Run("none", func(t *testing.T) {
+		actual, ok := analysis.ExpressionAtPos(esc.Pos{})
+		require.False(t, ok)
+		assert.Nil(t, actual)
+	})
+}

--- a/eval/testdata/eval/builtin-combine/expected.json
+++ b/eval/testdata/eval/builtin-combine/expected.json
@@ -53,6 +53,19 @@
                         },
                         "builtin": {
                             "name": "fn::join",
+                            "nameRange": {
+                                "environment": "builtin-combine",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 9,
+                                    "byte": 107
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 17,
+                                    "byte": 115
+                                }
+                            },
                             "argSchema": {
                                 "prefixItems": [
                                     {
@@ -70,15 +83,16 @@
                             },
                             "arg": {
                                 "range": {
+                                    "environment": "builtin-combine",
                                     "begin": {
-                                        "line": 0,
-                                        "column": 0,
-                                        "byte": 0
+                                        "line": 7,
+                                        "column": 19,
+                                        "byte": 117
                                     },
                                     "end": {
-                                        "line": 0,
-                                        "column": 0,
-                                        "byte": 0
+                                        "line": 7,
+                                        "column": 53,
+                                        "byte": 151
                                     }
                                 },
                                 "list": [
@@ -246,6 +260,19 @@
                         },
                         "builtin": {
                             "name": "fn::toBase64",
+                            "nameRange": {
+                                "environment": "builtin-combine",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 9,
+                                    "byte": 168
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 21,
+                                    "byte": 180
+                                }
+                            },
                             "argSchema": {
                                 "type": "string"
                             },
@@ -347,6 +374,19 @@
                         },
                         "builtin": {
                             "name": "fn::toJSON",
+                            "nameRange": {
+                                "environment": "builtin-combine",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 9,
+                                    "byte": 218
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 19,
+                                    "byte": 228
+                                }
+                            },
                             "argSchema": true,
                             "arg": {
                                 "range": {
@@ -446,6 +486,19 @@
                         },
                         "builtin": {
                             "name": "fn::toString",
+                            "nameRange": {
+                                "environment": "builtin-combine",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 9,
+                                    "byte": 266
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 21,
+                                    "byte": 278
+                                }
+                            },
                             "argSchema": true,
                             "arg": {
                                 "range": {
@@ -556,6 +609,19 @@
                 },
                 "builtin": {
                     "name": "fn::open::test",
+                    "nameRange": {
+                        "environment": "builtin-combine",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 19,
+                            "byte": 34
+                        }
+                    },
                     "argSchema": true,
                     "arg": {
                         "range": {
@@ -582,6 +648,21 @@
                             "required": [
                                 "foo"
                             ]
+                        },
+                        "keyRanges": {
+                            "foo": {
+                                "environment": "builtin-combine",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 7,
+                                    "byte": 42
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 10,
+                                    "byte": 45
+                                }
+                            }
                         },
                         "object": {
                             "foo": {
@@ -628,6 +709,19 @@
                 },
                 "builtin": {
                     "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "builtin-combine",
+                        "begin": {
+                            "line": 5,
+                            "column": 15,
+                            "byte": 65
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 25,
+                            "byte": 75
+                        }
+                    },
                     "argSchema": true,
                     "arg": {
                         "range": {

--- a/eval/testdata/eval/builtin-errs/expected.json
+++ b/eval/testdata/eval/builtin-errs/expected.json
@@ -384,6 +384,19 @@
                         "schema": true,
                         "builtin": {
                             "name": "fn::open::test",
+                            "nameRange": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 9,
+                                    "byte": 41
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 23,
+                                    "byte": 55
+                                }
+                            },
                             "argSchema": true,
                             "arg": {
                                 "range": {
@@ -440,6 +453,19 @@
                         },
                         "builtin": {
                             "name": "fn::join",
+                            "nameRange": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 9,
+                                    "byte": 80
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 17,
+                                    "byte": 88
+                                }
+                            },
                             "argSchema": {
                                 "prefixItems": [
                                     {
@@ -457,15 +483,16 @@
                             },
                             "arg": {
                                 "range": {
+                                    "environment": "builtin-errs",
                                     "begin": {
-                                        "line": 0,
-                                        "column": 0,
-                                        "byte": 0
+                                        "line": 5,
+                                        "column": 19,
+                                        "byte": 90
                                     },
                                     "end": {
-                                        "line": 0,
-                                        "column": 0,
-                                        "byte": 0
+                                        "line": 5,
+                                        "column": 35,
+                                        "byte": 106
                                     }
                                 },
                                 "list": [
@@ -546,6 +573,19 @@
                         },
                         "builtin": {
                             "name": "fn::join",
+                            "nameRange": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 9,
+                                    "byte": 121
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 17,
+                                    "byte": 129
+                                }
+                            },
                             "argSchema": {
                                 "prefixItems": [
                                     {
@@ -563,15 +603,16 @@
                             },
                             "arg": {
                                 "range": {
+                                    "environment": "builtin-errs",
                                     "begin": {
-                                        "line": 0,
-                                        "column": 0,
-                                        "byte": 0
+                                        "line": 6,
+                                        "column": 19,
+                                        "byte": 131
                                     },
                                     "end": {
-                                        "line": 0,
-                                        "column": 0,
-                                        "byte": 0
+                                        "line": 6,
+                                        "column": 36,
+                                        "byte": 148
                                     }
                                 },
                                 "list": [
@@ -682,6 +723,19 @@
                         },
                         "builtin": {
                             "name": "fn::toBase64",
+                            "nameRange": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 9,
+                                    "byte": 165
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 21,
+                                    "byte": 177
+                                }
+                            },
                             "argSchema": {
                                 "type": "string"
                             },
@@ -740,6 +794,19 @@
                         },
                         "builtin": {
                             "name": "fn::toBase64",
+                            "nameRange": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 9,
+                                    "byte": 202
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 21,
+                                    "byte": 214
+                                }
+                            },
                             "argSchema": {
                                 "type": "string"
                             },
@@ -801,6 +868,19 @@
                         },
                         "builtin": {
                             "name": "fn::toJSON",
+                            "nameRange": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 9,
+                                    "byte": 238
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 19,
+                                    "byte": 248
+                                }
+                            },
                             "argSchema": true,
                             "arg": {
                                 "range": {
@@ -857,6 +937,19 @@
                         },
                         "builtin": {
                             "name": "fn::toString",
+                            "nameRange": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 9,
+                                    "byte": 273
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 21,
+                                    "byte": 285
+                                }
+                            },
                             "argSchema": true,
                             "arg": {
                                 "range": {

--- a/eval/testdata/eval/cycle/expected.json
+++ b/eval/testdata/eval/cycle/expected.json
@@ -120,6 +120,21 @@
                         "p"
                     ]
                 },
+                "keyRanges": {
+                    "p": {
+                        "environment": "cycle",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 17
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 6,
+                            "byte": 18
+                        }
+                    }
+                },
                 "object": {
                     "p": {
                         "range": {
@@ -196,6 +211,21 @@
                         "p"
                     ]
                 },
+                "keyRanges": {
+                    "p": {
+                        "environment": "cycle",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 36
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 6,
+                            "byte": 37
+                        }
+                    }
+                },
                 "object": {
                     "p": {
                         "range": {
@@ -271,6 +301,21 @@
                     "required": [
                         "p"
                     ]
+                },
+                "keyRanges": {
+                    "p": {
+                        "environment": "cycle",
+                        "begin": {
+                            "line": 7,
+                            "column": 5,
+                            "byte": 55
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 6,
+                            "byte": 56
+                        }
+                    }
                 },
                 "object": {
                     "p": {

--- a/eval/testdata/eval/duplicate-keys/expected.json
+++ b/eval/testdata/eval/duplicate-keys/expected.json
@@ -143,6 +143,21 @@
                         "foo"
                     ]
                 },
+                "keyRanges": {
+                    "foo": {
+                        "environment": "duplicate-keys",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 54
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 8,
+                            "byte": 57
+                        }
+                    }
+                },
                 "object": {
                     "foo": {
                         "range": {

--- a/eval/testdata/eval/escape-keys/expected.json
+++ b/eval/testdata/eval/escape-keys/expected.json
@@ -37,6 +37,47 @@
                         "with-hyphen"
                     ]
                 },
+                "keyRanges": {
+                    "\"quoted\"": {
+                        "environment": "escape-keys",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 66
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 13,
+                            "byte": 74
+                        }
+                    },
+                    "0leadingDigit": {
+                        "environment": "escape-keys",
+                        "begin": {
+                            "line": 4,
+                            "column": 5,
+                            "byte": 43
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 18,
+                            "byte": 56
+                        }
+                    },
+                    "with-hyphen": {
+                        "environment": "escape-keys",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 22
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 16,
+                            "byte": 33
+                        }
+                    }
+                },
                 "object": {
                     "\"quoted\"": {
                         "range": {

--- a/eval/testdata/eval/imports/expected.json
+++ b/eval/testdata/eval/imports/expected.json
@@ -230,6 +230,47 @@
                             "foo"
                         ]
                     },
+                    "keyRanges": {
+                        "alpha": {
+                            "environment": "b",
+                            "begin": {
+                                "line": 9,
+                                "column": 5,
+                                "byte": 89
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 10,
+                                "byte": 94
+                            }
+                        },
+                        "baz": {
+                            "environment": "b",
+                            "begin": {
+                                "line": 8,
+                                "column": 5,
+                                "byte": 76
+                            },
+                            "end": {
+                                "line": 8,
+                                "column": 8,
+                                "byte": 79
+                            }
+                        },
+                        "foo": {
+                            "environment": "b",
+                            "begin": {
+                                "line": 7,
+                                "column": 5,
+                                "byte": 63
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 8,
+                                "byte": 66
+                            }
+                        }
+                    },
                     "object": {
                         "alpha": {
                             "range": {
@@ -290,6 +331,73 @@
                                 "const": "bar"
                             },
                             "literal": "bar"
+                        }
+                    }
+                },
+                "keyRanges": {
+                    "alpha": {
+                        "environment": "imports",
+                        "begin": {
+                            "line": 13,
+                            "column": 5,
+                            "byte": 168
+                        },
+                        "end": {
+                            "line": 13,
+                            "column": 10,
+                            "byte": 173
+                        }
+                    },
+                    "beta": {
+                        "environment": "imports",
+                        "begin": {
+                            "line": 14,
+                            "column": 5,
+                            "byte": 184
+                        },
+                        "end": {
+                            "line": 14,
+                            "column": 9,
+                            "byte": 188
+                        }
+                    },
+                    "goodbye": {
+                        "environment": "imports",
+                        "begin": {
+                            "line": 12,
+                            "column": 5,
+                            "byte": 147
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 12,
+                            "byte": 154
+                        }
+                    },
+                    "hello": {
+                        "environment": "imports",
+                        "begin": {
+                            "line": 11,
+                            "column": 5,
+                            "byte": 130
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 10,
+                            "byte": 135
+                        }
+                    },
+                    "zed": {
+                        "environment": "imports",
+                        "begin": {
+                            "line": 15,
+                            "column": 5,
+                            "byte": 211
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 8,
+                            "byte": 214
                         }
                     }
                 },

--- a/eval/testdata/eval/interp/expected.json
+++ b/eval/testdata/eval/interp/expected.json
@@ -56,6 +56,60 @@
                         "t"
                     ]
                 },
+                "keyRanges": {
+                    "p": {
+                        "environment": "interp",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 17
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 6,
+                            "byte": 18
+                        }
+                    },
+                    "q": {
+                        "environment": "interp",
+                        "begin": {
+                            "line": 4,
+                            "column": 5,
+                            "byte": 31
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 6,
+                            "byte": 32
+                        }
+                    },
+                    "s": {
+                        "environment": "interp",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 42
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 6,
+                            "byte": 43
+                        }
+                    },
+                    "t": {
+                        "environment": "interp",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 75
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 6,
+                            "byte": 76
+                        }
+                    }
+                },
                 "object": {
                     "p": {
                         "range": {
@@ -156,6 +210,19 @@
                         },
                         "builtin": {
                             "name": "fn::secret",
+                            "nameRange": {
+                                "environment": "interp",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 10,
+                                    "byte": 47
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 20,
+                                    "byte": 57
+                                }
+                            },
                             "argSchema": true,
                             "arg": {
                                 "range": {
@@ -234,6 +301,19 @@
                         },
                         "builtin": {
                             "name": "fn::secret",
+                            "nameRange": {
+                                "environment": "interp",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 10,
+                                    "byte": 80
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 20,
+                                    "byte": 90
+                                }
+                            },
                             "argSchema": true,
                             "arg": {
                                 "range": {
@@ -260,6 +340,21 @@
                                     "required": [
                                         "password"
                                     ]
+                                },
+                                "keyRanges": {
+                                    "password": {
+                                        "environment": "interp",
+                                        "begin": {
+                                            "line": 6,
+                                            "column": 24,
+                                            "byte": 94
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 32,
+                                            "byte": 102
+                                        }
+                                    }
                                 },
                                 "object": {
                                     "password": {
@@ -313,6 +408,21 @@
                     "required": [
                         "p"
                     ]
+                },
+                "keyRanges": {
+                    "p": {
+                        "environment": "interp",
+                        "begin": {
+                            "line": 8,
+                            "column": 5,
+                            "byte": 125
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 6,
+                            "byte": 126
+                        }
+                    }
                 },
                 "object": {
                     "p": {
@@ -427,6 +537,47 @@
                         "b",
                         "s"
                     ]
+                },
+                "keyRanges": {
+                    "a": {
+                        "environment": "interp",
+                        "begin": {
+                            "line": 10,
+                            "column": 5,
+                            "byte": 144
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 6,
+                            "byte": 145
+                        }
+                    },
+                    "b": {
+                        "environment": "interp",
+                        "begin": {
+                            "line": 14,
+                            "column": 5,
+                            "byte": 210
+                        },
+                        "end": {
+                            "line": 14,
+                            "column": 6,
+                            "byte": 211
+                        }
+                    },
+                    "s": {
+                        "environment": "interp",
+                        "begin": {
+                            "line": 15,
+                            "column": 5,
+                            "byte": 224
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 6,
+                            "byte": 225
+                        }
+                    }
                 },
                 "object": {
                     "a": {

--- a/eval/testdata/eval/invalid-access/expected.json
+++ b/eval/testdata/eval/invalid-access/expected.json
@@ -1474,6 +1474,21 @@
                         "foo"
                     ]
                 },
+                "keyRanges": {
+                    "foo": {
+                        "environment": "invalid-access",
+                        "begin": {
+                            "line": 10,
+                            "column": 5,
+                            "byte": 105
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 8,
+                            "byte": 108
+                        }
+                    }
+                },
                 "object": {
                     "foo": {
                         "range": {
@@ -1554,6 +1569,21 @@
                             "baz"
                         ]
                     },
+                    "keyRanges": {
+                        "baz": {
+                            "environment": "a",
+                            "begin": {
+                                "line": 3,
+                                "column": 5,
+                                "byte": 22
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 8,
+                                "byte": 25
+                            }
+                        }
+                    },
                     "object": {
                         "baz": {
                             "range": {
@@ -1574,6 +1604,21 @@
                                 "const": "qux"
                             },
                             "literal": "qux"
+                        }
+                    }
+                },
+                "keyRanges": {
+                    "hello": {
+                        "environment": "invalid-access",
+                        "begin": {
+                            "line": 8,
+                            "column": 5,
+                            "byte": 76
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 10,
+                            "byte": 81
                         }
                     }
                 },
@@ -1768,6 +1813,19 @@
                 },
                 "builtin": {
                     "name": "fn::open::schema",
+                    "nameRange": {
+                        "environment": "invalid-access",
+                        "begin": {
+                            "line": 12,
+                            "column": 5,
+                            "byte": 126
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 21,
+                            "byte": 142
+                        }
+                    },
                     "argSchema": {
                         "$defs": {
                             "defRecord": {
@@ -2153,6 +2211,203 @@
                                 "tuple"
                             ]
                         },
+                        "keyRanges": {
+                            "anyOf": {
+                                "environment": "invalid-access",
+                                "begin": {
+                                    "line": 25,
+                                    "column": 7,
+                                    "byte": 448
+                                },
+                                "end": {
+                                    "line": 25,
+                                    "column": 12,
+                                    "byte": 453
+                                }
+                            },
+                            "array": {
+                                "environment": "invalid-access",
+                                "begin": {
+                                    "line": 21,
+                                    "column": 7,
+                                    "byte": 298
+                                },
+                                "end": {
+                                    "line": 21,
+                                    "column": 12,
+                                    "byte": 303
+                                }
+                            },
+                            "boolean": {
+                                "environment": "invalid-access",
+                                "begin": {
+                                    "line": 14,
+                                    "column": 7,
+                                    "byte": 169
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "column": 14,
+                                    "byte": 176
+                                }
+                            },
+                            "false": {
+                                "environment": "invalid-access",
+                                "begin": {
+                                    "line": 15,
+                                    "column": 7,
+                                    "byte": 189
+                                },
+                                "end": {
+                                    "line": 15,
+                                    "column": 12,
+                                    "byte": 194
+                                }
+                            },
+                            "hello": {
+                                "environment": "invalid-access",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 7,
+                                    "byte": 279
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 12,
+                                    "byte": 284
+                                }
+                            },
+                            "map": {
+                                "environment": "invalid-access",
+                                "begin": {
+                                    "line": 23,
+                                    "column": 7,
+                                    "byte": 383
+                                },
+                                "end": {
+                                    "line": 23,
+                                    "column": 10,
+                                    "byte": 386
+                                }
+                            },
+                            "null": {
+                                "environment": "invalid-access",
+                                "begin": {
+                                    "line": 13,
+                                    "column": 7,
+                                    "byte": 150
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 11,
+                                    "byte": 154
+                                }
+                            },
+                            "number": {
+                                "environment": "invalid-access",
+                                "begin": {
+                                    "line": 17,
+                                    "column": 7,
+                                    "byte": 229
+                                },
+                                "end": {
+                                    "line": 17,
+                                    "column": 13,
+                                    "byte": 235
+                                }
+                            },
+                            "oneOf": {
+                                "environment": "invalid-access",
+                                "begin": {
+                                    "line": 26,
+                                    "column": 7,
+                                    "byte": 467
+                                },
+                                "end": {
+                                    "line": 26,
+                                    "column": 12,
+                                    "byte": 472
+                                }
+                            },
+                            "pi": {
+                                "environment": "invalid-access",
+                                "begin": {
+                                    "line": 18,
+                                    "column": 7,
+                                    "byte": 246
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 9,
+                                    "byte": 248
+                                }
+                            },
+                            "record": {
+                                "environment": "invalid-access",
+                                "begin": {
+                                    "line": 24,
+                                    "column": 7,
+                                    "byte": 421
+                                },
+                                "end": {
+                                    "line": 24,
+                                    "column": 13,
+                                    "byte": 427
+                                }
+                            },
+                            "ref": {
+                                "environment": "invalid-access",
+                                "begin": {
+                                    "line": 27,
+                                    "column": 7,
+                                    "byte": 483
+                                },
+                                "end": {
+                                    "line": 27,
+                                    "column": 10,
+                                    "byte": 486
+                                }
+                            },
+                            "string": {
+                                "environment": "invalid-access",
+                                "begin": {
+                                    "line": 19,
+                                    "column": 7,
+                                    "byte": 261
+                                },
+                                "end": {
+                                    "line": 19,
+                                    "column": 13,
+                                    "byte": 267
+                                }
+                            },
+                            "true": {
+                                "environment": "invalid-access",
+                                "begin": {
+                                    "line": 16,
+                                    "column": 7,
+                                    "byte": 210
+                                },
+                                "end": {
+                                    "line": 16,
+                                    "column": 11,
+                                    "byte": 214
+                                }
+                            },
+                            "tuple": {
+                                "environment": "invalid-access",
+                                "begin": {
+                                    "line": 22,
+                                    "column": 7,
+                                    "byte": 353
+                                },
+                                "end": {
+                                    "line": 22,
+                                    "column": 12,
+                                    "byte": 358
+                                }
+                            }
+                        },
                         "object": {
                             "anyOf": {
                                 "range": {
@@ -2290,6 +2545,21 @@
                                             "required": [
                                                 "some"
                                             ]
+                                        },
+                                        "keyRanges": {
+                                            "some": {
+                                                "environment": "invalid-access",
+                                                "begin": {
+                                                    "line": 21,
+                                                    "column": 28,
+                                                    "byte": 319
+                                                },
+                                                "end": {
+                                                    "line": 21,
+                                                    "column": 32,
+                                                    "byte": 323
+                                                }
+                                            }
                                         },
                                         "object": {
                                             "some": {
@@ -2454,6 +2724,34 @@
                                         "hello"
                                     ]
                                 },
+                                "keyRanges": {
+                                    "blue": {
+                                        "environment": "invalid-access",
+                                        "begin": {
+                                            "line": 23,
+                                            "column": 28,
+                                            "byte": 404
+                                        },
+                                        "end": {
+                                            "line": 23,
+                                            "column": 32,
+                                            "byte": 408
+                                        }
+                                    },
+                                    "hello": {
+                                        "environment": "invalid-access",
+                                        "begin": {
+                                            "line": 23,
+                                            "column": 14,
+                                            "byte": 390
+                                        },
+                                        "end": {
+                                            "line": 23,
+                                            "column": 19,
+                                            "byte": 395
+                                        }
+                                    }
+                                },
                                 "object": {
                                     "blue": {
                                         "range": {
@@ -2601,6 +2899,21 @@
                                         "foo"
                                     ]
                                 },
+                                "keyRanges": {
+                                    "foo": {
+                                        "environment": "invalid-access",
+                                        "begin": {
+                                            "line": 24,
+                                            "column": 17,
+                                            "byte": 431
+                                        },
+                                        "end": {
+                                            "line": 24,
+                                            "column": 20,
+                                            "byte": 434
+                                        }
+                                    }
+                                },
                                 "object": {
                                     "foo": {
                                         "range": {
@@ -2649,6 +2962,21 @@
                                     "required": [
                                         "baz"
                                     ]
+                                },
+                                "keyRanges": {
+                                    "baz": {
+                                        "environment": "invalid-access",
+                                        "begin": {
+                                            "line": 27,
+                                            "column": 14,
+                                            "byte": 490
+                                        },
+                                        "end": {
+                                            "line": 27,
+                                            "column": 17,
+                                            "byte": 493
+                                        }
+                                    }
                                 },
                                 "object": {
                                     "baz": {

--- a/eval/testdata/eval/literals/expected.json
+++ b/eval/testdata/eval/literals/expected.json
@@ -161,6 +161,34 @@
                         "hello"
                     ]
                 },
+                "keyRanges": {
+                    "goodbye": {
+                        "environment": "literals",
+                        "begin": {
+                            "line": 11,
+                            "column": 5,
+                            "byte": 156
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 12,
+                            "byte": 163
+                        }
+                    },
+                    "hello": {
+                        "environment": "literals",
+                        "begin": {
+                            "line": 10,
+                            "column": 5,
+                            "byte": 139
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 10,
+                            "byte": 144
+                        }
+                    }
+                },
                 "object": {
                     "goodbye": {
                         "range": {

--- a/eval/testdata/eval/merge-replace/expected.json
+++ b/eval/testdata/eval/merge-replace/expected.json
@@ -47,6 +47,21 @@
                     },
                     "literal": "bar"
                 },
+                "keyRanges": {
+                    "bar": {
+                        "environment": "merge-replace",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 34
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 8,
+                            "byte": 37
+                        }
+                    }
+                },
                 "object": {
                     "bar": {
                         "range": {

--- a/eval/testdata/eval/merge-unknown/expected.json
+++ b/eval/testdata/eval/merge-unknown/expected.json
@@ -68,6 +68,19 @@
                     },
                     "builtin": {
                         "name": "fn::open::test",
+                        "nameRange": {
+                            "environment": "a",
+                            "begin": {
+                                "line": 3,
+                                "column": 5,
+                                "byte": 20
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 19,
+                                "byte": 34
+                            }
+                        },
                         "argSchema": true,
                         "arg": {
                             "range": {
@@ -95,6 +108,21 @@
                                     "baz"
                                 ]
                             },
+                            "keyRanges": {
+                                "baz": {
+                                    "environment": "a",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 7,
+                                        "byte": 42
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 10,
+                                        "byte": 45
+                                    }
+                                }
+                            },
                             "object": {
                                 "baz": {
                                     "range": {
@@ -117,6 +145,34 @@
                                     "literal": "qux"
                                 }
                             }
+                        }
+                    }
+                },
+                "keyRanges": {
+                    "baz": {
+                        "environment": "merge-unknown",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 48
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 8,
+                            "byte": 51
+                        }
+                    },
+                    "foo": {
+                        "environment": "merge-unknown",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 35
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 8,
+                            "byte": 38
                         }
                     }
                 },
@@ -175,6 +231,19 @@
                             },
                             "builtin": {
                                 "name": "fn::open::test",
+                                "nameRange": {
+                                    "environment": "a",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 5,
+                                        "byte": 20
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 19,
+                                        "byte": 34
+                                    }
+                                },
                                 "argSchema": true,
                                 "arg": {
                                     "range": {
@@ -202,6 +271,21 @@
                                             "baz"
                                         ]
                                     },
+                                    "keyRanges": {
+                                        "baz": {
+                                            "environment": "a",
+                                            "begin": {
+                                                "line": 4,
+                                                "column": 7,
+                                                "byte": 42
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 10,
+                                                "byte": 45
+                                            }
+                                        }
+                                    },
                                     "object": {
                                         "baz": {
                                             "range": {
@@ -224,6 +308,21 @@
                                             "literal": "qux"
                                         }
                                     }
+                                }
+                            }
+                        },
+                        "keyRanges": {
+                            "qux": {
+                                "environment": "merge-unknown",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 7,
+                                    "byte": 59
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 10,
+                                    "byte": 62
                                 }
                             }
                         },

--- a/eval/testdata/eval/omnibus/expected.json
+++ b/eval/testdata/eval/omnibus/expected.json
@@ -73,6 +73,19 @@
                 },
                 "builtin": {
                     "name": "fn::fromBase64",
+                    "nameRange": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 41
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 19,
+                            "byte": 55
+                        }
+                    },
                     "argSchema": {
                         "type": "string"
                     },
@@ -172,6 +185,19 @@
                 },
                 "builtin": {
                     "name": "fn::fromJSON",
+                    "nameRange": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 7,
+                            "column": 5,
+                            "byte": 85
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 17,
+                            "byte": 97
+                        }
+                    },
                     "argSchema": true,
                     "arg": {
                         "range": {
@@ -271,6 +297,19 @@
                 },
                 "builtin": {
                     "name": "fn::join",
+                    "nameRange": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 9,
+                            "column": 5,
+                            "byte": 121
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 13,
+                            "byte": 129
+                        }
+                    },
                     "argSchema": {
                         "prefixItems": [
                             {
@@ -288,15 +327,16 @@
                     },
                     "arg": {
                         "range": {
+                            "environment": "omnibus",
                             "begin": {
-                                "line": 0,
-                                "column": 0,
-                                "byte": 0
+                                "line": 9,
+                                "column": 15,
+                                "byte": 131
                             },
                             "end": {
-                                "line": 0,
-                                "column": 0,
-                                "byte": 0
+                                "line": 9,
+                                "column": 32,
+                                "byte": 148
                             }
                         },
                         "list": [
@@ -453,6 +493,21 @@
                             "foo"
                         ]
                     },
+                    "keyRanges": {
+                        "foo": {
+                            "environment": "a",
+                            "begin": {
+                                "line": 3,
+                                "column": 5,
+                                "byte": 20
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 8,
+                                "byte": 23
+                            }
+                        }
+                    },
                     "object": {
                         "foo": {
                             "range": {
@@ -478,6 +533,19 @@
                 },
                 "builtin": {
                     "name": "fn::open::test",
+                    "nameRange": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 11,
+                            "column": 5,
+                            "byte": 165
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 19,
+                            "byte": 179
+                        }
+                    },
                     "argSchema": true,
                     "arg": {
                         "range": {
@@ -529,6 +597,73 @@
                                 "c",
                                 "d"
                             ]
+                        },
+                        "keyRanges": {
+                            "a": {
+                                "environment": "omnibus",
+                                "begin": {
+                                    "line": 12,
+                                    "column": 7,
+                                    "byte": 187
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 8,
+                                    "byte": 188
+                                }
+                            },
+                            "b": {
+                                "environment": "omnibus",
+                                "begin": {
+                                    "line": 13,
+                                    "column": 7,
+                                    "byte": 201
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 8,
+                                    "byte": 202
+                                }
+                            },
+                            "baz": {
+                                "environment": "omnibus",
+                                "begin": {
+                                    "line": 16,
+                                    "column": 7,
+                                    "byte": 246
+                                },
+                                "end": {
+                                    "line": 16,
+                                    "column": 10,
+                                    "byte": 249
+                                }
+                            },
+                            "c": {
+                                "environment": "omnibus",
+                                "begin": {
+                                    "line": 14,
+                                    "column": 7,
+                                    "byte": 215
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "column": 8,
+                                    "byte": 216
+                                }
+                            },
+                            "d": {
+                                "environment": "omnibus",
+                                "begin": {
+                                    "line": 15,
+                                    "column": 7,
+                                    "byte": 227
+                                },
+                                "end": {
+                                    "line": 15,
+                                    "column": 8,
+                                    "byte": 228
+                                }
+                            }
                         },
                         "object": {
                             "a": {
@@ -718,6 +853,19 @@
                 },
                 "builtin": {
                     "name": "fn::open::test",
+                    "nameRange": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 27,
+                            "column": 5,
+                            "byte": 418
+                        },
+                        "end": {
+                            "line": 27,
+                            "column": 19,
+                            "byte": 432
+                        }
+                    },
                     "argSchema": true,
                     "arg": {
                         "range": {
@@ -816,6 +964,19 @@
                 },
                 "builtin": {
                     "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 18,
+                            "column": 5,
+                            "byte": 269
+                        },
+                        "end": {
+                            "line": 18,
+                            "column": 15,
+                            "byte": 279
+                        }
+                    },
                     "argSchema": true,
                     "arg": {
                         "range": {
@@ -858,6 +1019,19 @@
                 },
                 "builtin": {
                     "name": "fn::toBase64",
+                    "nameRange": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 21,
+                            "column": 5,
+                            "byte": 311
+                        },
+                        "end": {
+                            "line": 21,
+                            "column": 17,
+                            "byte": 323
+                        }
+                    },
                     "argSchema": {
                         "type": "string"
                     },
@@ -918,6 +1092,19 @@
                 },
                 "builtin": {
                     "name": "fn::toJSON",
+                    "nameRange": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 23,
+                            "column": 5,
+                            "byte": 347
+                        },
+                        "end": {
+                            "line": 23,
+                            "column": 15,
+                            "byte": 357
+                        }
+                    },
                     "argSchema": true,
                     "arg": {
                         "range": {
@@ -1015,6 +1202,19 @@
                 },
                 "builtin": {
                     "name": "fn::toString",
+                    "nameRange": {
+                        "environment": "omnibus",
+                        "begin": {
+                            "line": 25,
+                            "column": 5,
+                            "byte": 383
+                        },
+                        "end": {
+                            "line": 25,
+                            "column": 17,
+                            "byte": 395
+                        }
+                    },
                     "argSchema": true,
                     "arg": {
                         "range": {

--- a/eval/testdata/eval/open-unknown/expected.json
+++ b/eval/testdata/eval/open-unknown/expected.json
@@ -43,6 +43,19 @@
                 "schema": true,
                 "builtin": {
                     "name": "fn::open::error",
+                    "nameRange": {
+                        "environment": "open-unknown",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 74
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 20,
+                            "byte": 89
+                        }
+                    },
                     "argSchema": {
                         "properties": {
                             "why": {
@@ -76,6 +89,21 @@
                             "required": [
                                 "why"
                             ]
+                        },
+                        "keyRanges": {
+                            "why": {
+                                "environment": "open-unknown",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 7,
+                                    "byte": 97
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 10,
+                                    "byte": 100
+                                }
+                            }
                         },
                         "object": {
                             "why": {
@@ -133,6 +161,19 @@
                 "schema": true,
                 "builtin": {
                     "name": "fn::open::error",
+                    "nameRange": {
+                        "environment": "open-unknown",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 21
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 20,
+                            "byte": 36
+                        }
+                    },
                     "argSchema": {
                         "properties": {
                             "why": {
@@ -169,6 +210,21 @@
                             "required": [
                                 "why"
                             ]
+                        },
+                        "keyRanges": {
+                            "why": {
+                                "environment": "open-unknown",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 7,
+                                    "byte": 44
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 10,
+                                    "byte": 47
+                                }
+                            }
                         },
                         "object": {
                             "why": {

--- a/eval/testdata/eval/open/expected.json
+++ b/eval/testdata/eval/open/expected.json
@@ -83,6 +83,60 @@
                         "test"
                     ]
                 },
+                "keyRanges": {
+                    "foo": {
+                        "environment": "open",
+                        "begin": {
+                            "line": 15,
+                            "column": 5,
+                            "byte": 215
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 8,
+                            "byte": 218
+                        }
+                    },
+                    "list": {
+                        "environment": "open",
+                        "begin": {
+                            "line": 16,
+                            "column": 5,
+                            "byte": 236
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 9,
+                            "byte": 240
+                        }
+                    },
+                    "object": {
+                        "environment": "open",
+                        "begin": {
+                            "line": 17,
+                            "column": 5,
+                            "byte": 262
+                        },
+                        "end": {
+                            "line": 17,
+                            "column": 11,
+                            "byte": 268
+                        }
+                    },
+                    "test": {
+                        "environment": "open",
+                        "begin": {
+                            "line": 14,
+                            "column": 5,
+                            "byte": 197
+                        },
+                        "end": {
+                            "line": 14,
+                            "column": 9,
+                            "byte": 201
+                        }
+                    }
+                },
                 "object": {
                     "foo": {
                         "range": {
@@ -416,6 +470,19 @@
                 },
                 "builtin": {
                     "name": "fn::open",
+                    "nameRange": {
+                        "environment": "open",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 13,
+                            "byte": 28
+                        }
+                    },
                     "argSchema": {
                         "properties": {
                             "inputs": true,
@@ -501,6 +568,60 @@
                                         "list",
                                         "object"
                                     ]
+                                },
+                                "keyRanges": {
+                                    "baz": {
+                                        "environment": "open",
+                                        "begin": {
+                                            "line": 7,
+                                            "column": 9,
+                                            "byte": 90
+                                        },
+                                        "end": {
+                                            "line": 7,
+                                            "column": 12,
+                                            "byte": 93
+                                        }
+                                    },
+                                    "foo": {
+                                        "environment": "open",
+                                        "begin": {
+                                            "line": 6,
+                                            "column": 9,
+                                            "byte": 73
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 12,
+                                            "byte": 76
+                                        }
+                                    },
+                                    "list": {
+                                        "environment": "open",
+                                        "begin": {
+                                            "line": 8,
+                                            "column": 9,
+                                            "byte": 107
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 13,
+                                            "byte": 111
+                                        }
+                                    },
+                                    "object": {
+                                        "environment": "open",
+                                        "begin": {
+                                            "line": 11,
+                                            "column": 9,
+                                            "byte": 152
+                                        },
+                                        "end": {
+                                            "line": 11,
+                                            "column": 15,
+                                            "byte": 158
+                                        }
+                                    }
                                 },
                                 "object": {
                                     "baz": {
@@ -639,6 +760,21 @@
                                             "required": [
                                                 "key"
                                             ]
+                                        },
+                                        "keyRanges": {
+                                            "key": {
+                                                "environment": "open",
+                                                "begin": {
+                                                    "line": 12,
+                                                    "column": 11,
+                                                    "byte": 170
+                                                },
+                                                "end": {
+                                                    "line": 12,
+                                                    "column": 14,
+                                                    "byte": 173
+                                                }
+                                            }
                                         },
                                         "object": {
                                             "key": {

--- a/eval/testdata/eval/schema-error/expected.json
+++ b/eval/testdata/eval/schema-error/expected.json
@@ -1160,6 +1160,19 @@
                 },
                 "builtin": {
                     "name": "fn::open::schema",
+                    "nameRange": {
+                        "environment": "schema-error",
+                        "begin": {
+                            "line": 37,
+                            "column": 5,
+                            "byte": 847
+                        },
+                        "end": {
+                            "line": 37,
+                            "column": 21,
+                            "byte": 863
+                        }
+                    },
                     "argSchema": {
                         "$defs": {
                             "defRecord": {
@@ -1625,6 +1638,320 @@
                                 "string",
                                 "triple"
                             ]
+                        },
+                        "keyRanges": {
+                            "anyOf": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 42,
+                                    "column": 7,
+                                    "byte": 993
+                                },
+                                "end": {
+                                    "line": 42,
+                                    "column": 12,
+                                    "byte": 998
+                                }
+                            },
+                            "boolean": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 38,
+                                    "column": 7,
+                                    "byte": 871
+                                },
+                                "end": {
+                                    "line": 38,
+                                    "column": 14,
+                                    "byte": 878
+                                }
+                            },
+                            "const-array": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 44,
+                                    "column": 7,
+                                    "byte": 1051
+                                },
+                                "end": {
+                                    "line": 44,
+                                    "column": 18,
+                                    "byte": 1062
+                                }
+                            },
+                            "const-object": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 45,
+                                    "column": 7,
+                                    "byte": 1087
+                                },
+                                "end": {
+                                    "line": 45,
+                                    "column": 19,
+                                    "byte": 1099
+                                }
+                            },
+                            "dependentReq": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 49,
+                                    "column": 7,
+                                    "byte": 1215
+                                },
+                                "end": {
+                                    "line": 49,
+                                    "column": 19,
+                                    "byte": 1227
+                                }
+                            },
+                            "double": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 47,
+                                    "column": 7,
+                                    "byte": 1153
+                                },
+                                "end": {
+                                    "line": 47,
+                                    "column": 13,
+                                    "byte": 1159
+                                }
+                            },
+                            "enum": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 46,
+                                    "column": 7,
+                                    "byte": 1124
+                                },
+                                "end": {
+                                    "line": 46,
+                                    "column": 11,
+                                    "byte": 1128
+                                }
+                            },
+                            "exclusiveMaximum": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 54,
+                                    "column": 7,
+                                    "byte": 1407
+                                },
+                                "end": {
+                                    "line": 54,
+                                    "column": 23,
+                                    "byte": 1423
+                                }
+                            },
+                            "exclusiveMinimum": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 52,
+                                    "column": 7,
+                                    "byte": 1323
+                                },
+                                "end": {
+                                    "line": 52,
+                                    "column": 23,
+                                    "byte": 1339
+                                }
+                            },
+                            "maxItems": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 59,
+                                    "column": 7,
+                                    "byte": 1568
+                                },
+                                "end": {
+                                    "line": 59,
+                                    "column": 15,
+                                    "byte": 1576
+                                }
+                            },
+                            "maxLength": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 56,
+                                    "column": 7,
+                                    "byte": 1469
+                                },
+                                "end": {
+                                    "line": 56,
+                                    "column": 16,
+                                    "byte": 1478
+                                }
+                            },
+                            "maxProperties": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 61,
+                                    "column": 7,
+                                    "byte": 1639
+                                },
+                                "end": {
+                                    "line": 61,
+                                    "column": 20,
+                                    "byte": 1652
+                                }
+                            },
+                            "maximum": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 53,
+                                    "column": 7,
+                                    "byte": 1365
+                                },
+                                "end": {
+                                    "line": 53,
+                                    "column": 14,
+                                    "byte": 1372
+                                }
+                            },
+                            "minItems": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 58,
+                                    "column": 7,
+                                    "byte": 1535
+                                },
+                                "end": {
+                                    "line": 58,
+                                    "column": 15,
+                                    "byte": 1543
+                                }
+                            },
+                            "minLength": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 55,
+                                    "column": 7,
+                                    "byte": 1449
+                                },
+                                "end": {
+                                    "line": 55,
+                                    "column": 16,
+                                    "byte": 1458
+                                }
+                            },
+                            "minProperties": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 60,
+                                    "column": 7,
+                                    "byte": 1601
+                                },
+                                "end": {
+                                    "line": 60,
+                                    "column": 20,
+                                    "byte": 1614
+                                }
+                            },
+                            "minimum": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 51,
+                                    "column": 7,
+                                    "byte": 1281
+                                },
+                                "end": {
+                                    "line": 51,
+                                    "column": 14,
+                                    "byte": 1288
+                                }
+                            },
+                            "multiple": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 50,
+                                    "column": 7,
+                                    "byte": 1252
+                                },
+                                "end": {
+                                    "line": 50,
+                                    "column": 15,
+                                    "byte": 1260
+                                }
+                            },
+                            "number": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 40,
+                                    "column": 7,
+                                    "byte": 931
+                                },
+                                "end": {
+                                    "line": 40,
+                                    "column": 13,
+                                    "byte": 937
+                                }
+                            },
+                            "oneOf": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 43,
+                                    "column": 7,
+                                    "byte": 1022
+                                },
+                                "end": {
+                                    "line": 43,
+                                    "column": 12,
+                                    "byte": 1027
+                                }
+                            },
+                            "pattern": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 57,
+                                    "column": 7,
+                                    "byte": 1503
+                                },
+                                "end": {
+                                    "line": 57,
+                                    "column": 14,
+                                    "byte": 1510
+                                }
+                            },
+                            "record": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 41,
+                                    "column": 7,
+                                    "byte": 962
+                                },
+                                "end": {
+                                    "line": 41,
+                                    "column": 13,
+                                    "byte": 968
+                                }
+                            },
+                            "string": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 39,
+                                    "column": 7,
+                                    "byte": 901
+                                },
+                                "end": {
+                                    "line": 39,
+                                    "column": 13,
+                                    "byte": 907
+                                }
+                            },
+                            "triple": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 48,
+                                    "column": 7,
+                                    "byte": 1184
+                                },
+                                "end": {
+                                    "line": 48,
+                                    "column": 13,
+                                    "byte": 1190
+                                }
+                            }
                         },
                         "object": {
                             "anyOf": {
@@ -3299,6 +3626,19 @@
                 },
                 "builtin": {
                     "name": "fn::open::schema",
+                    "nameRange": {
+                        "environment": "schema-error",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 22
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 21,
+                            "byte": 38
+                        }
+                    },
                     "argSchema": {
                         "$defs": {
                             "defRecord": {
@@ -3839,6 +4179,424 @@
                                 "tuple"
                             ]
                         },
+                        "keyRanges": {
+                            "always": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 22,
+                                    "column": 7,
+                                    "byte": 489
+                                },
+                                "end": {
+                                    "line": 22,
+                                    "column": 13,
+                                    "byte": 495
+                                }
+                            },
+                            "anyOf": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 16,
+                                    "column": 7,
+                                    "byte": 344
+                                },
+                                "end": {
+                                    "line": 16,
+                                    "column": 12,
+                                    "byte": 349
+                                }
+                            },
+                            "array": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 12,
+                                    "column": 7,
+                                    "byte": 194
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 12,
+                                    "byte": 199
+                                }
+                            },
+                            "boolean": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 7,
+                                    "byte": 65
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 14,
+                                    "byte": 72
+                                }
+                            },
+                            "const-array": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 19,
+                                    "column": 7,
+                                    "byte": 403
+                                },
+                                "end": {
+                                    "line": 19,
+                                    "column": 18,
+                                    "byte": 414
+                                }
+                            },
+                            "const-object": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 7,
+                                    "byte": 436
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 19,
+                                    "byte": 448
+                                }
+                            },
+                            "dependentReq": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 25,
+                                    "column": 7,
+                                    "byte": 568
+                                },
+                                "end": {
+                                    "line": 25,
+                                    "column": 19,
+                                    "byte": 580
+                                }
+                            },
+                            "double": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 23,
+                                    "column": 7,
+                                    "byte": 506
+                                },
+                                "end": {
+                                    "line": 23,
+                                    "column": 13,
+                                    "byte": 512
+                                }
+                            },
+                            "enum": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 21,
+                                    "column": 7,
+                                    "byte": 473
+                                },
+                                "end": {
+                                    "line": 21,
+                                    "column": 11,
+                                    "byte": 477
+                                }
+                            },
+                            "exclusiveMaximum": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 30,
+                                    "column": 7,
+                                    "byte": 688
+                                },
+                                "end": {
+                                    "line": 30,
+                                    "column": 23,
+                                    "byte": 704
+                                }
+                            },
+                            "exclusiveMinimum": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 28,
+                                    "column": 7,
+                                    "byte": 645
+                                },
+                                "end": {
+                                    "line": 28,
+                                    "column": 23,
+                                    "byte": 661
+                                }
+                            },
+                            "false": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 7,
+                                    "byte": 85
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 12,
+                                    "byte": 90
+                                }
+                            },
+                            "hello": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 11,
+                                    "column": 7,
+                                    "byte": 175
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 12,
+                                    "byte": 180
+                                }
+                            },
+                            "map": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 14,
+                                    "column": 7,
+                                    "byte": 279
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "column": 10,
+                                    "byte": 282
+                                }
+                            },
+                            "maxLength": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 32,
+                                    "column": 7,
+                                    "byte": 733
+                                },
+                                "end": {
+                                    "line": 32,
+                                    "column": 16,
+                                    "byte": 742
+                                }
+                            },
+                            "maxProperties": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 35,
+                                    "column": 7,
+                                    "byte": 807
+                                },
+                                "end": {
+                                    "line": 35,
+                                    "column": 20,
+                                    "byte": 820
+                                }
+                            },
+                            "maximum": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 29,
+                                    "column": 7,
+                                    "byte": 671
+                                },
+                                "end": {
+                                    "line": 29,
+                                    "column": 14,
+                                    "byte": 678
+                                }
+                            },
+                            "minLength": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 31,
+                                    "column": 7,
+                                    "byte": 714
+                                },
+                                "end": {
+                                    "line": 31,
+                                    "column": 16,
+                                    "byte": 723
+                                }
+                            },
+                            "minProperties": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 34,
+                                    "column": 7,
+                                    "byte": 773
+                                },
+                                "end": {
+                                    "line": 34,
+                                    "column": 20,
+                                    "byte": 786
+                                }
+                            },
+                            "minimum": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 27,
+                                    "column": 7,
+                                    "byte": 628
+                                },
+                                "end": {
+                                    "line": 27,
+                                    "column": 14,
+                                    "byte": 635
+                                }
+                            },
+                            "multiple": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 26,
+                                    "column": 7,
+                                    "byte": 610
+                                },
+                                "end": {
+                                    "line": 26,
+                                    "column": 15,
+                                    "byte": 618
+                                }
+                            },
+                            "null": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 7,
+                                    "byte": 46
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 11,
+                                    "byte": 50
+                                }
+                            },
+                            "number": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 7,
+                                    "byte": 125
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 13,
+                                    "byte": 131
+                                }
+                            },
+                            "oneOf": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 17,
+                                    "column": 7,
+                                    "byte": 363
+                                },
+                                "end": {
+                                    "line": 17,
+                                    "column": 12,
+                                    "byte": 368
+                                }
+                            },
+                            "pattern": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 33,
+                                    "column": 7,
+                                    "byte": 752
+                                },
+                                "end": {
+                                    "line": 33,
+                                    "column": 14,
+                                    "byte": 759
+                                }
+                            },
+                            "pi": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 7,
+                                    "byte": 142
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 9,
+                                    "byte": 144
+                                }
+                            },
+                            "record": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 15,
+                                    "column": 7,
+                                    "byte": 317
+                                },
+                                "end": {
+                                    "line": 15,
+                                    "column": 13,
+                                    "byte": 323
+                                }
+                            },
+                            "ref": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 18,
+                                    "column": 7,
+                                    "byte": 379
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 10,
+                                    "byte": 382
+                                }
+                            },
+                            "string": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 7,
+                                    "byte": 157
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 13,
+                                    "byte": 163
+                                }
+                            },
+                            "triple": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 24,
+                                    "column": 7,
+                                    "byte": 534
+                                },
+                                "end": {
+                                    "line": 24,
+                                    "column": 13,
+                                    "byte": 540
+                                }
+                            },
+                            "true": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 7,
+                                    "byte": 106
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 11,
+                                    "byte": 110
+                                }
+                            },
+                            "tuple": {
+                                "environment": "schema-error",
+                                "begin": {
+                                    "line": 13,
+                                    "column": 7,
+                                    "byte": 249
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 12,
+                                    "byte": 254
+                                }
+                            }
+                        },
                         "object": {
                             "always": {
                                 "range": {
@@ -3994,6 +4752,21 @@
                                             "required": [
                                                 "some"
                                             ]
+                                        },
+                                        "keyRanges": {
+                                            "some": {
+                                                "environment": "schema-error",
+                                                "begin": {
+                                                    "line": 12,
+                                                    "column": 28,
+                                                    "byte": 215
+                                                },
+                                                "end": {
+                                                    "line": 12,
+                                                    "column": 32,
+                                                    "byte": 219
+                                                }
+                                            }
                                         },
                                         "object": {
                                             "some": {
@@ -4184,6 +4957,21 @@
                                         "hello"
                                     ]
                                 },
+                                "keyRanges": {
+                                    "hello": {
+                                        "environment": "schema-error",
+                                        "begin": {
+                                            "line": 20,
+                                            "column": 23,
+                                            "byte": 452
+                                        },
+                                        "end": {
+                                            "line": 20,
+                                            "column": 28,
+                                            "byte": 457
+                                        }
+                                    }
+                                },
                                 "object": {
                                     "hello": {
                                         "range": {
@@ -4237,6 +5025,34 @@
                                         "bar",
                                         "foo"
                                     ]
+                                },
+                                "keyRanges": {
+                                    "bar": {
+                                        "environment": "schema-error",
+                                        "begin": {
+                                            "line": 25,
+                                            "column": 33,
+                                            "byte": 594
+                                        },
+                                        "end": {
+                                            "line": 25,
+                                            "column": 36,
+                                            "byte": 597
+                                        }
+                                    },
+                                    "foo": {
+                                        "environment": "schema-error",
+                                        "begin": {
+                                            "line": 25,
+                                            "column": 23,
+                                            "byte": 584
+                                        },
+                                        "end": {
+                                            "line": 25,
+                                            "column": 26,
+                                            "byte": 587
+                                        }
+                                    }
                                 },
                                 "object": {
                                     "bar": {
@@ -4483,6 +5299,34 @@
                                         "hello"
                                     ]
                                 },
+                                "keyRanges": {
+                                    "blue": {
+                                        "environment": "schema-error",
+                                        "begin": {
+                                            "line": 14,
+                                            "column": 28,
+                                            "byte": 300
+                                        },
+                                        "end": {
+                                            "line": 14,
+                                            "column": 32,
+                                            "byte": 304
+                                        }
+                                    },
+                                    "hello": {
+                                        "environment": "schema-error",
+                                        "begin": {
+                                            "line": 14,
+                                            "column": 14,
+                                            "byte": 286
+                                        },
+                                        "end": {
+                                            "line": 14,
+                                            "column": 19,
+                                            "byte": 291
+                                        }
+                                    }
+                                },
                                 "object": {
                                     "blue": {
                                         "range": {
@@ -4572,6 +5416,21 @@
                                         "foo"
                                     ]
                                 },
+                                "keyRanges": {
+                                    "foo": {
+                                        "environment": "schema-error",
+                                        "begin": {
+                                            "line": 35,
+                                            "column": 24,
+                                            "byte": 824
+                                        },
+                                        "end": {
+                                            "line": 35,
+                                            "column": 27,
+                                            "byte": 827
+                                        }
+                                    }
+                                },
                                 "object": {
                                     "foo": {
                                         "range": {
@@ -4660,6 +5519,21 @@
                                     "required": [
                                         "foo"
                                     ]
+                                },
+                                "keyRanges": {
+                                    "foo": {
+                                        "environment": "schema-error",
+                                        "begin": {
+                                            "line": 34,
+                                            "column": 24,
+                                            "byte": 790
+                                        },
+                                        "end": {
+                                            "line": 34,
+                                            "column": 27,
+                                            "byte": 793
+                                        }
+                                    }
                                 },
                                 "object": {
                                     "foo": {
@@ -4848,6 +5722,21 @@
                                         "foo"
                                     ]
                                 },
+                                "keyRanges": {
+                                    "foo": {
+                                        "environment": "schema-error",
+                                        "begin": {
+                                            "line": 15,
+                                            "column": 17,
+                                            "byte": 327
+                                        },
+                                        "end": {
+                                            "line": 15,
+                                            "column": 20,
+                                            "byte": 330
+                                        }
+                                    }
+                                },
                                 "object": {
                                     "foo": {
                                         "range": {
@@ -4896,6 +5785,21 @@
                                     "required": [
                                         "baz"
                                     ]
+                                },
+                                "keyRanges": {
+                                    "baz": {
+                                        "environment": "schema-error",
+                                        "begin": {
+                                            "line": 18,
+                                            "column": 14,
+                                            "byte": 386
+                                        },
+                                        "end": {
+                                            "line": 18,
+                                            "column": 17,
+                                            "byte": 389
+                                        }
+                                    }
                                 },
                                 "object": {
                                     "baz": {

--- a/eval/testdata/eval/schema/expected.json
+++ b/eval/testdata/eval/schema/expected.json
@@ -817,6 +817,19 @@
                 },
                 "builtin": {
                     "name": "fn::open::schema",
+                    "nameRange": {
+                        "environment": "schema",
+                        "begin": {
+                            "line": 37,
+                            "column": 5,
+                            "byte": 847
+                        },
+                        "end": {
+                            "line": 37,
+                            "column": 21,
+                            "byte": 863
+                        }
+                    },
                     "argSchema": {
                         "$defs": {
                             "defRecord": {
@@ -1701,6 +1714,19 @@
                 },
                 "builtin": {
                     "name": "fn::open::schema",
+                    "nameRange": {
+                        "environment": "schema",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 22
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 21,
+                            "byte": 38
+                        }
+                    },
                     "argSchema": {
                         "$defs": {
                             "defRecord": {
@@ -2241,6 +2267,424 @@
                                 "tuple"
                             ]
                         },
+                        "keyRanges": {
+                            "always": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 22,
+                                    "column": 7,
+                                    "byte": 489
+                                },
+                                "end": {
+                                    "line": 22,
+                                    "column": 13,
+                                    "byte": 495
+                                }
+                            },
+                            "anyOf": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 16,
+                                    "column": 7,
+                                    "byte": 344
+                                },
+                                "end": {
+                                    "line": 16,
+                                    "column": 12,
+                                    "byte": 349
+                                }
+                            },
+                            "array": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 12,
+                                    "column": 7,
+                                    "byte": 194
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 12,
+                                    "byte": 199
+                                }
+                            },
+                            "boolean": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 7,
+                                    "byte": 65
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 14,
+                                    "byte": 72
+                                }
+                            },
+                            "const-array": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 19,
+                                    "column": 7,
+                                    "byte": 403
+                                },
+                                "end": {
+                                    "line": 19,
+                                    "column": 18,
+                                    "byte": 414
+                                }
+                            },
+                            "const-object": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 7,
+                                    "byte": 436
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 19,
+                                    "byte": 448
+                                }
+                            },
+                            "dependentReq": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 25,
+                                    "column": 7,
+                                    "byte": 568
+                                },
+                                "end": {
+                                    "line": 25,
+                                    "column": 19,
+                                    "byte": 580
+                                }
+                            },
+                            "double": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 23,
+                                    "column": 7,
+                                    "byte": 506
+                                },
+                                "end": {
+                                    "line": 23,
+                                    "column": 13,
+                                    "byte": 512
+                                }
+                            },
+                            "enum": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 21,
+                                    "column": 7,
+                                    "byte": 473
+                                },
+                                "end": {
+                                    "line": 21,
+                                    "column": 11,
+                                    "byte": 477
+                                }
+                            },
+                            "exclusiveMaximum": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 30,
+                                    "column": 7,
+                                    "byte": 688
+                                },
+                                "end": {
+                                    "line": 30,
+                                    "column": 23,
+                                    "byte": 704
+                                }
+                            },
+                            "exclusiveMinimum": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 28,
+                                    "column": 7,
+                                    "byte": 645
+                                },
+                                "end": {
+                                    "line": 28,
+                                    "column": 23,
+                                    "byte": 661
+                                }
+                            },
+                            "false": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 7,
+                                    "byte": 85
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 12,
+                                    "byte": 90
+                                }
+                            },
+                            "hello": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 11,
+                                    "column": 7,
+                                    "byte": 175
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 12,
+                                    "byte": 180
+                                }
+                            },
+                            "map": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 14,
+                                    "column": 7,
+                                    "byte": 279
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "column": 10,
+                                    "byte": 282
+                                }
+                            },
+                            "maxLength": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 32,
+                                    "column": 7,
+                                    "byte": 733
+                                },
+                                "end": {
+                                    "line": 32,
+                                    "column": 16,
+                                    "byte": 742
+                                }
+                            },
+                            "maxProperties": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 35,
+                                    "column": 7,
+                                    "byte": 807
+                                },
+                                "end": {
+                                    "line": 35,
+                                    "column": 20,
+                                    "byte": 820
+                                }
+                            },
+                            "maximum": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 29,
+                                    "column": 7,
+                                    "byte": 671
+                                },
+                                "end": {
+                                    "line": 29,
+                                    "column": 14,
+                                    "byte": 678
+                                }
+                            },
+                            "minLength": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 31,
+                                    "column": 7,
+                                    "byte": 714
+                                },
+                                "end": {
+                                    "line": 31,
+                                    "column": 16,
+                                    "byte": 723
+                                }
+                            },
+                            "minProperties": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 34,
+                                    "column": 7,
+                                    "byte": 773
+                                },
+                                "end": {
+                                    "line": 34,
+                                    "column": 20,
+                                    "byte": 786
+                                }
+                            },
+                            "minimum": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 27,
+                                    "column": 7,
+                                    "byte": 628
+                                },
+                                "end": {
+                                    "line": 27,
+                                    "column": 14,
+                                    "byte": 635
+                                }
+                            },
+                            "multiple": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 26,
+                                    "column": 7,
+                                    "byte": 610
+                                },
+                                "end": {
+                                    "line": 26,
+                                    "column": 15,
+                                    "byte": 618
+                                }
+                            },
+                            "null": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 7,
+                                    "byte": 46
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 11,
+                                    "byte": 50
+                                }
+                            },
+                            "number": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 7,
+                                    "byte": 125
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 13,
+                                    "byte": 131
+                                }
+                            },
+                            "oneOf": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 17,
+                                    "column": 7,
+                                    "byte": 363
+                                },
+                                "end": {
+                                    "line": 17,
+                                    "column": 12,
+                                    "byte": 368
+                                }
+                            },
+                            "pattern": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 33,
+                                    "column": 7,
+                                    "byte": 752
+                                },
+                                "end": {
+                                    "line": 33,
+                                    "column": 14,
+                                    "byte": 759
+                                }
+                            },
+                            "pi": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 7,
+                                    "byte": 142
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 9,
+                                    "byte": 144
+                                }
+                            },
+                            "record": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 15,
+                                    "column": 7,
+                                    "byte": 317
+                                },
+                                "end": {
+                                    "line": 15,
+                                    "column": 13,
+                                    "byte": 323
+                                }
+                            },
+                            "ref": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 18,
+                                    "column": 7,
+                                    "byte": 379
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 10,
+                                    "byte": 382
+                                }
+                            },
+                            "string": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 7,
+                                    "byte": 157
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 13,
+                                    "byte": 163
+                                }
+                            },
+                            "triple": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 24,
+                                    "column": 7,
+                                    "byte": 534
+                                },
+                                "end": {
+                                    "line": 24,
+                                    "column": 13,
+                                    "byte": 540
+                                }
+                            },
+                            "true": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 7,
+                                    "byte": 106
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 11,
+                                    "byte": 110
+                                }
+                            },
+                            "tuple": {
+                                "environment": "schema",
+                                "begin": {
+                                    "line": 13,
+                                    "column": 7,
+                                    "byte": 249
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 12,
+                                    "byte": 254
+                                }
+                            }
+                        },
                         "object": {
                             "always": {
                                 "range": {
@@ -2396,6 +2840,21 @@
                                             "required": [
                                                 "some"
                                             ]
+                                        },
+                                        "keyRanges": {
+                                            "some": {
+                                                "environment": "schema",
+                                                "begin": {
+                                                    "line": 12,
+                                                    "column": 28,
+                                                    "byte": 215
+                                                },
+                                                "end": {
+                                                    "line": 12,
+                                                    "column": 32,
+                                                    "byte": 219
+                                                }
+                                            }
                                         },
                                         "object": {
                                             "some": {
@@ -2586,6 +3045,21 @@
                                         "hello"
                                     ]
                                 },
+                                "keyRanges": {
+                                    "hello": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 20,
+                                            "column": 23,
+                                            "byte": 452
+                                        },
+                                        "end": {
+                                            "line": 20,
+                                            "column": 28,
+                                            "byte": 457
+                                        }
+                                    }
+                                },
                                 "object": {
                                     "hello": {
                                         "range": {
@@ -2639,6 +3113,34 @@
                                         "bar",
                                         "foo"
                                     ]
+                                },
+                                "keyRanges": {
+                                    "bar": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 25,
+                                            "column": 33,
+                                            "byte": 594
+                                        },
+                                        "end": {
+                                            "line": 25,
+                                            "column": 36,
+                                            "byte": 597
+                                        }
+                                    },
+                                    "foo": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 25,
+                                            "column": 23,
+                                            "byte": 584
+                                        },
+                                        "end": {
+                                            "line": 25,
+                                            "column": 26,
+                                            "byte": 587
+                                        }
+                                    }
                                 },
                                 "object": {
                                     "bar": {
@@ -2885,6 +3387,34 @@
                                         "hello"
                                     ]
                                 },
+                                "keyRanges": {
+                                    "blue": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 14,
+                                            "column": 28,
+                                            "byte": 300
+                                        },
+                                        "end": {
+                                            "line": 14,
+                                            "column": 32,
+                                            "byte": 304
+                                        }
+                                    },
+                                    "hello": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 14,
+                                            "column": 14,
+                                            "byte": 286
+                                        },
+                                        "end": {
+                                            "line": 14,
+                                            "column": 19,
+                                            "byte": 291
+                                        }
+                                    }
+                                },
                                 "object": {
                                     "blue": {
                                         "range": {
@@ -2974,6 +3504,21 @@
                                         "foo"
                                     ]
                                 },
+                                "keyRanges": {
+                                    "foo": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 35,
+                                            "column": 24,
+                                            "byte": 824
+                                        },
+                                        "end": {
+                                            "line": 35,
+                                            "column": 27,
+                                            "byte": 827
+                                        }
+                                    }
+                                },
                                 "object": {
                                     "foo": {
                                         "range": {
@@ -3062,6 +3607,21 @@
                                     "required": [
                                         "foo"
                                     ]
+                                },
+                                "keyRanges": {
+                                    "foo": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 34,
+                                            "column": 24,
+                                            "byte": 790
+                                        },
+                                        "end": {
+                                            "line": 34,
+                                            "column": 27,
+                                            "byte": 793
+                                        }
+                                    }
                                 },
                                 "object": {
                                     "foo": {
@@ -3250,6 +3810,21 @@
                                         "foo"
                                     ]
                                 },
+                                "keyRanges": {
+                                    "foo": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 15,
+                                            "column": 17,
+                                            "byte": 327
+                                        },
+                                        "end": {
+                                            "line": 15,
+                                            "column": 20,
+                                            "byte": 330
+                                        }
+                                    }
+                                },
                                 "object": {
                                     "foo": {
                                         "range": {
@@ -3298,6 +3873,21 @@
                                     "required": [
                                         "baz"
                                     ]
+                                },
+                                "keyRanges": {
+                                    "baz": {
+                                        "environment": "schema",
+                                        "begin": {
+                                            "line": 18,
+                                            "column": 14,
+                                            "byte": 386
+                                        },
+                                        "end": {
+                                            "line": 18,
+                                            "column": 17,
+                                            "byte": 389
+                                        }
+                                    }
                                 },
                                 "object": {
                                     "baz": {

--- a/eval/testdata/eval/unicode/expected.json
+++ b/eval/testdata/eval/unicode/expected.json
@@ -27,6 +27,21 @@
                         "hovedstad"
                     ]
                 },
+                "keyRanges": {
+                    "hovedstad": {
+                        "environment": "unicode",
+                        "begin": {
+                            "line": 8,
+                            "column": 5,
+                            "byte": 89
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 14,
+                            "byte": 98
+                        }
+                    }
+                },
                 "object": {
                     "hovedstad": {
                         "range": {

--- a/expr.go
+++ b/expr.go
@@ -29,22 +29,25 @@ type Expr struct {
 	// The expression that defined this expression's base value, if any.
 	Base *Expr `json:"base,omitempty"`
 
+	// Ranges for the object's keys, if this is an object expression.
+	KeyRanges map[string]Range `json:"keyRanges,omitempty"`
+
 	// The fields below act as a discriminated union. Only one must be non-nil at any given time. If all fields are nil,
 	// then this Expr is a null literal expression.
 
 	// The literal value, if this is a literal expression (nil, bool, json.Number, or string)
 	Literal any `json:"literal,omitempty"`
 
-	// The interpolations, if this is a a string interpolation expression
+	// The interpolations, if this is a string interpolation expression.
 	Interpolate []Interpolation `json:"interpolate,omitempty"`
 
-	// The property accessors, if this is a a symbol expression
+	// The property accessors, if this is a symbol expression.
 	Symbol []PropertyAccessor `json:"symbol,omitempty"`
 
-	// The access, if this is an access expression
+	// The access, if this is an access expression.
 	Access *AccessExpr `json:"access,omitempty"`
 
-	// The list elements, if this is a list expression
+	// The list elements, if this is a list expression.
 	List []Expr `json:"list,omitempty"`
 
 	// The object properties, if this is an object expression.
@@ -92,6 +95,7 @@ type AccessExpr struct {
 // A BuiltinExpr is a call to a builtin function.
 type BuiltinExpr struct {
 	Name      string         `json:"name"`
+	NameRange Range          `json:"nameRange"`
 	ArgSchema *schema.Schema `json:"argSchema"`
 	Arg       Expr           `json:"arg"`
 }


### PR DESCRIPTION
These changes add a package to aid in authoring tools that use the results of Check/Open as a jumping-off point for analyzing environments. This package currently supports finding the expression at a given source position and describing the entity at a given source position.