### PR TITLE
syntax: diags coverage

### DIFF
--- a/ast/expr.go
+++ b/ast/expr.go
@@ -591,7 +591,7 @@ func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) 
 		}
 
 		if strings.HasPrefix(strings.ToLower(kvp.Key.Value()), "fn::") {
-			diags = append(diags, syntax.Warning(kvp.Key.Syntax().Range(),
+			diags = append(diags, syntax.Error(kvp.Key.Syntax().Range(),
 				"'fn::' is a reserved prefix",
 				fmt.Sprintf("If you need to use the raw key '%s',"+
 					" please open an issue at https://github.com/pulumi/pulumi-yaml/issues", kvp.Key.Value())))

--- a/syntax/diags.go
+++ b/syntax/diags.go
@@ -24,31 +24,6 @@ import (
 // A Diagnostic represents a warning or an error to be presented to the user.
 type Diagnostic struct {
 	hcl.Diagnostic
-
-	// Whether the diagnostic has been shown to the user
-	Shown bool
-}
-
-// WithContext adds context without mutating the receiver.
-func (d Diagnostic) WithContext(rng *hcl.Range) *Diagnostic {
-	d.Context = rng
-	return &d
-}
-
-func (d Diagnostic) HCL() *hcl.Diagnostic {
-	return &d.Diagnostic
-}
-
-// Warning creates a new warning-level diagnostic from the given subject, summary, and detail.
-func Warning(rng *hcl.Range, summary, detail string) *Diagnostic {
-	return &Diagnostic{
-		Diagnostic: hcl.Diagnostic{
-			Severity: hcl.DiagWarning,
-			Subject:  rng,
-			Summary:  summary,
-			Detail:   detail,
-		},
-	}
 }
 
 // Error creates a new error-level diagnostic from the given subject, summary, and detail.
@@ -114,25 +89,4 @@ func (d *Diagnostics) Extend(diags ...*Diagnostic) {
 			}
 		}
 	}
-}
-
-func (d *Diagnostics) HCL() hcl.Diagnostics {
-	if d == nil {
-		return nil
-	}
-	a := make(hcl.Diagnostics, 0, len(*d))
-	for _, diag := range *d {
-		a = append(a, diag.HCL())
-	}
-	return a
-}
-
-func (d Diagnostics) Unshown() *Diagnostics {
-	diags := Diagnostics{}
-	for _, diag := range d {
-		if !diag.Shown {
-			diags = append(diags, diag)
-		}
-	}
-	return &diags
 }

--- a/syntax/diags_test.go
+++ b/syntax/diags_test.go
@@ -1,0 +1,40 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntax
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiagsError(t *testing.T) {
+	t.Run("none", func(t *testing.T) {
+		assert.Equal(t, "no diagnostics", Diagnostics{}.Error())
+	})
+
+	t.Run("single diagnostic", func(t *testing.T) {
+		assert.Equal(t, "<nil>: diag summary; ", Diagnostics{Error(nil, "diag summary", "")}.Error())
+	})
+
+	t.Run("multiple diagnostics", func(t *testing.T) {
+		diags := Diagnostics{
+			&Diagnostic{Diagnostic: hcl.Diagnostic{Severity: hcl.DiagError, Summary: "error diag"}},
+			&Diagnostic{Diagnostic: hcl.Diagnostic{Severity: hcl.DiagWarning, Summary: "warning diag"}},
+		}
+		assert.Equal(t, "\n-error: <nil>: error diag; \n-warning: <nil>: warning diag; ", diags.Error())
+	})
+}


### PR DESCRIPTION
- Remove some unused exports from syntax.Diagnostic{,s}
- Add coverage for Diagnostics.Error