### PR TITLE
esc, cli: helpers for well-known properties

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,8 +3,11 @@
 - Add two new builtins, `fn::fromBase64` and `fn::fromJSON`. The former decodes a base64-encoded
   string into a binary string and the latter decodes a JSON string into a value.
   [#117](https://github.com/pulumi/esc/pull/117)
-- Add support for file projection in run command.
+- Add support for temporary file projection in run and open commands.
   [#141](https://github.com/pulumi/esc/pull/141)
+  [#151](https://github.com/pulumi/esc/pull/151)
+- Support null, boolean, and number values in environment variables.
+  [#151](https://github.com/pulumi/esc/pull/151)
   
 ### Bug Fixes
 

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -111,19 +111,23 @@ func (tfs testFS) CreateTemp(dir, pattern string) (string, io.ReadWriteCloser, e
 	if dir == "" {
 		dir = "temp"
 	}
-	name := path.Join(dir, strings.ReplaceAll(pattern, "*", "temp"))
 
-	f := &fstest.MapFile{Mode: 0o600}
-	tfs.MapFS[name] = f
-	return name, &testFile{f: f}, nil
+	for i := 0; ; i++ {
+		name := path.Join(dir, strings.ReplaceAll(pattern, "*", fmt.Sprintf("temp-%v", i)))
+		if _, ok := tfs.MapFS[name]; !ok {
+			f := &fstest.MapFile{Mode: 0o600}
+			tfs.MapFS[name] = f
+			return name, &testFile{f: f}, nil
+		}
+	}
 }
 
 func (tfs testFS) Remove(name string) error {
-	f, err := tfs.Stat(name)
+	_, err := tfs.Stat(name)
 	if err != nil {
 		return err
 	}
-	delete(tfs.MapFS, f.Name())
+	delete(tfs.MapFS, name)
 	return nil
 }
 

--- a/cmd/esc/cli/env_get.go
+++ b/cmd/esc/cli/env_get.go
@@ -148,7 +148,7 @@ func (get *envGetCommand) showValue(
 	if err != nil {
 		return fmt.Errorf("getting environment: %w", err)
 	}
-	return renderValue(get.env.esc.stdout, env, path, format)
+	return get.env.renderValue(get.env.esc.stdout, env, path, format, true)
 }
 
 func (get *envGetCommand) getEntireEnvironment(

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/pulumi/esc"
 	"github.com/pulumi/esc/cmd/esc/cli/client"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
 )
@@ -71,7 +73,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 				return envcmd.writePropertyEnvironmentDiagnostics(envcmd.esc.stderr, diags)
 			}
 
-			return renderValue(envcmd.esc.stdout, env, path, format)
+			return envcmd.renderValue(envcmd.esc.stdout, env, path, format, false)
 		},
 	}
 
@@ -85,17 +87,18 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 	return cmd
 }
 
