### PR TITLE
cli: support --show-secrets in `env get`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,9 +1,12 @@
 ### Improvements
 
-* Include paths in diagnostics. [#157](https://github.com/pulumi/esc/pull/157)
+- Include paths in diagnostics. [#157](https://github.com/pulumi/esc/pull/157)
   
 - Support secret elision in definitions via encryption and decryption
   [#155](https://github.com/pulumi/esc/pull/155)
+
+- Support `--show-secrets` in `esc env get` to display secrets in plaintext.
+  [#163](https://github.com/pulumi/esc/pull/163)
 
 ### Bug Fixes
 

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -55,7 +55,7 @@ type Client interface {
 
 	CreateEnvironment(ctx context.Context, orgName, envName string) error
 
-	GetEnvironment(ctx context.Context, orgName, envName string) ([]byte, string, error)
+	GetEnvironment(ctx context.Context, orgName, envName string, decrypt bool) ([]byte, string, error)
 
 	UpdateEnvironment(
 		ctx context.Context,
@@ -227,8 +227,12 @@ func (pc *client) CreateEnvironment(ctx context.Context, orgName, envName string
 	return pc.restCall(ctx, http.MethodPost, path, nil, nil, nil)
 }
 
-func (pc *client) GetEnvironment(ctx context.Context, orgName, envName string) ([]byte, string, error) {
+func (pc *client) GetEnvironment(ctx context.Context, orgName, envName string, decrypt bool) ([]byte, string, error) {
 	path := fmt.Sprintf("/api/preview/environments/%v/%v", orgName, envName)
+	if decrypt {
+		path += "/decrypt"
+	}
+
 	var resp *http.Response
 	if err := pc.restCall(ctx, http.MethodGet, path, nil, nil, &resp); err != nil {
 		return nil, "", err

--- a/cmd/esc/cli/client/client_test.go
+++ b/cmd/esc/cli/client/client_test.go
@@ -186,7 +186,23 @@ func TestGetEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		actualYAML, actualTag, err := client.GetEnvironment(context.Background(), "test-org", "test-env")
+		actualYAML, actualTag, err := client.GetEnvironment(context.Background(), "test-org", "test-env", false)
+		require.NoError(t, err)
+		assert.Equal(t, string(expectedYAML), string(actualYAML))
+		assert.Equal(t, expectedTag, actualTag)
+	})
+
+	t.Run("Decrypt", func(t *testing.T) {
+		expectedYAML := []byte("arbitrary content")
+		expectedTag := "new-tag"
+
+		client := newTestClient(t, http.MethodGet, "/api/preview/environments/test-org/test-env/decrypt", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("ETag", expectedTag)
+			_, err := w.Write(expectedYAML)
+			require.NoError(t, err)
+		})
+
+		actualYAML, actualTag, err := client.GetEnvironment(context.Background(), "test-org", "test-env", true)
 		require.NoError(t, err)
 		assert.Equal(t, string(expectedYAML), string(actualYAML))
 		assert.Equal(t, expectedTag, actualTag)
@@ -203,7 +219,7 @@ func TestGetEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		_, _, err := client.GetEnvironment(context.Background(), "test-org", "test-env")
+		_, _, err := client.GetEnvironment(context.Background(), "test-org", "test-env", false)
 		assert.ErrorContains(t, err, "not found")
 	})
 }

--- a/cmd/esc/cli/env_edit.go
+++ b/cmd/esc/cli/env_edit.go
@@ -28,6 +28,8 @@ type envEditCommand struct {
 }
 
 func newEnvEditCmd(env *envCommand) *cobra.Command {
+	var showSecrets bool
+
 	edit := &envEditCommand{env: env}
 
 	cmd := &cobra.Command{
@@ -61,7 +63,7 @@ func newEnvEditCmd(env *envCommand) *cobra.Command {
 			}
 			_ = args
 
-			yaml, tag, err := edit.env.esc.client.GetEnvironment(ctx, orgName, envName)
+			yaml, tag, err := edit.env.esc.client.GetEnvironment(ctx, orgName, envName, showSecrets)
 			if err != nil {
 				return fmt.Errorf("getting environment definition: %w", err)
 			}
@@ -111,6 +113,10 @@ func newEnvEditCmd(env *envCommand) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&edit.editorFlag, "editor", "", "the command to use to edit the environment definition")
+
+	cmd.Flags().BoolVar(
+		&showSecrets, "show-secrets", false,
+		"Show static secrets in plaintext rather than ciphertext")
 
 	return cmd
 }

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -69,7 +69,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 				return envcmd.writePropertyEnvironmentDiagnostics(envcmd.esc.stderr, diags)
 			}
 
-			return envcmd.renderValue(envcmd.esc.stdout, env, path, format, false)
+			return envcmd.renderValue(envcmd.esc.stdout, env, path, format, false, true)
 		},
 	}
 
@@ -89,6 +89,7 @@ func (env *envCommand) renderValue(
 	path resource.PropertyPath,
 	format string,
 	pretend bool,
+	showSecrets bool,
 ) error {
 	if e == nil {
 		return nil
@@ -105,7 +106,7 @@ func (env *envCommand) renderValue(
 
 	switch format {
 	case "json":
-		body := val.ToJSON(false)
+		body := val.ToJSON(!showSecrets)
 		enc := json.NewEncoder(out)
 		enc.SetIndent("", "  ")
 		return enc.Encode(body)
@@ -132,7 +133,7 @@ func (env *envCommand) renderValue(
 		}
 		return nil
 	case "string":
-		fmt.Fprintf(out, "%v\n", val.ToString(false))
+		fmt.Fprintf(out, "%v\n", val.ToString(!showSecrets))
 		return nil
 	default:
 		// NOTE: we shouldn't get here. This was checked at the beginning of the function.

--- a/cmd/esc/cli/env_rm.go
+++ b/cmd/esc/cli/env_rm.go
@@ -69,7 +69,7 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 				return fmt.Errorf("invalid path: %w", err)
 			}
 
-			def, tag, err := env.esc.client.GetEnvironment(ctx, orgName, envName)
+			def, tag, err := env.esc.client.GetEnvironment(ctx, orgName, envName, false)
 			if err != nil {
 				return fmt.Errorf("getting environment definition: %w", err)
 			}

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -78,7 +78,7 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 				yamlValue = *yamlValue.Content[0]
 			}
 
-			def, tag, err := env.esc.client.GetEnvironment(ctx, orgName, envName)
+			def, tag, err := env.esc.client.GetEnvironment(ctx, orgName, envName, false)
 			if err != nil {
 				return fmt.Errorf("getting environment definition: %w", err)
 			}

--- a/cmd/esc/cli/testdata/env-set-secret.yaml
+++ b/cmd/esc/cli/testdata/env-set-secret.yaml
@@ -1,12 +1,18 @@
 run: |
   esc env init test
+  esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= || echo OK
   esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret
   esc env get test
+  esc env get test password
+  esc env get test --show-secrets
+  esc env get test password --show-secrets
   esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
   esc env get test
 stdout: |+
   > esc env init test
   Environment created.
+  > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+  OK
   > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret
   > esc env get test
   # Value
@@ -19,9 +25,54 @@ stdout: |+
   ```yaml
   values:
     password:
+      fn::secret:
+        ciphertext: ZXNjeAAAAAHZzcjk7+e21uvV8eLW07XkwcXy+Nflzfm4s/K0yOXC5c7S5MX11cb3y7PNve6n0kM=
+
+  ```
+
+  > esc env get test password
+  # Value
+  ```json
+  "[secret]"
+  ```
+  # Definition
+  ```yaml
+  fn::secret:
+    ciphertext: ZXNjeAAAAAHZzcjk7+e21uvV8eLW07XkwcXy+Nflzfm4s/K0yOXC5c7S5MX11cb3y7PNve6n0kM=
+
+  ```
+
+  # Defined at
+  - test:3:5
+
+  > esc env get test --show-secrets
+  # Value
+  ```json
+  {
+    "password": "YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M="
+  }
+  ```
+  # Definition
+  ```yaml
+  values:
+    password:
       fn::secret: YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
 
   ```
+
+  > esc env get test password --show-secrets
+  # Value
+  ```json
+  "YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M="
+  ```
+  # Definition
+  ```yaml
+  fn::secret: YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+
+  ```
+
+  # Defined at
+  - test:3:5
 
   > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
   > esc env get test
@@ -40,7 +91,12 @@ stdout: |+
 
 stderr: |
   > esc env init test
+  > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+  Error: value looks like a secret; rerun with --secret to mark it as such, or --plaintext if you meant to leave it as plaintext
   > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret
   > esc env get test
+  > esc env get test password
+  > esc env get test --show-secrets
+  > esc env get test password --show-secrets
   > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
   > esc env get test

--- a/value.go
+++ b/value.go
@@ -154,11 +154,11 @@ func fromJSON(path string, v any) (Value, error) {
 // ToJSON converts a Value into a plain-old-JSON value (i.e. a value of type nil, bool, json.Number, string, []any, or
 // map[string]any). If redact is true, secrets are replaced with [secret].
 func (v Value) ToJSON(redact bool) any {
-	if v.Unknown {
-		return "[unknown]"
-	}
 	if v.Secret && redact {
 		return "[secret]"
+	}
+	if v.Unknown {
+		return "[unknown]"
 	}
 
 	switch pv := v.Value.(type) {
@@ -181,11 +181,11 @@ func (v Value) ToJSON(redact bool) any {
 
 // ToString returns the string representation of this value. If redact is true, secrets are replaced with [secret].
 func (v Value) ToString(redact bool) string {
-	if v.Unknown {
-		return "[unknown]"
-	}
 	if v.Secret && redact {
 		return "[secret]"
+	}
+	if v.Unknown {
+		return "[unknown]"
 	}
 
 	switch pv := v.Value.(type) {


### PR DESCRIPTION
When this flag is passed, static secrets will be shown in plaintext rather than ciphertext.