### PR TITLE
def: support secret encryption + decryption

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,5 +2,8 @@
 
 * Include paths in diagnostics. [#157](https://github.com/pulumi/esc/pull/157)
   
+- Support secret elision in definitions via encryption and decryption
+  [#155](https://github.com/pulumi/esc/pull/155)
+
 ### Bug Fixes
 

--- a/analysis/common_test.go
+++ b/analysis/common_test.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	"github.com/pulumi/esc"
+	"github.com/pulumi/esc/eval"
 	"github.com/pulumi/esc/schema"
 	"golang.org/x/exp/maps"
 )
@@ -72,11 +73,11 @@ func (testProviders) LoadProvider(ctx context.Context, name string) (esc.Provide
 
 type testEnvironments struct{}
 
-func (testEnvironments) LoadEnvironment(ctx context.Context, name string) ([]byte, error) {
+func (testEnvironments) LoadEnvironment(ctx context.Context, name string) ([]byte, eval.Decrypter, error) {
 	if name != "a" {
-		return nil, errors.New("not found")
+		return nil, nil, errors.New("not found")
 	}
-	return []byte(`{"values": {}}`), nil
+	return []byte(`{"values": {}}`), nil, nil
 }
 
 const def = `imports:

--- a/eval/crypt.go
+++ b/eval/crypt.go
@@ -1,0 +1,222 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eval
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+
+	"github.com/pulumi/esc/syntax"
+	"github.com/pulumi/esc/syntax/encoding"
+	"gopkg.in/yaml.v3"
+)
+
+// An Encrypter encrypts plaintext into ciphertext.
+type Encrypter interface {
+	// Encrypt encrypts a single plaintext value.
+	Encrypt(ctx context.Context, value []byte) ([]byte, error)
+}
+
+// A Decrypter decrypts ciphertext into plaintext.
+type Decrypter interface {
+	// Decrypt decrypts a single ciphertext value.
+	Decrypt(ctx context.Context, value []byte) ([]byte, error)
+}
+
+// rewriteYAML is a helper for rewriting a single YAML document.
+func rewriteYAML(
+	ctx context.Context,
+	filename string,
+	source []byte,
+	visitor func(n syntax.Node) (syntax.Node, syntax.Diagnostics, error),
+) ([]byte, error) {
+	syn, diags := encoding.DecodeYAMLBytes(filename, source, TagDecoder)
+	if len(diags) != 0 {
+		return nil, diags
+	}
+
+	doc, diags, err := syntax.Walk(syn, visitor)
+	if err != nil {
+		return nil, err
+	}
+	if len(diags) != 0 {
+		return nil, diags
+	}
+
+	var b bytes.Buffer
+	enc := yaml.NewEncoder(&b)
+	enc.SetIndent(2)
+	diags = encoding.EncodeYAML(enc, doc)
+	if len(diags) != 0 {
+		return nil, diags
+	}
+	return b.Bytes(), nil
+}
+
+// parseSecret attempts to parse a syntax.Node as a call to the fn::secret builtin. If the node is such a call,
+// parseSecret extracts and returns the plaintext or ciphertext.
+//
+// A call that carries ciphertext is of the form
+//
+//	fn::secret:
+//	  ciphertext: <base64-encoded envelope>
+//
+// A call that carries plaintext is of the form
+//
+//	fn::secret: <string literal>
+func parseSecret(node syntax.Node) (obj *syntax.ObjectNode, plaintext, ciphertext *syntax.StringNode, ok bool) {
+	obj, ok = node.(*syntax.ObjectNode)
+	if !ok {
+		return nil, nil, nil, false
+	}
+	if obj.Len() != 1 || obj.Index(0).Key.Value() != "fn::secret" {
+		return nil, nil, nil, false
+	}
+	value := obj.Index(0).Value
+
+	if arg, ok := value.(*syntax.ObjectNode); ok && arg.Len() == 1 {
+		kvp := arg.Index(0)
+		if kvp.Key.Value() == "ciphertext" {
+			if str, ok := kvp.Value.(*syntax.StringNode); ok {
+				return obj, nil, str, true
+			}
+		}
+	}
+
+	str, ok := value.(*syntax.StringNode)
+	if !ok {
+		return nil, nil, nil, false
+	}
+	return obj, str, nil, true
+}
+
+// EncryptSecrets encrypts any secrets in the given YAML document and returns the rewritten source. Encryption replaces
+// all plaintext arguments to `fn::secret` with encrypted ciphertext.
+func EncryptSecrets(ctx context.Context, filename string, source []byte, encrypter Encrypter) ([]byte, error) {
+	return rewriteYAML(ctx, filename, source, func(n syntax.Node) (syntax.Node, syntax.Diagnostics, error) {
+		obj, plaintext, _, ok := parseSecret(n)
+		if !ok || plaintext == nil {
+			return n, nil, nil
+		}
+
+		// Encrypt the plaintext.
+		ciphertext, err := encrypter.Encrypt(ctx, []byte(plaintext.Value()))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Replace the original call to `fn::secret` with a new call whose argument is the encrypted ciphertext.
+		//
+		// Trivia from the plaintext value is copied to the ciphertext string.
+		return syntax.ObjectSyntax(obj.Syntax(),
+			syntax.ObjectPropertySyntax(
+				obj.Index(0).Syntax,
+				obj.Index(0).Key,
+				syntax.Object(
+					syntax.ObjectProperty(
+						syntax.String("ciphertext"),
+						syntax.StringSyntax(syntax.CopyTrivia(plaintext.Syntax()), encodeCiphertext(ciphertext)),
+					),
+				),
+			),
+		), nil, nil
+	})
+}
+
+// DecryptSecrets decrypts any secrets in the given YAML document and returns the rewritten source. Decryption replaces
+// all ciphertext arguments to `fn::secret` with decrypted plaintext.
+func DecryptSecrets(ctx context.Context, filename string, source []byte, decrypter Decrypter) ([]byte, error) {
+	return rewriteYAML(ctx, filename, source, func(n syntax.Node) (syntax.Node, syntax.Diagnostics, error) {
+		obj, _, ciphertextNode, ok := parseSecret(n)
+		if !ok || ciphertextNode == nil {
+			return n, nil, nil
+		}
+
+		ciphertext, err := decodeCiphertext(ciphertextNode.Value())
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid ciphertext: %w", err)
+		}
+
+		plaintext, err := decrypter.Decrypt(ctx, ciphertext)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Replace the original call to `fn::secret` with a new call whose argument is the decrypted plaintext.
+		return syntax.ObjectSyntax(obj.Syntax(),
+			syntax.ObjectPropertySyntax(obj.Index(0).Syntax, obj.Index(0).Key, syntax.StringSyntax(ciphertextNode.Syntax(), string(plaintext))),
+		), nil, nil
+	})
+}
+
+const envelopeMagic = "escx"
+const envelopeVersion = uint32(1)
+
+// Ciphertext is wrapped in an envelope that is encoded as a binary string of the form
+//
+//	“escx” <envelope version> <ciphertext> <crc32>
+//
+// The envelope version and checksum are encoded as big-endian 4-byte values. The checksum takes into account all of
+// the preceding bytes. It is highly unlikely that user-specified plaintext values will collide with this encoding.
+//
+// The envelope itself is base64-encoded.
+func decodeCiphertext(repr string) ([]byte, error) {
+	bin, err := base64.StdEncoding.DecodeString(repr)
+	if err != nil {
+		return nil, err
+	}
+
+	// The minimum length for the envelope is 16 bytes (4 bytes each for the magic number, version, length, and
+	// checksum)
+	if len(bin) < 16 {
+		return nil, io.EOF
+	}
+
+	// The envelope must begin with "escx".
+	if string(bin[0:4]) != envelopeMagic {
+		return nil, errors.New("invalid header")
+	}
+
+	// The expected and actual checksums must match.
+	expectedChecksum := binary.BigEndian.Uint32(bin[len(bin)-4:])
+	actualChecksum := crc32.Checksum(bin[:len(bin)-4], crc32.IEEETable)
+	if actualChecksum != expectedChecksum {
+		return nil, fmt.Errorf("invalid checksum")
+	}
+
+	// The expected and actual versions must match.
+	version := binary.BigEndian.Uint32(bin[4:])
+	if version != envelopeVersion {
+		return nil, fmt.Errorf("unsupported version")
+	}
+
+	// Extract the ciphertext.
+	return bin[8 : len(bin)-4], nil
+}
+
+func encodeCiphertext(ciphertext []byte) string {
+	var b bytes.Buffer
+	b.WriteString(envelopeMagic)                                                            // "escx"
+	b.Write(binary.BigEndian.AppendUint32(nil, envelopeVersion))                            // version
+	b.Write(ciphertext)                                                                     // ciphertext
+	b.Write(binary.BigEndian.AppendUint32(nil, crc32.Checksum(b.Bytes(), crc32.IEEETable))) // crc32
+	return base64.StdEncoding.EncodeToString(b.Bytes())
+}

--- a/eval/crypt_test.go
+++ b/eval/crypt_test.go
@@ -1,0 +1,192 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eval
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"hash/crc32"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type rot128 struct{}
+
+func (rot128) Encrypt(_ context.Context, plaintext []byte) ([]byte, error) {
+	for i, b := range plaintext {
+		plaintext[i] = b + 128
+	}
+	return plaintext, nil
+}
+
+func (rot128) Decrypt(_ context.Context, plaintext []byte) ([]byte, error) {
+	for i, b := range plaintext {
+		plaintext[i] = b + 128
+	}
+	return plaintext, nil
+}
+
+func TestCrypt(t *testing.T) {
+	path := filepath.Join("testdata", "crypt")
+	entries, err := os.ReadDir(path)
+	require.NoError(t, err)
+	for _, e := range entries {
+		baseName, ok := strings.CutSuffix(e.Name(), ".plaintext.yaml")
+		if !ok {
+			continue
+		}
+
+		t.Run(e.Name(), func(t *testing.T) {
+			plaintextPath := filepath.Join(path, e.Name())
+			ciphertextPath := filepath.Join(path, baseName+".ciphertext.yaml")
+
+			plaintextBytes, err := os.ReadFile(plaintextPath)
+			require.NoError(t, err)
+
+			if accept() {
+				encrypted, err := EncryptSecrets(context.Background(), baseName, plaintextBytes, rot128{})
+				require.NoError(t, err)
+
+				err = os.WriteFile(ciphertextPath, encrypted, 0o600)
+				require.NoError(t, err)
+
+				decrypted, err := DecryptSecrets(context.Background(), baseName, encrypted, rot128{})
+				require.NoError(t, err)
+
+				err = os.WriteFile(plaintextPath, decrypted, 0o600)
+				require.NoError(t, err)
+
+				return
+			}
+
+			ciphertextBytes, err := os.ReadFile(ciphertextPath)
+			require.NoError(t, err)
+
+			encrypted, err := EncryptSecrets(context.Background(), baseName, plaintextBytes, rot128{})
+			require.NoError(t, err)
+
+			require.Equal(t, ciphertextBytes, encrypted)
+
+			decrypted, err := DecryptSecrets(context.Background(), baseName, encrypted, rot128{})
+			require.NoError(t, err)
+
+			assert.Equal(t, plaintextBytes, decrypted)
+		})
+	}
+}
+
+func TestDecryptInvalidBase64(t *testing.T) {
+	const doc = `values:
+  password:
+    fn::secret:
+      ciphertext: "********"
+`
+
+	_, err := DecryptSecrets(context.Background(), "doc", []byte(doc), rot128{})
+	assert.Error(t, err)
+}
+
+type broken struct{}
+
+func (broken) Encrypt(_ context.Context, plaintext []byte) ([]byte, error) {
+	return nil, errors.New("broken")
+}
+
+func (broken) Decrypt(_ context.Context, plaintext []byte) ([]byte, error) {
+	return nil, errors.New("broken")
+}
+
+func TestEncryptBroken(t *testing.T) {
+	const doc = `values:
+  password:
+    fn::secret: hunter2
+`
+
+	_, err := EncryptSecrets(context.Background(), "doc", []byte(doc), broken{})
+	assert.Error(t, err)
+}
+
+func TestDecryptBroken(t *testing.T) {
+	const doc = `values:
+  password:
+    fn::secret:
+      ciphertext: "aHVudGVyMg=="
+`
+
+	_, err := DecryptSecrets(context.Background(), "doc", []byte(doc), broken{})
+	assert.Error(t, err)
+}
+
+func TestEncryptMalformedSecret(t *testing.T) {
+	const doc = `values:
+  password:
+    fn::secret: [ array ]
+`
+
+	// Encryption and decryption ignore malformed secrets. Errors are reported if/when the environment is parsed.
+	_, err := EncryptSecrets(context.Background(), "doc", []byte(doc), broken{})
+	assert.NoError(t, err)
+}
+
+func TestDecryptMalformedSecret(t *testing.T) {
+	const doc = `values:
+  password:
+    fn::secret: [ array ]
+`
+
+	// Encryption and decryption ignore malformed secrets. Errors are reported if/when the environment is parsed.
+	_, err := EncryptSecrets(context.Background(), "doc", []byte(doc), broken{})
+	assert.NoError(t, err)
+}
+
+func TestInvalidEnvelope(t *testing.T) {
+	encodeBin := func(magic string, version uint32, ciphertext []byte) []byte {
+		var b bytes.Buffer
+		b.WriteString(magic)
+		b.Write(binary.BigEndian.AppendUint32(nil, version))                                    // version
+		b.Write(ciphertext)                                                                     // ciphertext
+		b.Write(binary.BigEndian.AppendUint32(nil, crc32.Checksum(b.Bytes(), crc32.IEEETable))) // crc32
+		return b.Bytes()
+	}
+	encode := func(magic string, version uint32, ciphertext []byte) string {
+		return base64.StdEncoding.EncodeToString(encodeBin(magic, version, ciphertext))
+	}
+
+	// Short
+	_, err := decodeCiphertext(base64.StdEncoding.EncodeToString([]byte("escx")))
+	assert.Error(t, err)
+
+	// Invalid magic
+	_, err = decodeCiphertext(encode("xcse", envelopeVersion, []byte("foo")))
+	assert.Error(t, err)
+
+	// Invalid version
+	_, err = decodeCiphertext(encode(envelopeMagic, 0, []byte("foo")))
+	assert.Error(t, err)
+
+	// Invalid checksum
+	bin := encodeBin(envelopeMagic, envelopeVersion, []byte("foo"))
+	bin[0] += 128
+	_, err = decodeCiphertext(base64.StdEncoding.EncodeToString(bin))
+	assert.Error(t, err)
+}

--- a/eval/testdata/crypt/omnibus.ciphertext.yaml
+++ b/eval/testdata/crypt/omnibus.ciphertext.yaml
@@ -1,0 +1,29 @@
+imports:
+  - a
+values:
+  fromBase64:
+    fn::fromBase64: ${toBase64}
+  fromJSON:
+    fn::fromJSON: ${toJSON}
+  join:
+    fn::join: [",", "${strings}"]
+  open:
+    fn::open::test:
+      a: null
+      b: true
+      c: 42
+      d: [hello]
+      baz: qux
+  secret:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAHo9e705fKyKo30VQ==
+  toBase64:
+    fn::toBase64: ${join}
+  toJSON:
+    fn::toJSON: ${open}
+  toString:
+    fn::toString: ${open}
+  open2:
+    fn::open::test: ${open}
+  interp: hello, ${toString}
+  access: ${open["baz"]}

--- a/eval/testdata/crypt/omnibus.plaintext.yaml
+++ b/eval/testdata/crypt/omnibus.plaintext.yaml
@@ -1,0 +1,28 @@
+imports:
+  - a
+values:
+  fromBase64:
+    fn::fromBase64: ${toBase64}
+  fromJSON:
+    fn::fromJSON: ${toJSON}
+  join:
+    fn::join: [",", "${strings}"]
+  open:
+    fn::open::test:
+      a: null
+      b: true
+      c: 42
+      d: [hello]
+      baz: qux
+  secret:
+    fn::secret: hunter2
+  toBase64:
+    fn::toBase64: ${join}
+  toJSON:
+    fn::toJSON: ${open}
+  toString:
+    fn::toString: ${open}
+  open2:
+    fn::open::test: ${open}
+  interp: hello, ${toString}
+  access: ${open["baz"]}

--- a/eval/testdata/crypt/open.ciphertext.yaml
+++ b/eval/testdata/crypt/open.ciphertext.yaml
@@ -1,0 +1,11 @@
+values:
+  aws:
+    creds:
+      fn::open::aws-login:
+        static:
+          accessKeyId: accessKeyId
+          secretAccessKey: {'fn::secret': {ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7}}
+  environmentVariables:
+    AWS_ACCESS_KEY_ID: ${aws.creds.accessKeyId}
+    AWS_SECRET_ACCESS_KEY: ${aws.creds.secretAccessKey}
+    AWS_SESSION_TOKEN: ${aws.creds.sessionToken}

--- a/eval/testdata/crypt/open.plaintext.yaml
+++ b/eval/testdata/crypt/open.plaintext.yaml
@@ -1,0 +1,11 @@
+values:
+  aws:
+    creds:
+      fn::open::aws-login:
+        static:
+          accessKeyId: accessKeyId
+          secretAccessKey: {'fn::secret': secretAccessKey}
+  environmentVariables:
+    AWS_ACCESS_KEY_ID: ${aws.creds.accessKeyId}
+    AWS_SECRET_ACCESS_KEY: ${aws.creds.secretAccessKey}
+    AWS_SESSION_TOKEN: ${aws.creds.sessionToken}

--- a/eval/testdata/crypt/trivia.ciphertext.yaml
+++ b/eval/testdata/crypt/trivia.ciphertext.yaml
@@ -1,0 +1,5 @@
+values:
+  password:
+    # Here's a header comment
+    fn::secret:
+      ciphertext: ZXNjeAAAAAHo9e705fKyKo30VQ== # Here's a line comment, too

--- a/eval/testdata/crypt/trivia.plaintext.yaml
+++ b/eval/testdata/crypt/trivia.plaintext.yaml
@@ -1,0 +1,4 @@
+values:
+  password:
+    # Here's a header comment
+    fn::secret: hunter2 # Here's a line comment, too

--- a/eval/testdata/eval/ciphertext-invalid/env.yaml
+++ b/eval/testdata/eval/ciphertext-invalid/env.yaml
@@ -1,0 +1,4 @@
+values:
+  password:
+    fn::secret:
+      ciphertext: hunter23

--- a/eval/testdata/eval/ciphertext-invalid/expected.json
+++ b/eval/testdata/eval/ciphertext-invalid/expected.json
@@ -1,0 +1,160 @@
+{
+    "checkDiags": [
+        {
+            "Severity": 1,
+            "Summary": "invalid ciphertext: EOF",
+            "Detail": "",
+            "Subject": {
+                "Filename": "ciphertext-invalid",
+                "Start": {
+                    "Line": 3,
+                    "Column": 5,
+                    "Byte": 24
+                },
+                "End": {
+                    "Line": 4,
+                    "Column": 27,
+                    "Byte": 62
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.password"
+        }
+    ],
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "invalid ciphertext: EOF",
+            "Detail": "",
+            "Subject": {
+                "Filename": "ciphertext-invalid",
+                "Start": {
+                    "Line": 3,
+                    "Column": 5,
+                    "Byte": 24
+                },
+                "End": {
+                    "Line": 4,
+                    "Column": 27,
+                    "Byte": 62
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.password"
+        }
+    ],
+    "environment": {
+        "exprs": {
+            "password": {
+                "range": {
+                    "environment": "ciphertext-invalid",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 24
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 27,
+                        "byte": 62
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "ciphertext-invalid",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 24
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 34
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "ciphertext-invalid",
+                            "begin": {
+                                "line": 4,
+                                "column": 7,
+                                "byte": 42
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 27,
+                                "byte": 62
+                            }
+                        },
+                        "object": {
+                            "ciphertext": {
+                                "range": {
+                                    "environment": "ciphertext-invalid",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 19,
+                                        "byte": 54
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 27,
+                                        "byte": 62
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "hunter23"
+                                },
+                                "literal": "hunter23"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "password": {
+                "secret": true,
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "ciphertext-invalid",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 24
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 27,
+                            "byte": 62
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "password": {
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "required": [
+                "password"
+            ]
+        }
+    }
+}

--- a/eval/testdata/eval/ciphertext/env.yaml
+++ b/eval/testdata/eval/ciphertext/env.yaml
@@ -1,0 +1,4 @@
+values:
+  password:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAHo9e705fKyKo30VQ==

--- a/eval/testdata/eval/ciphertext/expected.json
+++ b/eval/testdata/eval/ciphertext/expected.json
@@ -1,0 +1,110 @@
+{
+    "environment": {
+        "exprs": {
+            "password": {
+                "range": {
+                    "environment": "ciphertext",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 24
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 47,
+                        "byte": 82
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "ciphertext",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 24
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 34
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "ciphertext",
+                            "begin": {
+                                "line": 4,
+                                "column": 7,
+                                "byte": 42
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 47,
+                                "byte": 82
+                            }
+                        },
+                        "object": {
+                            "ciphertext": {
+                                "range": {
+                                    "environment": "ciphertext",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 19,
+                                        "byte": 54
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 47,
+                                        "byte": 82
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "ZXNjeAAAAAHo9e705fKyKo30VQ=="
+                                },
+                                "literal": "ZXNjeAAAAAHo9e705fKyKo30VQ=="
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "password": {
+                "value": "hunter2",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "ciphertext",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 24
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 47,
+                            "byte": 82
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "password": {
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "required": [
+                "password"
+            ]
+        }
+    }
+}

--- a/eval/testdata/eval/interp/env.yaml
+++ b/eval/testdata/eval/interp/env.yaml
@@ -2,8 +2,6 @@ values:
   a:
     p: ${a.q}
     q: foo
-    s: { fn::secret: [ shhhh ] }
-    t: { fn::secret: { password: hunter2 } }
     u: { "\"baz": merp }
   b:
     p: ${a.p}
@@ -14,8 +12,6 @@ values:
       - ${c.a[0]} bar
     b: world!
     s:
-      - ${a.s[0]}
-      - ${a.t.password}
       - ${a.u["\"baz"]}
       - ${["34"]}
       - ${["35"].okay}

--- a/eval/testdata/eval/interp/expected.json
+++ b/eval/testdata/eval/interp/expected.json
@@ -5,14 +5,14 @@
                 "range": {
                     "environment": "interp",
                     "begin": {
-                        "line": 22,
+                        "line": 18,
                         "column": 9,
-                        "byte": 367
+                        "byte": 247
                     },
                     "end": {
-                        "line": 22,
+                        "line": 18,
                         "column": 28,
-                        "byte": 386
+                        "byte": 266
                     }
                 },
                 "schema": {
@@ -25,14 +25,14 @@
                 "range": {
                     "environment": "interp",
                     "begin": {
-                        "line": 24,
+                        "line": 20,
                         "column": 5,
-                        "byte": 399
+                        "byte": 279
                     },
                     "end": {
-                        "line": 24,
+                        "line": 20,
                         "column": 20,
-                        "byte": 414
+                        "byte": 294
                     }
                 },
                 "schema": {
@@ -51,14 +51,14 @@
                     "okay": {
                         "environment": "interp",
                         "begin": {
-                            "line": 24,
+                            "line": 20,
                             "column": 5,
-                            "byte": 399
+                            "byte": 279
                         },
                         "end": {
-                            "line": 24,
+                            "line": 20,
                             "column": 9,
-                            "byte": 403
+                            "byte": 283
                         }
                     }
                 },
@@ -67,14 +67,14 @@
                         "range": {
                             "environment": "interp",
                             "begin": {
-                                "line": 24,
+                                "line": 20,
                                 "column": 11,
-                                "byte": 405
+                                "byte": 285
                             },
                             "end": {
-                                "line": 24,
+                                "line": 20,
                                 "column": 20,
-                                "byte": 414
+                                "byte": 294
                             }
                         },
                         "schema": {
@@ -94,9 +94,9 @@
                         "byte": 17
                     },
                     "end": {
-                        "line": 7,
+                        "line": 5,
                         "column": 23,
-                        "byte": 138
+                        "byte": 60
                     }
                 },
                 "schema": {
@@ -108,28 +108,6 @@
                         "q": {
                             "type": "string",
                             "const": "foo"
-                        },
-                        "s": {
-                            "prefixItems": [
-                                {
-                                    "type": "string",
-                                    "const": "shhhh"
-                                }
-                            ],
-                            "items": false,
-                            "type": "array"
-                        },
-                        "t": {
-                            "properties": {
-                                "password": {
-                                    "type": "string",
-                                    "const": "hunter2"
-                                }
-                            },
-                            "type": "object",
-                            "required": [
-                                "password"
-                            ]
                         },
                         "u": {
                             "properties": {
@@ -148,8 +126,6 @@
                     "required": [
                         "p",
                         "q",
-                        "s",
-                        "t",
                         "u"
                     ]
                 },
@@ -180,7 +156,7 @@
                             "byte": 32
                         }
                     },
-                    "s": {
+                    "u": {
                         "environment": "interp",
                         "begin": {
                             "line": 5,
@@ -191,32 +167,6 @@
                             "line": 5,
                             "column": 6,
                             "byte": 43
-                        }
-                    },
-                    "t": {
-                        "environment": "interp",
-                        "begin": {
-                            "line": 6,
-                            "column": 5,
-                            "byte": 75
-                        },
-                        "end": {
-                            "line": 6,
-                            "column": 6,
-                            "byte": 76
-                        }
-                    },
-                    "u": {
-                        "environment": "interp",
-                        "begin": {
-                            "line": 7,
-                            "column": 5,
-                            "byte": 120
-                        },
-                        "end": {
-                            "line": 7,
-                            "column": 6,
-                            "byte": 121
                         }
                     }
                 },
@@ -250,9 +200,9 @@
                                         "byte": 17
                                     },
                                     "end": {
-                                        "line": 7,
+                                        "line": 5,
                                         "column": 23,
-                                        "byte": 138
+                                        "byte": 60
                                     }
                                 }
                             },
@@ -294,7 +244,7 @@
                         },
                         "literal": "foo"
                     },
-                    "s": {
+                    "u": {
                         "range": {
                             "environment": "interp",
                             "begin": {
@@ -304,205 +254,8 @@
                             },
                             "end": {
                                 "line": 5,
-                                "column": 29,
-                                "byte": 66
-                            }
-                        },
-                        "schema": {
-                            "prefixItems": [
-                                {
-                                    "type": "string",
-                                    "const": "shhhh"
-                                }
-                            ],
-                            "items": false,
-                            "type": "array"
-                        },
-                        "builtin": {
-                            "name": "fn::secret",
-                            "nameRange": {
-                                "environment": "interp",
-                                "begin": {
-                                    "line": 5,
-                                    "column": 10,
-                                    "byte": 47
-                                },
-                                "end": {
-                                    "line": 5,
-                                    "column": 20,
-                                    "byte": 57
-                                }
-                            },
-                            "argSchema": true,
-                            "arg": {
-                                "range": {
-                                    "environment": "interp",
-                                    "begin": {
-                                        "line": 5,
-                                        "column": 22,
-                                        "byte": 59
-                                    },
-                                    "end": {
-                                        "line": 5,
-                                        "column": 29,
-                                        "byte": 66
-                                    }
-                                },
-                                "schema": {
-                                    "prefixItems": [
-                                        {
-                                            "type": "string",
-                                            "const": "shhhh"
-                                        }
-                                    ],
-                                    "items": false,
-                                    "type": "array"
-                                },
-                                "list": [
-                                    {
-                                        "range": {
-                                            "environment": "interp",
-                                            "begin": {
-                                                "line": 5,
-                                                "column": 24,
-                                                "byte": 61
-                                            },
-                                            "end": {
-                                                "line": 5,
-                                                "column": 29,
-                                                "byte": 66
-                                            }
-                                        },
-                                        "schema": {
-                                            "type": "string",
-                                            "const": "shhhh"
-                                        },
-                                        "literal": "shhhh"
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "t": {
-                        "range": {
-                            "environment": "interp",
-                            "begin": {
-                                "line": 6,
-                                "column": 8,
-                                "byte": 78
-                            },
-                            "end": {
-                                "line": 6,
-                                "column": 41,
-                                "byte": 111
-                            }
-                        },
-                        "schema": {
-                            "properties": {
-                                "password": {
-                                    "type": "string",
-                                    "const": "hunter2"
-                                }
-                            },
-                            "type": "object",
-                            "required": [
-                                "password"
-                            ]
-                        },
-                        "builtin": {
-                            "name": "fn::secret",
-                            "nameRange": {
-                                "environment": "interp",
-                                "begin": {
-                                    "line": 6,
-                                    "column": 10,
-                                    "byte": 80
-                                },
-                                "end": {
-                                    "line": 6,
-                                    "column": 20,
-                                    "byte": 90
-                                }
-                            },
-                            "argSchema": true,
-                            "arg": {
-                                "range": {
-                                    "environment": "interp",
-                                    "begin": {
-                                        "line": 6,
-                                        "column": 22,
-                                        "byte": 92
-                                    },
-                                    "end": {
-                                        "line": 6,
-                                        "column": 41,
-                                        "byte": 111
-                                    }
-                                },
-                                "schema": {
-                                    "properties": {
-                                        "password": {
-                                            "type": "string",
-                                            "const": "hunter2"
-                                        }
-                                    },
-                                    "type": "object",
-                                    "required": [
-                                        "password"
-                                    ]
-                                },
-                                "keyRanges": {
-                                    "password": {
-                                        "environment": "interp",
-                                        "begin": {
-                                            "line": 6,
-                                            "column": 24,
-                                            "byte": 94
-                                        },
-                                        "end": {
-                                            "line": 6,
-                                            "column": 32,
-                                            "byte": 102
-                                        }
-                                    }
-                                },
-                                "object": {
-                                    "password": {
-                                        "range": {
-                                            "environment": "interp",
-                                            "begin": {
-                                                "line": 6,
-                                                "column": 34,
-                                                "byte": 104
-                                            },
-                                            "end": {
-                                                "line": 6,
-                                                "column": 41,
-                                                "byte": 111
-                                            }
-                                        },
-                                        "schema": {
-                                            "type": "string",
-                                            "const": "hunter2"
-                                        },
-                                        "literal": "hunter2"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "u": {
-                        "range": {
-                            "environment": "interp",
-                            "begin": {
-                                "line": 7,
-                                "column": 8,
-                                "byte": 123
-                            },
-                            "end": {
-                                "line": 7,
                                 "column": 23,
-                                "byte": 138
+                                "byte": 60
                             }
                         },
                         "schema": {
@@ -521,14 +274,14 @@
                             "\"baz": {
                                 "environment": "interp",
                                 "begin": {
-                                    "line": 7,
+                                    "line": 5,
                                     "column": 10,
-                                    "byte": 125
+                                    "byte": 47
                                 },
                                 "end": {
-                                    "line": 7,
+                                    "line": 5,
                                     "column": 14,
-                                    "byte": 129
+                                    "byte": 51
                                 }
                             }
                         },
@@ -537,14 +290,14 @@
                                 "range": {
                                     "environment": "interp",
                                     "begin": {
-                                        "line": 7,
+                                        "line": 5,
                                         "column": 19,
-                                        "byte": 134
+                                        "byte": 56
                                     },
                                     "end": {
-                                        "line": 7,
+                                        "line": 5,
                                         "column": 23,
-                                        "byte": 138
+                                        "byte": 60
                                     }
                                 },
                                 "schema": {
@@ -561,14 +314,14 @@
                 "range": {
                     "environment": "interp",
                     "begin": {
-                        "line": 9,
+                        "line": 7,
                         "column": 5,
-                        "byte": 150
+                        "byte": 72
                     },
                     "end": {
-                        "line": 9,
+                        "line": 7,
                         "column": 14,
-                        "byte": 159
+                        "byte": 81
                     }
                 },
                 "schema": {
@@ -587,14 +340,14 @@
                     "p": {
                         "environment": "interp",
                         "begin": {
-                            "line": 9,
+                            "line": 7,
                             "column": 5,
-                            "byte": 150
+                            "byte": 72
                         },
                         "end": {
-                            "line": 9,
+                            "line": 7,
                             "column": 6,
-                            "byte": 151
+                            "byte": 73
                         }
                     }
                 },
@@ -603,14 +356,14 @@
                         "range": {
                             "environment": "interp",
                             "begin": {
-                                "line": 9,
+                                "line": 7,
                                 "column": 8,
-                                "byte": 153
+                                "byte": 75
                             },
                             "end": {
-                                "line": 9,
+                                "line": 7,
                                 "column": 14,
-                                "byte": 159
+                                "byte": 81
                             }
                         },
                         "schema": {
@@ -628,9 +381,9 @@
                                         "byte": 17
                                     },
                                     "end": {
-                                        "line": 7,
+                                        "line": 5,
                                         "column": 23,
-                                        "byte": 138
+                                        "byte": 60
                                     }
                                 }
                             },
@@ -658,14 +411,14 @@
                 "range": {
                     "environment": "interp",
                     "begin": {
-                        "line": 11,
+                        "line": 9,
                         "column": 5,
-                        "byte": 169
+                        "byte": 91
                     },
                     "end": {
-                        "line": 21,
+                        "line": 17,
                         "column": 23,
-                        "byte": 358
+                        "byte": 238
                     }
                 },
                 "schema": {
@@ -694,14 +447,6 @@
                             "prefixItems": [
                                 {
                                     "type": "string",
-                                    "const": "shhhh"
-                                },
-                                {
-                                    "type": "string",
-                                    "const": "hunter2"
-                                },
-                                {
-                                    "type": "string",
                                     "const": "merp"
                                 },
                                 {
@@ -728,40 +473,40 @@
                     "a": {
                         "environment": "interp",
                         "begin": {
-                            "line": 11,
+                            "line": 9,
                             "column": 5,
-                            "byte": 169
+                            "byte": 91
                         },
                         "end": {
-                            "line": 11,
+                            "line": 9,
                             "column": 6,
-                            "byte": 170
+                            "byte": 92
                         }
                     },
                     "b": {
                         "environment": "interp",
                         "begin": {
-                            "line": 15,
+                            "line": 13,
                             "column": 5,
-                            "byte": 235
+                            "byte": 157
                         },
                         "end": {
-                            "line": 15,
+                            "line": 13,
                             "column": 6,
-                            "byte": 236
+                            "byte": 158
                         }
                     },
                     "s": {
                         "environment": "interp",
                         "begin": {
-                            "line": 16,
+                            "line": 14,
                             "column": 5,
-                            "byte": 249
+                            "byte": 171
                         },
                         "end": {
-                            "line": 16,
+                            "line": 14,
                             "column": 6,
-                            "byte": 250
+                            "byte": 172
                         }
                     }
                 },
@@ -770,14 +515,14 @@
                         "range": {
                             "environment": "interp",
                             "begin": {
-                                "line": 12,
+                                "line": 10,
                                 "column": 7,
-                                "byte": 178
+                                "byte": 100
                             },
                             "end": {
-                                "line": 14,
+                                "line": 12,
                                 "column": 22,
-                                "byte": 230
+                                "byte": 152
                             }
                         },
                         "schema": {
@@ -801,14 +546,14 @@
                                 "range": {
                                     "environment": "interp",
                                     "begin": {
-                                        "line": 12,
+                                        "line": 10,
                                         "column": 9,
-                                        "byte": 180
+                                        "byte": 102
                                     },
                                     "end": {
-                                        "line": 12,
+                                        "line": 10,
                                         "column": 15,
-                                        "byte": 186
+                                        "byte": 108
                                     }
                                 },
                                 "schema": {
@@ -821,14 +566,14 @@
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
-                                                "line": 9,
+                                                "line": 7,
                                                 "column": 5,
-                                                "byte": 150
+                                                "byte": 72
                                             },
                                             "end": {
-                                                "line": 9,
+                                                "line": 7,
                                                 "column": 14,
-                                                "byte": 159
+                                                "byte": 81
                                             }
                                         }
                                     },
@@ -837,14 +582,14 @@
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
-                                                "line": 9,
+                                                "line": 7,
                                                 "column": 8,
-                                                "byte": 153
+                                                "byte": 75
                                             },
                                             "end": {
-                                                "line": 9,
+                                                "line": 7,
                                                 "column": 14,
-                                                "byte": 159
+                                                "byte": 81
                                             }
                                         }
                                     }
@@ -854,14 +599,14 @@
                                 "range": {
                                     "environment": "interp",
                                     "begin": {
-                                        "line": 13,
+                                        "line": 11,
                                         "column": 9,
-                                        "byte": 195
+                                        "byte": 117
                                     },
                                     "end": {
-                                        "line": 13,
+                                        "line": 11,
                                         "column": 22,
-                                        "byte": 208
+                                        "byte": 130
                                     }
                                 },
                                 "schema": {
@@ -876,14 +621,14 @@
                                                 "value": {
                                                     "environment": "interp",
                                                     "begin": {
-                                                        "line": 11,
+                                                        "line": 9,
                                                         "column": 5,
-                                                        "byte": 169
+                                                        "byte": 91
                                                     },
                                                     "end": {
-                                                        "line": 21,
+                                                        "line": 17,
                                                         "column": 23,
-                                                        "byte": 358
+                                                        "byte": 238
                                                     }
                                                 }
                                             },
@@ -892,14 +637,14 @@
                                                 "value": {
                                                     "environment": "interp",
                                                     "begin": {
-                                                        "line": 15,
+                                                        "line": 13,
                                                         "column": 8,
-                                                        "byte": 238
+                                                        "byte": 160
                                                     },
                                                     "end": {
-                                                        "line": 15,
+                                                        "line": 13,
                                                         "column": 14,
-                                                        "byte": 244
+                                                        "byte": 166
                                                     }
                                                 }
                                             }
@@ -911,14 +656,14 @@
                                 "range": {
                                     "environment": "interp",
                                     "begin": {
-                                        "line": 14,
+                                        "line": 12,
                                         "column": 9,
-                                        "byte": 217
+                                        "byte": 139
                                     },
                                     "end": {
-                                        "line": 14,
+                                        "line": 12,
                                         "column": 22,
-                                        "byte": 230
+                                        "byte": 152
                                     }
                                 },
                                 "schema": {
@@ -932,14 +677,14 @@
                                                 "value": {
                                                     "environment": "interp",
                                                     "begin": {
-                                                        "line": 11,
+                                                        "line": 9,
                                                         "column": 5,
-                                                        "byte": 169
+                                                        "byte": 91
                                                     },
                                                     "end": {
-                                                        "line": 21,
+                                                        "line": 17,
                                                         "column": 23,
-                                                        "byte": 358
+                                                        "byte": 238
                                                     }
                                                 }
                                             },
@@ -948,14 +693,14 @@
                                                 "value": {
                                                     "environment": "interp",
                                                     "begin": {
-                                                        "line": 12,
+                                                        "line": 10,
                                                         "column": 7,
-                                                        "byte": 178
+                                                        "byte": 100
                                                     },
                                                     "end": {
-                                                        "line": 14,
+                                                        "line": 12,
                                                         "column": 22,
-                                                        "byte": 230
+                                                        "byte": 152
                                                     }
                                                 }
                                             },
@@ -964,14 +709,14 @@
                                                 "value": {
                                                     "environment": "interp",
                                                     "begin": {
-                                                        "line": 12,
+                                                        "line": 10,
                                                         "column": 9,
-                                                        "byte": 180
+                                                        "byte": 102
                                                     },
                                                     "end": {
-                                                        "line": 12,
+                                                        "line": 10,
                                                         "column": 15,
-                                                        "byte": 186
+                                                        "byte": 108
                                                     }
                                                 }
                                             }
@@ -988,14 +733,14 @@
                         "range": {
                             "environment": "interp",
                             "begin": {
-                                "line": 15,
+                                "line": 13,
                                 "column": 8,
-                                "byte": 238
+                                "byte": 160
                             },
                             "end": {
-                                "line": 15,
+                                "line": 13,
                                 "column": 14,
-                                "byte": 244
+                                "byte": 166
                             }
                         },
                         "schema": {
@@ -1008,26 +753,18 @@
                         "range": {
                             "environment": "interp",
                             "begin": {
-                                "line": 17,
+                                "line": 15,
                                 "column": 7,
-                                "byte": 258
+                                "byte": 180
                             },
                             "end": {
-                                "line": 21,
+                                "line": 17,
                                 "column": 23,
-                                "byte": 358
+                                "byte": 238
                             }
                         },
                         "schema": {
                             "prefixItems": [
-                                {
-                                    "type": "string",
-                                    "const": "shhhh"
-                                },
-                                {
-                                    "type": "string",
-                                    "const": "hunter2"
-                                },
                                 {
                                     "type": "string",
                                     "const": "merp"
@@ -1049,152 +786,14 @@
                                 "range": {
                                     "environment": "interp",
                                     "begin": {
-                                        "line": 17,
+                                        "line": 15,
                                         "column": 9,
-                                        "byte": 260
+                                        "byte": 182
                                     },
                                     "end": {
-                                        "line": 17,
-                                        "column": 18,
-                                        "byte": 269
-                                    }
-                                },
-                                "schema": {
-                                    "type": "string",
-                                    "const": "shhhh"
-                                },
-                                "symbol": [
-                                    {
-                                        "key": "a",
-                                        "value": {
-                                            "environment": "interp",
-                                            "begin": {
-                                                "line": 3,
-                                                "column": 5,
-                                                "byte": 17
-                                            },
-                                            "end": {
-                                                "line": 7,
-                                                "column": 23,
-                                                "byte": 138
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "key": "s",
-                                        "value": {
-                                            "environment": "interp",
-                                            "begin": {
-                                                "line": 5,
-                                                "column": 8,
-                                                "byte": 45
-                                            },
-                                            "end": {
-                                                "line": 5,
-                                                "column": 29,
-                                                "byte": 66
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "index": 0,
-                                        "value": {
-                                            "environment": "interp",
-                                            "begin": {
-                                                "line": 5,
-                                                "column": 24,
-                                                "byte": 61
-                                            },
-                                            "end": {
-                                                "line": 5,
-                                                "column": 29,
-                                                "byte": 66
-                                            }
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "range": {
-                                    "environment": "interp",
-                                    "begin": {
-                                        "line": 18,
-                                        "column": 9,
-                                        "byte": 278
-                                    },
-                                    "end": {
-                                        "line": 18,
+                                        "line": 15,
                                         "column": 24,
-                                        "byte": 293
-                                    }
-                                },
-                                "schema": {
-                                    "type": "string",
-                                    "const": "hunter2"
-                                },
-                                "symbol": [
-                                    {
-                                        "key": "a",
-                                        "value": {
-                                            "environment": "interp",
-                                            "begin": {
-                                                "line": 3,
-                                                "column": 5,
-                                                "byte": 17
-                                            },
-                                            "end": {
-                                                "line": 7,
-                                                "column": 23,
-                                                "byte": 138
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "key": "t",
-                                        "value": {
-                                            "environment": "interp",
-                                            "begin": {
-                                                "line": 6,
-                                                "column": 8,
-                                                "byte": 78
-                                            },
-                                            "end": {
-                                                "line": 6,
-                                                "column": 41,
-                                                "byte": 111
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "key": "password",
-                                        "value": {
-                                            "environment": "interp",
-                                            "begin": {
-                                                "line": 6,
-                                                "column": 34,
-                                                "byte": 104
-                                            },
-                                            "end": {
-                                                "line": 6,
-                                                "column": 41,
-                                                "byte": 111
-                                            }
-                                        }
-                                    }
-                                ]
-                            },
-                            {
-                                "range": {
-                                    "environment": "interp",
-                                    "begin": {
-                                        "line": 19,
-                                        "column": 9,
-                                        "byte": 302
-                                    },
-                                    "end": {
-                                        "line": 19,
-                                        "column": 24,
-                                        "byte": 317
+                                        "byte": 197
                                     }
                                 },
                                 "schema": {
@@ -1212,9 +811,9 @@
                                                 "byte": 17
                                             },
                                             "end": {
-                                                "line": 7,
+                                                "line": 5,
                                                 "column": 23,
-                                                "byte": 138
+                                                "byte": 60
                                             }
                                         }
                                     },
@@ -1223,14 +822,14 @@
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
-                                                "line": 7,
+                                                "line": 5,
                                                 "column": 8,
-                                                "byte": 123
+                                                "byte": 45
                                             },
                                             "end": {
-                                                "line": 7,
+                                                "line": 5,
                                                 "column": 23,
-                                                "byte": 138
+                                                "byte": 60
                                             }
                                         }
                                     },
@@ -1239,14 +838,14 @@
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
-                                                "line": 7,
+                                                "line": 5,
                                                 "column": 19,
-                                                "byte": 134
+                                                "byte": 56
                                             },
                                             "end": {
-                                                "line": 7,
+                                                "line": 5,
                                                 "column": 23,
-                                                "byte": 138
+                                                "byte": 60
                                             }
                                         }
                                     }
@@ -1256,14 +855,14 @@
                                 "range": {
                                     "environment": "interp",
                                     "begin": {
-                                        "line": 20,
+                                        "line": 16,
                                         "column": 9,
-                                        "byte": 326
+                                        "byte": 206
                                     },
                                     "end": {
-                                        "line": 20,
+                                        "line": 16,
                                         "column": 18,
-                                        "byte": 335
+                                        "byte": 215
                                     }
                                 },
                                 "schema": {
@@ -1276,14 +875,14 @@
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
-                                                "line": 22,
+                                                "line": 18,
                                                 "column": 9,
-                                                "byte": 367
+                                                "byte": 247
                                             },
                                             "end": {
-                                                "line": 22,
+                                                "line": 18,
                                                 "column": 28,
-                                                "byte": 386
+                                                "byte": 266
                                             }
                                         }
                                     }
@@ -1293,14 +892,14 @@
                                 "range": {
                                     "environment": "interp",
                                     "begin": {
-                                        "line": 21,
+                                        "line": 17,
                                         "column": 9,
-                                        "byte": 344
+                                        "byte": 224
                                     },
                                     "end": {
-                                        "line": 21,
+                                        "line": 17,
                                         "column": 23,
-                                        "byte": 358
+                                        "byte": 238
                                     }
                                 },
                                 "schema": {
@@ -1313,14 +912,14 @@
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
-                                                "line": 24,
+                                                "line": 20,
                                                 "column": 5,
-                                                "byte": 399
+                                                "byte": 279
                                             },
                                             "end": {
-                                                "line": 24,
+                                                "line": 20,
                                                 "column": 20,
-                                                "byte": 414
+                                                "byte": 294
                                             }
                                         }
                                     },
@@ -1329,14 +928,14 @@
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
-                                                "line": 24,
+                                                "line": 20,
                                                 "column": 11,
-                                                "byte": 405
+                                                "byte": 285
                                             },
                                             "end": {
-                                                "line": 24,
+                                                "line": 20,
                                                 "column": 20,
-                                                "byte": 414
+                                                "byte": 294
                                             }
                                         }
                                     }
@@ -1354,14 +953,14 @@
                     "def": {
                         "environment": "interp",
                         "begin": {
-                            "line": 22,
+                            "line": 18,
                             "column": 9,
-                            "byte": 367
+                            "byte": 247
                         },
                         "end": {
-                            "line": 22,
+                            "line": 18,
                             "column": 28,
-                            "byte": 386
+                            "byte": 266
                         }
                     }
                 }
@@ -1374,14 +973,14 @@
                             "def": {
                                 "environment": "interp",
                                 "begin": {
-                                    "line": 24,
+                                    "line": 20,
                                     "column": 11,
-                                    "byte": 405
+                                    "byte": 285
                                 },
                                 "end": {
-                                    "line": 24,
+                                    "line": 20,
                                     "column": 20,
-                                    "byte": 414
+                                    "byte": 294
                                 }
                             }
                         }
@@ -1391,14 +990,14 @@
                     "def": {
                         "environment": "interp",
                         "begin": {
-                            "line": 24,
+                            "line": 20,
                             "column": 5,
-                            "byte": 399
+                            "byte": 279
                         },
                         "end": {
-                            "line": 24,
+                            "line": 20,
                             "column": 20,
-                            "byte": 414
+                            "byte": 294
                         }
                     }
                 }
@@ -1441,82 +1040,6 @@
                             }
                         }
                     },
-                    "s": {
-                        "value": [
-                            {
-                                "value": "shhhh",
-                                "trace": {
-                                    "def": {
-                                        "environment": "interp",
-                                        "begin": {
-                                            "line": 5,
-                                            "column": 24,
-                                            "byte": 61
-                                        },
-                                        "end": {
-                                            "line": 5,
-                                            "column": 29,
-                                            "byte": 66
-                                        }
-                                    }
-                                }
-                            }
-                        ],
-                        "secret": true,
-                        "trace": {
-                            "def": {
-                                "environment": "interp",
-                                "begin": {
-                                    "line": 5,
-                                    "column": 22,
-                                    "byte": 59
-                                },
-                                "end": {
-                                    "line": 5,
-                                    "column": 29,
-                                    "byte": 66
-                                }
-                            }
-                        }
-                    },
-                    "t": {
-                        "value": {
-                            "password": {
-                                "value": "hunter2",
-                                "trace": {
-                                    "def": {
-                                        "environment": "interp",
-                                        "begin": {
-                                            "line": 6,
-                                            "column": 34,
-                                            "byte": 104
-                                        },
-                                        "end": {
-                                            "line": 6,
-                                            "column": 41,
-                                            "byte": 111
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "secret": true,
-                        "trace": {
-                            "def": {
-                                "environment": "interp",
-                                "begin": {
-                                    "line": 6,
-                                    "column": 22,
-                                    "byte": 92
-                                },
-                                "end": {
-                                    "line": 6,
-                                    "column": 41,
-                                    "byte": 111
-                                }
-                            }
-                        }
-                    },
                     "u": {
                         "value": {
                             "\"baz": {
@@ -1525,14 +1048,14 @@
                                     "def": {
                                         "environment": "interp",
                                         "begin": {
-                                            "line": 7,
+                                            "line": 5,
                                             "column": 19,
-                                            "byte": 134
+                                            "byte": 56
                                         },
                                         "end": {
-                                            "line": 7,
+                                            "line": 5,
                                             "column": 23,
-                                            "byte": 138
+                                            "byte": 60
                                         }
                                     }
                                 }
@@ -1542,20 +1065,19 @@
                             "def": {
                                 "environment": "interp",
                                 "begin": {
-                                    "line": 7,
+                                    "line": 5,
                                     "column": 8,
-                                    "byte": 123
+                                    "byte": 45
                                 },
                                 "end": {
-                                    "line": 7,
+                                    "line": 5,
                                     "column": 23,
-                                    "byte": 138
+                                    "byte": 60
                                 }
                             }
                         }
                     }
                 },
-                "secret": true,
                 "trace": {
                     "def": {
                         "environment": "interp",
@@ -1565,9 +1087,9 @@
                             "byte": 17
                         },
                         "end": {
-                            "line": 7,
+                            "line": 5,
                             "column": 23,
-                            "byte": 138
+                            "byte": 60
                         }
                     }
                 }
@@ -1580,14 +1102,14 @@
                             "def": {
                                 "environment": "interp",
                                 "begin": {
-                                    "line": 9,
+                                    "line": 7,
                                     "column": 8,
-                                    "byte": 153
+                                    "byte": 75
                                 },
                                 "end": {
-                                    "line": 9,
+                                    "line": 7,
                                     "column": 14,
-                                    "byte": 159
+                                    "byte": 81
                                 }
                             }
                         }
@@ -1597,14 +1119,14 @@
                     "def": {
                         "environment": "interp",
                         "begin": {
-                            "line": 9,
+                            "line": 7,
                             "column": 5,
-                            "byte": 150
+                            "byte": 72
                         },
                         "end": {
-                            "line": 9,
+                            "line": 7,
                             "column": 14,
-                            "byte": 159
+                            "byte": 81
                         }
                     }
                 }
@@ -1619,14 +1141,14 @@
                                     "def": {
                                         "environment": "interp",
                                         "begin": {
-                                            "line": 12,
+                                            "line": 10,
                                             "column": 9,
-                                            "byte": 180
+                                            "byte": 102
                                         },
                                         "end": {
-                                            "line": 12,
+                                            "line": 10,
                                             "column": 15,
-                                            "byte": 186
+                                            "byte": 108
                                         }
                                     }
                                 }
@@ -1637,14 +1159,14 @@
                                     "def": {
                                         "environment": "interp",
                                         "begin": {
-                                            "line": 13,
+                                            "line": 11,
                                             "column": 9,
-                                            "byte": 195
+                                            "byte": 117
                                         },
                                         "end": {
-                                            "line": 13,
+                                            "line": 11,
                                             "column": 22,
-                                            "byte": 208
+                                            "byte": 130
                                         }
                                     }
                                 }
@@ -1655,14 +1177,14 @@
                                     "def": {
                                         "environment": "interp",
                                         "begin": {
-                                            "line": 14,
+                                            "line": 12,
                                             "column": 9,
-                                            "byte": 217
+                                            "byte": 139
                                         },
                                         "end": {
-                                            "line": 14,
+                                            "line": 12,
                                             "column": 22,
-                                            "byte": 230
+                                            "byte": 152
                                         }
                                     }
                                 }
@@ -1672,14 +1194,14 @@
                             "def": {
                                 "environment": "interp",
                                 "begin": {
-                                    "line": 12,
+                                    "line": 10,
                                     "column": 7,
-                                    "byte": 178
+                                    "byte": 100
                                 },
                                 "end": {
-                                    "line": 14,
+                                    "line": 12,
                                     "column": 22,
-                                    "byte": 230
+                                    "byte": 152
                                 }
                             }
                         }
@@ -1690,14 +1212,14 @@
                             "def": {
                                 "environment": "interp",
                                 "begin": {
-                                    "line": 15,
+                                    "line": 13,
                                     "column": 8,
-                                    "byte": 238
+                                    "byte": 160
                                 },
                                 "end": {
-                                    "line": 15,
+                                    "line": 13,
                                     "column": 14,
-                                    "byte": 244
+                                    "byte": 166
                                 }
                             }
                         }
@@ -1705,55 +1227,19 @@
                     "s": {
                         "value": [
                             {
-                                "value": "shhhh",
-                                "trace": {
-                                    "def": {
-                                        "environment": "interp",
-                                        "begin": {
-                                            "line": 17,
-                                            "column": 9,
-                                            "byte": 260
-                                        },
-                                        "end": {
-                                            "line": 17,
-                                            "column": 18,
-                                            "byte": 269
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "value": "hunter2",
-                                "trace": {
-                                    "def": {
-                                        "environment": "interp",
-                                        "begin": {
-                                            "line": 18,
-                                            "column": 9,
-                                            "byte": 278
-                                        },
-                                        "end": {
-                                            "line": 18,
-                                            "column": 24,
-                                            "byte": 293
-                                        }
-                                    }
-                                }
-                            },
-                            {
                                 "value": "merp",
                                 "trace": {
                                     "def": {
                                         "environment": "interp",
                                         "begin": {
-                                            "line": 19,
+                                            "line": 15,
                                             "column": 9,
-                                            "byte": 302
+                                            "byte": 182
                                         },
                                         "end": {
-                                            "line": 19,
+                                            "line": 15,
                                             "column": 24,
-                                            "byte": 317
+                                            "byte": 197
                                         }
                                     }
                                 }
@@ -1764,14 +1250,14 @@
                                     "def": {
                                         "environment": "interp",
                                         "begin": {
-                                            "line": 20,
+                                            "line": 16,
                                             "column": 9,
-                                            "byte": 326
+                                            "byte": 206
                                         },
                                         "end": {
-                                            "line": 20,
+                                            "line": 16,
                                             "column": 18,
-                                            "byte": 335
+                                            "byte": 215
                                         }
                                     }
                                 }
@@ -1782,14 +1268,14 @@
                                     "def": {
                                         "environment": "interp",
                                         "begin": {
-                                            "line": 21,
+                                            "line": 17,
                                             "column": 9,
-                                            "byte": 344
+                                            "byte": 224
                                         },
                                         "end": {
-                                            "line": 21,
+                                            "line": 17,
                                             "column": 23,
-                                            "byte": 358
+                                            "byte": 238
                                         }
                                     }
                                 }
@@ -1799,14 +1285,14 @@
                             "def": {
                                 "environment": "interp",
                                 "begin": {
-                                    "line": 17,
+                                    "line": 15,
                                     "column": 7,
-                                    "byte": 258
+                                    "byte": 180
                                 },
                                 "end": {
-                                    "line": 21,
+                                    "line": 17,
                                     "column": 23,
-                                    "byte": 358
+                                    "byte": 238
                                 }
                             }
                         }
@@ -1816,14 +1302,14 @@
                     "def": {
                         "environment": "interp",
                         "begin": {
-                            "line": 11,
+                            "line": 9,
                             "column": 5,
-                            "byte": 169
+                            "byte": 91
                         },
                         "end": {
-                            "line": 21,
+                            "line": 17,
                             "column": 23,
-                            "byte": 358
+                            "byte": 238
                         }
                     }
                 }
@@ -1857,28 +1343,6 @@
                             "type": "string",
                             "const": "foo"
                         },
-                        "s": {
-                            "prefixItems": [
-                                {
-                                    "type": "string",
-                                    "const": "shhhh"
-                                }
-                            ],
-                            "items": false,
-                            "type": "array"
-                        },
-                        "t": {
-                            "properties": {
-                                "password": {
-                                    "type": "string",
-                                    "const": "hunter2"
-                                }
-                            },
-                            "type": "object",
-                            "required": [
-                                "password"
-                            ]
-                        },
                         "u": {
                             "properties": {
                                 "\"baz": {
@@ -1896,8 +1360,6 @@
                     "required": [
                         "p",
                         "q",
-                        "s",
-                        "t",
                         "u"
                     ]
                 },
@@ -1937,14 +1399,6 @@
                         },
                         "s": {
                             "prefixItems": [
-                                {
-                                    "type": "string",
-                                    "const": "shhhh"
-                                },
-                                {
-                                    "type": "string",
-                                    "const": "hunter2"
-                                },
                                 {
                                     "type": "string",
                                     "const": "merp"

--- a/eval/testdata/eval/plaintext/env.yaml
+++ b/eval/testdata/eval/plaintext/env.yaml
@@ -1,0 +1,3 @@
+values:
+  password:
+    fn::secret: hunter2

--- a/eval/testdata/eval/plaintext/expected.json
+++ b/eval/testdata/eval/plaintext/expected.json
@@ -1,0 +1,95 @@
+{
+    "environment": {
+        "exprs": {
+            "password": {
+                "range": {
+                    "environment": "plaintext",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 24
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 24,
+                        "byte": 43
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "hunter2"
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "plaintext",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 24
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 34
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "plaintext",
+                            "begin": {
+                                "line": 3,
+                                "column": 17,
+                                "byte": 36
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 24,
+                                "byte": 43
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "hunter2"
+                        },
+                        "literal": "hunter2"
+                    }
+                }
+            }
+        },
+        "properties": {
+            "password": {
+                "value": "hunter2",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "plaintext",
+                        "begin": {
+                            "line": 3,
+                            "column": 17,
+                            "byte": 36
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 24,
+                            "byte": 43
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "password": {
+                    "type": "string",
+                    "const": "hunter2"
+                }
+            },
+            "type": "object",
+            "required": [
+                "password"
+            ]
+        }
+    }
+}

--- a/syntax/encoding/testdata/yaml/top-level-array/decoded.json
+++ b/syntax/encoding/testdata/yaml/top-level-array/decoded.json
@@ -1,15 +1,67 @@
 {
-    "diags": [
-        {
-            "Severity": 1,
-            "Summary": "Top level of 'top-level-array' must be an object",
-            "Detail": "",
-            "Subject": null,
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": ""
+    "syntax": {
+        "array": [
+            {
+                "literal": "list",
+                "range": {
+                    "Filename": "top-level-array",
+                    "Start": {
+                        "Line": 1,
+                        "Column": 3,
+                        "Byte": 2
+                    },
+                    "End": {
+                        "Line": 1,
+                        "Column": 7,
+                        "Byte": 6
+                    }
+                }
+            },
+            {
+                "literal": "of",
+                "range": {
+                    "Filename": "top-level-array",
+                    "Start": {
+                        "Line": 2,
+                        "Column": 3,
+                        "Byte": 9
+                    },
+                    "End": {
+                        "Line": 2,
+                        "Column": 5,
+                        "Byte": 11
+                    }
+                }
+            },
+            {
+                "literal": "values",
+                "range": {
+                    "Filename": "top-level-array",
+                    "Start": {
+                        "Line": 3,
+                        "Column": 3,
+                        "Byte": 14
+                    },
+                    "End": {
+                        "Line": 3,
+                        "Column": 9,
+                        "Byte": 20
+                    }
+                }
+            }
+        ],
+        "range": {
+            "Filename": "top-level-array",
+            "Start": {
+                "Line": 1,
+                "Column": 1,
+                "Byte": 0
+            },
+            "End": {
+                "Line": 3,
+                "Column": 9,
+                "Byte": 20
+            }
         }
-    ]
+    }
 }

--- a/syntax/encoding/testdata/yaml/top-level-array/encoded.yaml
+++ b/syntax/encoding/testdata/yaml/top-level-array/encoded.yaml
@@ -1,0 +1,3 @@
+- list
+- of
+- values

--- a/syntax/encoding/yaml_test.go
+++ b/syntax/encoding/yaml_test.go
@@ -161,8 +161,10 @@ baz: qux
 baz: qux
 `
 
-	root, diags := DecodeYAML("yaml", yaml.NewDecoder(strings.NewReader(doc)), nil)
+	rootNode, diags := DecodeYAML("yaml", yaml.NewDecoder(strings.NewReader(doc)), nil)
 	assert.Empty(t, diags)
+
+	root := rootNode.(*syntax.ObjectNode)
 
 	root.SetIndex(0, syntax.ObjectProperty(syntax.String("foo"), syntax.NumberSyntax(root.Index(0).Value.Syntax(), 42)))
 	root.SetIndex(1, syntax.ObjectProperty(syntax.StringSyntax(comment("head comment"), "baz"), syntax.String("qux")))

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -42,3 +42,41 @@ type Trivia interface {
 	LineComment() string
 	FootComment() string
 }
+
+type triviaSyntax struct {
+	headComment string
+	lineComment string
+	footComment string
+}
+
+func (s triviaSyntax) Range() *hcl.Range {
+	return nil
+}
+
+func (s triviaSyntax) Path() string {
+	return ""
+}
+
+func (s triviaSyntax) HeadComment() string {
+	return s.headComment
+}
+
+func (s triviaSyntax) LineComment() string {
+	return s.lineComment
+}
+
+func (s triviaSyntax) FootComment() string {
+	return s.footComment
+}
+
+func CopyTrivia(s Syntax) Syntax {
+	trivia, ok := s.(Trivia)
+	if !ok {
+		return NoSyntax
+	}
+	return triviaSyntax{
+		headComment: trivia.HeadComment(),
+		lineComment: trivia.LineComment(),
+		footComment: trivia.FootComment(),
+	}
+}

--- a/syntax/walk.go
+++ b/syntax/walk.go
@@ -1,0 +1,45 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntax
+
+// Walk recursively walks the tree rooted at the given node. The visitor is called after the Node's descendants have
+// been walked (i.e. visitation is post-order).
+func Walk(n Node, visitor func(n Node) (Node, Diagnostics, error)) (Node, Diagnostics, error) {
+	var diags Diagnostics
+	switch n := n.(type) {
+	case *ArrayNode:
+		for i, e := range n.elements {
+			m, d, err := Walk(e, visitor)
+			diags.Extend(d...)
+			if err != nil {
+				return nil, diags, err
+			}
+			n.elements[i] = m
+		}
+	case *ObjectNode:
+		for i, e := range n.entries {
+			v, d, err := Walk(e.Value, visitor)
+			diags.Extend(d...)
+			if err != nil {
+				return nil, diags, err
+			}
+			n.entries[i] = ObjectProperty(e.Key, v)
+		}
+	}
+
+	n, d, err := visitor(n)
+	diags.Extend(d...)
+	return n, diags, err
+}


### PR DESCRIPTION
These changes add support for encrypting and decrypting static secrets in environment definitions. Encryprtion and decryption is handled as a pre-evaluation pass. The parser expects secrets to be decrypted prior to parsing, and will issue errors if it detects encrypted secrets.

Encrypted secrets are represented in the document by calls to `fn::secret` of the form

```yaml
fn::secret:
  ciphertext: <base64-encoded value>
```

In order to support this representation, `fn::secret` now requires that its argument is a string literal.