-func renderValue(
+func (env *envCommand) renderValue(
 	out io.Writer,
-	env *esc.Environment,
+	e *esc.Environment,
 	path resource.PropertyPath,
 	format string,
+	pretend bool,
 ) error {
-	if env == nil {
+	if e == nil {
 		return nil
 	}
 
-	val := esc.NewValue(env.Properties)
+	val := esc.NewValue(e.Properties)
 	if len(path) != 0 {
 		if vv, ok := getEnvValue(val, path); ok {
 			val = *vv
@@ -115,12 +118,20 @@ func renderValue(
 		enc.SetIndent("", "  ")
 		return enc.Encode(val)
 	case "dotenv":
-		for _, kvp := range getEnvironmentVariables(env) {
+		_, environ, _, err := env.prepareEnvironment(e, prepareOptions{pretend: pretend, quote: true})
+		if err != nil {
+			return err
+		}
+		for _, kvp := range environ {
 			fmt.Fprintln(out, kvp)
 		}
 		return nil
 	case "shell":
-		for _, kvp := range getEnvironmentVariables(env) {
+		_, environ, _, err := env.prepareEnvironment(e, prepareOptions{pretend: pretend, quote: true})
+		if err != nil {
+			return err
+		}
+		for _, kvp := range environ {
 			fmt.Fprintf(out, "export %v\n", kvp)
 		}
 		return nil
@@ -134,22 +145,95 @@ func renderValue(
 
 }
 
-func getEnvironmentVariables(env *esc.Environment) []string {
-	vars, ok := env.Properties["environmentVariables"].Value.(map[string]esc.Value)
-	if !ok {
-		return nil
-	}
+type prepareOptions struct {
+	quote   bool
+	pretend bool
+}
+
+func getEnvironmentVariables(env *esc.Environment, quote bool) (environ, secrets []string) {
+	vars := env.GetEnvironmentVariables()
 	keys := maps.Keys(vars)
 	sort.Strings(keys)
 
-	var environ []string
 	for _, k := range keys {
 		v := vars[k]
-		if strValue, ok := v.Value.(string); ok {
-			environ = append(environ, fmt.Sprintf("%v=%q", k, strValue))
+		s := v.Value.(string)
+
+		if v.Secret {
+			secrets = append(secrets, s)
 		}
+		if quote {
+			s = strconv.Quote(s)
+		}
+		environ = append(environ, fmt.Sprintf("%v=%v", k, s))
 	}
-	return environ
+	return environ, secrets
+}
+
+func (env *envCommand) createTemporaryFile(content []byte) (string, error) {
+	filename, f, err := env.esc.fs.CreateTemp("", "esc-*")
+	if err != nil {
+		return "", err
+	}
+	defer contract.IgnoreClose(f)
+
+	if _, err = f.Write(content); err != nil {
+		contract.IgnoreClose(f)
+		rmErr := env.esc.fs.Remove(filename)
+		contract.IgnoreError(rmErr)
+		return "", err
+	}
+	return filename, nil
+}
+
+func (env *envCommand) createTemporaryFiles(e *esc.Environment, opts prepareOptions) (paths, environ, secrets []string, err error) {
+	files := e.GetTemporaryFiles()
+	keys := maps.Keys(files)
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := files[k]
+		s := v.Value.(string)
+
+		if v.Secret {
+			secrets = append(secrets, s)
+		}
+
+		path := "[unknown]"
+		if !opts.pretend {
+			path, err = env.createTemporaryFile([]byte(s))
+			if err != nil {
+				env.removeTemporaryFiles(paths)
+				return nil, nil, nil, err
+			}
+			paths = append(paths, path)
+		}
+		if opts.quote {
+			path = strconv.Quote(path)
+		}
+		environ = append(environ, fmt.Sprintf("%v=%v", k, path))
+	}
+	return paths, environ, secrets, nil
+}
+
+func (env *envCommand) removeTemporaryFiles(paths []string) {
+	for _, path := range paths {
+		err := env.esc.fs.Remove(path)
+		contract.IgnoreError(err)
+	}
+}
+
+func (env *envCommand) prepareEnvironment(e *esc.Environment, opts prepareOptions) (files, environ, secrets []string, err error) {
+	envVars, envSecrets := getEnvironmentVariables(e, opts.quote)
+
+	filePaths, fileVars, fileSecrets, err := env.createTemporaryFiles(e, opts)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("creating temporary files: %v", err)
+	}
+
+	environ = append(envVars, fileVars...)
+	secrets = append(envSecrets, fileSecrets...)
+	return filePaths, environ, secrets, nil
 }
 
 func (env *envCommand) openEnvironment(

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -145,11 +145,6 @@ func (env *envCommand) renderValue(
 
 }
 
-type prepareOptions struct {
-	quote   bool
-	pretend bool
-}
-
 func getEnvironmentVariables(env *esc.Environment, quote bool) (environ, secrets []string) {
 	vars := env.GetEnvironmentVariables()
 	keys := maps.Keys(vars)
@@ -223,6 +218,14 @@ func (env *envCommand) removeTemporaryFiles(paths []string) {
 	}
 }
 
+// prepareOptions contains options for prepareEnvironment.
+type prepareOptions struct {
+	quote   bool // True to quote environment variable values
+	pretend bool // True to skip actually writing temporary files
+}
+
+// prepareEnvironment prepares the envvar and temporary file projections for an environment. Returns the paths to
+// temporary files, environment variable pairs, and secret values.
 func (env *envCommand) prepareEnvironment(e *esc.Environment, opts prepareOptions) (files, environ, secrets []string, err error) {
 	envVars, envSecrets := getEnvironmentVariables(e, opts.quote)
 

--- a/cmd/esc/cli/env_rm.go
+++ b/cmd/esc/cli/env_rm.go
@@ -59,7 +59,7 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 				}
 
 				msg := fmt.Sprintf("%sEnvironment %q has been removed!%s", colors.SpecAttention, envSlug, colors.Reset)
-				fmt.Println(env.esc.colors.Colorize(msg))
+				fmt.Fprintln(env.esc.stdout, env.esc.colors.Colorize(msg))
 				return nil
 			}
 

--- a/cmd/esc/cli/env_run.go
+++ b/cmd/esc/cli/env_run.go
@@ -148,53 +148,11 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 				return envcmd.writePropertyEnvironmentDiagnostics(envcmd.esc.stderr, diags)
 			}
 
-			var secrets []string
-
-			environ := envcmd.esc.environ.Vars()
-			if vars, ok := env.Properties["environmentVariables"].Value.(map[string]esc.Value); ok {
-				for k, v := range vars {
-					if strValue, ok := v.Value.(string); ok {
-						if v.Secret {
-							secrets = append(secrets, strValue)
-						}
-
-						environ = append(environ, fmt.Sprintf("%v=%v", k, strValue))
-					}
-				}
+			files, environ, secrets, err := envcmd.prepareEnvironment(env, prepareOptions{})
+			if err != nil {
+				return err
 			}
-
-			writeTempFile := func(content string) (string, error) {
-				filename, f, err := envcmd.esc.fs.CreateTemp("", "esc-*")
-				if err != nil {
-					return "", err
-				}
-				defer contract.IgnoreClose(f)
-
-				if _, err = f.Write([]byte(content)); err != nil {
-					contract.IgnoreClose(f)
-					rmErr := envcmd.esc.fs.Remove(filename)
-					contract.IgnoreError(rmErr)
-					return "", err
-				}
-
-				return filename, nil
-			}
-			if files, ok := env.Properties["files"].Value.(map[string]esc.Value); ok {
-				for k, v := range files {
-					if strValue, ok := v.Value.(string); ok {
-						file, err := writeTempFile(strValue)
-						if err != nil {
-							return err
-						}
-						defer func() {
-							rmErr := envcmd.esc.fs.Remove(file)
-							contract.IgnoreError(rmErr)
-						}()
-
-						environ = append(environ, fmt.Sprintf("%v=%v", k, file))
-					}
-				}
-			}
+			defer envcmd.removeTemporaryFiles(files)
 
 			envV := esc.NewValue(env.Properties)
 			for i, v := range args {
@@ -230,7 +188,7 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 			}
 
 			runCmd := exec.Command(command, args...)
-			runCmd.Env = environ
+			runCmd.Env = append(envcmd.esc.environ.Vars(), environ...)
 
 			stdout, stderr := envcmd.esc.stdout, envcmd.esc.stderr
 			if !interactive {

--- a/cmd/esc/cli/testdata/env-get-all-value-dotenv.yaml
+++ b/cmd/esc/cli/testdata/env-get-all-value-dotenv.yaml
@@ -17,11 +17,20 @@ environments:
       open:
         fn::open::test: echo
       environmentVariables:
+        NULLV: null
+        BOOLEAN: true
+        NUMBER: 3.14
         STRING: ${string}
         OBJECT: {'fn::toJSON': "${object}"}
+      files:
+        FILE: ${string}
 stdout: |
   > esc env get test --value=dotenv
+  BOOLEAN="true"
+  NULLV=""
+  NUMBER="3.14"
   OBJECT="{\"hello\":\"world\"}"
   STRING="esc"
+  FILE="[unknown]"
 stderr: |
   > esc env get test --value=dotenv

--- a/cmd/esc/cli/testdata/env-get-all-value-shell.yaml
+++ b/cmd/esc/cli/testdata/env-get-all-value-shell.yaml
@@ -17,11 +17,20 @@ environments:
       open:
         fn::open::test: echo
       environmentVariables:
+        NULLV: null
+        BOOLEAN: true
+        NUMBER: 3.14
         STRING: ${string}
         OBJECT: {'fn::toJSON': "${object}"}
+      files:
+        FILE: ${string}
 stdout: |
   > esc env get test --value=shell
+  export BOOLEAN="true"
+  export NULLV=""
+  export NUMBER="3.14"
   export OBJECT="{\"hello\":\"world\"}"
   export STRING="esc"
+  export FILE="[unknown]"
 stderr: |
   > esc env get test --value=shell

--- a/cmd/esc/cli/testdata/env-rm-ok.yaml
+++ b/cmd/esc/cli/testdata/env-rm-ok.yaml
@@ -3,5 +3,6 @@ environments:
   test-user/dup: arbitrary
 stdout: |
   > esc env rm dup -y
+  Environment "test-user/dup" has been removed!
 stderr: |
   > esc env rm dup -y

--- a/cmd/esc/cli/testdata/open-dotenv.yaml
+++ b/cmd/esc/cli/testdata/open-dotenv.yaml
@@ -5,17 +5,31 @@ environments:
       - test-2
     values:
       foo: bar
+      yup: true
+      pi: 3.14
       environmentVariables:
         FOO: ${foo}
+        BOOL: ${yup}
+        NUM: ${pi}
+      files:
+        BOOL_FILE: ${yup}
+        NUM_FILE: ${pi}
   test-user/test-2:
     values:
       foo: baz
       hello: world
       environmentVariables:
         HELLO: ${hello}
+      files:
+        FILE: bar
 stdout: |
   > esc open test --format dotenv
+  BOOL="true"
   FOO="bar"
   HELLO="world"
+  NUM="3.14"
+  BOOL_FILE="temp/esc-temp-0"
+  FILE="temp/esc-temp-1"
+  NUM_FILE="temp/esc-temp-2"
 stderr: |
   > esc open test --format dotenv

--- a/cmd/esc/cli/testdata/open-shell.yaml
+++ b/cmd/esc/cli/testdata/open-shell.yaml
@@ -5,17 +5,31 @@ environments:
       - test-2
     values:
       foo: bar
+      yup: true
+      pi: 3.14
       environmentVariables:
         FOO: ${foo}
+        BOOL: ${yup}
+        NUM: ${pi}
+      files:
+        BOOL_FILE: ${yup}
+        NUM_FILE: ${pi}
   test-user/test-2:
     values:
       foo: baz
       hello: world
       environmentVariables:
         HELLO: ${hello}
+      files:
+        FILE: bar
 stdout: |
   > esc open test --format shell
+  export BOOL="true"
   export FOO="bar"
   export HELLO="world"
+  export NUM="3.14"
+  export BOOL_FILE="temp/esc-temp-0"
+  export FILE="temp/esc-temp-1"
+  export NUM_FILE="temp/esc-temp-2"
 stderr: |
   > esc open test --format shell

--- a/cmd/esc/cli/testdata/run.yaml
+++ b/cmd/esc/cli/testdata/run.yaml
@@ -8,7 +8,7 @@ run: |
 process:
   commands:
     dump-env: |
-      echo "secret: $SECRET, plain: $PLAIN"
+      echo "secret: $SECRET, plain: $PLAIN, bool: $BOOL, num: $NUM, file: $FILE, boolFile: $BOOL_FILE, numFile: $NUM_FILE"
     echo: |
       echo $*
     source-file: |
@@ -19,18 +19,24 @@ environments:
     values:
       secret: {"fn::secret": "hunter2"}
       plain: plaintext
+      yup: true
+      pi: 3.14
       environmentVariables:
         SECRET: ${secret}
         PLAIN: ${plain}
+        BOOL: ${yup}
+        NUM: ${pi}
       files:
         FILE: |
           export F_SECRET=${secret}
           export F_PLAIN=${plain}
+        BOOL_FILE: ${yup}
+        NUM_FILE: ${pi}
 stdout: |
   > esc env run test dump-env
-  secret: [secret], plain: plaintext
+  secret: [secret], plain: plaintext, bool: true, num: 3.14, file: temp/esc-temp-1, boolFile: temp/esc-temp-0, numFile: temp/esc-temp-2
   > esc env run -i test dump-env
-  secret: hunter2, plain: plaintext
+  secret: hunter2, plain: plaintext, bool: true, num: 3.14, file: temp/esc-temp-1, boolFile: temp/esc-temp-0, numFile: temp/esc-temp-2
   > esc env run test echo secret: ${secret}, plain: ${plain}
   secret: [secret], plain: plaintext
   > esc env run -i test echo secret: ${secret}, plain: ${plain}


### PR DESCRIPTION
These changes add helpers for fetching the environment variables and temporary files defined by an environment. The former are sourced from the `environmentVariables` top-level property and the latter from the `files` top-level property. In both cases, nested properties with scalar values are coerced to strings and nested properties with non-scalar values are ignored.

These changes also use these helpers to extend support for the `files` property to `open`.

Fixes #118.