### PR TITLE
vscode project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,17 @@
 # Go workspace file
 go.work
 
+### IntelliJ ###
 .idea/
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+# Local History for Visual Studio Code
+.history/
+# Built Visual Studio Code Extensions
+*.vsix

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"golang.go"
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,28 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+			"type": "shell",
+			"label": "make: build",
+			"command": "make build",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"problemMatcher": [
+				"$go"
+			]
+		},
+		{
+			"type": "shell",
+			"label": "make: test",
+			"command": "make test",
+			"group": {
+				"kind": "test",
+				"isDefault": true
+			}
+		}
+    ]
+}


### PR DESCRIPTION
This PR contributes a basic vscode project configuration for ease of
use.

The project files do the following:
1. Configure the default Build Task (⇧⌘B) to run `make build`.
2. Configure the default Test Task to run `make test`.
3. Recommend the "Go" vscode extensions when the project is opened.

See: https://github.com/github/gitignore/blob/4488915eec0b3a45b5c63ead28f286819c0917de/Global/VisualStudioCode.gitignore