### PR TITLE
eval: improve unknown/secret for complex literals 

### DIFF
--- a/eval/testdata/eval/builtin-combine/expected.json
+++ b/eval/testdata/eval/builtin-combine/expected.json
@@ -809,8 +809,6 @@
                         }
                     }
                 ],
-                "secret": true,
-                "unknown": true,
                 "trace": {
                     "def": {
                         "environment": "builtin-combine",
@@ -900,7 +898,12 @@
         }
     },
     "checkJson": {
-        "builtins": "[secret]",
+        "builtins": [
+            "[secret]",
+            "[secret]",
+            "[secret]",
+            "[secret]"
+        ],
         "open": "[unknown]",
         "password": "[secret]"
     },
@@ -1731,7 +1734,6 @@
                         }
                     }
                 ],
-                "secret": true,
                 "trace": {
                     "def": {
                         "environment": "builtin-combine",
@@ -1851,7 +1853,12 @@
         }
     },
     "evalJson": {
-        "builtins": "[secret]",
+        "builtins": [
+            "[secret]",
+            "[secret]",
+            "[secret]",
+            "[secret]"
+        ],
         "open": {
             "foo": "bar"
         },

--- a/eval/testdata/eval/builtin-errs/expected.json
+++ b/eval/testdata/eval/builtin-errs/expected.json
@@ -977,7 +977,6 @@
                         }
                     }
                 ],
-                "unknown": true,
                 "trace": {
                     "def": {
                         "environment": "builtin-errs",
@@ -1053,7 +1052,15 @@
         }
     },
     "checkJson": {
-        "builtins": "[unknown]",
+        "builtins": [
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]"
+        ],
         "number": 42
     },
     "evalDiags": [
@@ -2034,7 +2041,6 @@
                         }
                     }
                 ],
-                "unknown": true,
                 "trace": {
                     "def": {
                         "environment": "builtin-errs",
@@ -2110,7 +2116,15 @@
         }
     },
     "evalJson": {
-        "builtins": "[unknown]",
+        "builtins": [
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]"
+        ],
         "number": 42
     }
 }

--- a/eval/testdata/eval/cycle/expected.json
+++ b/eval/testdata/eval/cycle/expected.json
@@ -345,7 +345,6 @@
                         }
                     }
                 },
-                "unknown": true,
                 "trace": {
                     "def": {
                         "environment": "cycle",
@@ -383,7 +382,6 @@
                         }
                     }
                 },
-                "unknown": true,
                 "trace": {
                     "def": {
                         "environment": "cycle",
@@ -421,7 +419,6 @@
                         }
                     }
                 },
-                "unknown": true,
                 "trace": {
                     "def": {
                         "environment": "cycle",
@@ -478,9 +475,15 @@
         }
     },
     "checkJson": {
-        "a": "[unknown]",
-        "b": "[unknown]",
-        "c": "[unknown]"
+        "a": {
+            "p": "[unknown]"
+        },
+        "b": {
+            "p": "[unknown]"
+        },
+        "c": {
+            "p": "[unknown]"
+        }
     },
     "evalDiags": [
         {
@@ -828,7 +831,6 @@
                         }
                     }
                 },
-                "unknown": true,
                 "trace": {
                     "def": {
                         "environment": "cycle",
@@ -866,7 +868,6 @@
                         }
                     }
                 },
-                "unknown": true,
                 "trace": {
                     "def": {
                         "environment": "cycle",
@@ -904,7 +905,6 @@
                         }
                     }
                 },
-                "unknown": true,
                 "trace": {
                     "def": {
                         "environment": "cycle",
@@ -961,8 +961,14 @@
         }
     },
     "evalJson": {
-        "a": "[unknown]",
-        "b": "[unknown]",
-        "c": "[unknown]"
+        "a": {
+            "p": "[unknown]"
+        },
+        "b": {
+            "p": "[unknown]"
+        },
+        "c": {
+            "p": "[unknown]"
+        }
     }
 }

--- a/eval/testdata/eval/invalid-access/expected.json
+++ b/eval/testdata/eval/invalid-access/expected.json
@@ -3214,7 +3214,6 @@
                         }
                     }
                 ],
-                "unknown": true,
                 "trace": {
                     "def": {
                         "environment": "invalid-access",
@@ -3871,7 +3870,21 @@
             2,
             3
         ],
-        "errors": "[unknown]",
+        "errors": [
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]"
+        ],
         "myObject": {
             "foo": "bar"
         },
@@ -7033,7 +7046,6 @@
                         }
                     }
                 ],
-                "unknown": true,
                 "trace": {
                     "def": {
                         "environment": "invalid-access",
@@ -8116,7 +8128,21 @@
             2,
             3
         ],
-        "errors": "[unknown]",
+        "errors": [
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]"
+        ],
         "myObject": {
             "foo": "bar"
         },

--- a/eval/testdata/eval/nested-unknowns-secrets/env.yaml
+++ b/eval/testdata/eval/nested-unknowns-secrets/env.yaml
@@ -1,0 +1,23 @@
+values:
+  top-level-secret:
+    fn::secret: top-secret
+  cloudflare:
+    username: bot@pulumi.com
+    apiKey:
+      fn::secret: apiKeySecret
+    zoneId: zone-id-123
+    apiToken:
+      fn::secret: apiTokenSecret
+    account:
+      name: account-name
+      id:
+        fn::secret: accountIdSecret
+  jsonOutput:
+    fn::toJSON: ${cloudflare}
+  stringOutput:
+    fn::toString: ${cloudflare}
+  environmentVariables:
+    CLOUDFLARE_API_TOKEN: ${cloudflare.apiToken}
+  pulumiConfig:
+    accountId: ${cloudflare.account.id}
+    refTopLevelSecret: ${top-level-secret}

--- a/eval/testdata/eval/nested-unknowns-secrets/expected.json
+++ b/eval/testdata/eval/nested-unknowns-secrets/expected.json
@@ -1,0 +1,2786 @@
+{
+    "check": {
+        "exprs": {
+            "cloudflare": {
+                "range": {
+                    "environment": "nested-unknowns-secrets",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 73
+                    },
+                    "end": {
+                        "line": 14,
+                        "column": 36,
+                        "byte": 295
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "account": {
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "const": "accountIdSecret"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "const": "account-name"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "apiKey": {
+                            "type": "string",
+                            "const": "apiKeySecret"
+                        },
+                        "apiToken": {
+                            "type": "string",
+                            "const": "apiTokenSecret"
+                        },
+                        "username": {
+                            "type": "string",
+                            "const": "bot@pulumi.com"
+                        },
+                        "zoneId": {
+                            "type": "string",
+                            "const": "zone-id-123"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "account",
+                        "apiKey",
+                        "apiToken",
+                        "username",
+                        "zoneId"
+                    ]
+                },
+                "keyRanges": {
+                    "account": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 11,
+                            "column": 5,
+                            "byte": 216
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 12,
+                            "byte": 223
+                        }
+                    },
+                    "apiKey": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 102
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 11,
+                            "byte": 108
+                        }
+                    },
+                    "apiToken": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 9,
+                            "column": 5,
+                            "byte": 169
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 13,
+                            "byte": 177
+                        }
+                    },
+                    "username": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 73
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 13,
+                            "byte": 81
+                        }
+                    },
+                    "zoneId": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 8,
+                            "column": 5,
+                            "byte": 145
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 11,
+                            "byte": 151
+                        }
+                    }
+                },
+                "object": {
+                    "account": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 12,
+                                "column": 7,
+                                "byte": 231
+                            },
+                            "end": {
+                                "line": 14,
+                                "column": 36,
+                                "byte": 295
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "const": "accountIdSecret"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "const": "account-name"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "keyRanges": {
+                            "id": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 13,
+                                    "column": 7,
+                                    "byte": 256
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 9,
+                                    "byte": 258
+                                }
+                            },
+                            "name": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 12,
+                                    "column": 7,
+                                    "byte": 231
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 11,
+                                    "byte": 235
+                                }
+                            }
+                        },
+                        "object": {
+                            "id": {
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 14,
+                                        "column": 9,
+                                        "byte": 268
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 36,
+                                        "byte": 295
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "accountIdSecret"
+                                },
+                                "builtin": {
+                                    "name": "fn::secret",
+                                    "nameRange": {
+                                        "environment": "nested-unknowns-secrets",
+                                        "begin": {
+                                            "line": 14,
+                                            "column": 9,
+                                            "byte": 268
+                                        },
+                                        "end": {
+                                            "line": 14,
+                                            "column": 19,
+                                            "byte": 278
+                                        }
+                                    },
+                                    "argSchema": true,
+                                    "arg": {
+                                        "range": {
+                                            "environment": "nested-unknowns-secrets",
+                                            "begin": {
+                                                "line": 14,
+                                                "column": 21,
+                                                "byte": 280
+                                            },
+                                            "end": {
+                                                "line": 14,
+                                                "column": 36,
+                                                "byte": 295
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "accountIdSecret"
+                                        },
+                                        "literal": "accountIdSecret"
+                                    }
+                                }
+                            },
+                            "name": {
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 13,
+                                        "byte": 237
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 25,
+                                        "byte": 249
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "account-name"
+                                },
+                                "literal": "account-name"
+                            }
+                        }
+                    },
+                    "apiKey": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 7,
+                                "column": 7,
+                                "byte": 116
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 31,
+                                "byte": 140
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "apiKeySecret"
+                        },
+                        "builtin": {
+                            "name": "fn::secret",
+                            "nameRange": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 7,
+                                    "byte": 116
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 17,
+                                    "byte": 126
+                                }
+                            },
+                            "argSchema": true,
+                            "arg": {
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 19,
+                                        "byte": 128
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 31,
+                                        "byte": 140
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "apiKeySecret"
+                                },
+                                "literal": "apiKeySecret"
+                            }
+                        }
+                    },
+                    "apiToken": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 10,
+                                "column": 7,
+                                "byte": 185
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 33,
+                                "byte": 211
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "apiTokenSecret"
+                        },
+                        "builtin": {
+                            "name": "fn::secret",
+                            "nameRange": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 7,
+                                    "byte": 185
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 17,
+                                    "byte": 195
+                                }
+                            },
+                            "argSchema": true,
+                            "arg": {
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 19,
+                                        "byte": 197
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 33,
+                                        "byte": 211
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "apiTokenSecret"
+                                },
+                                "literal": "apiTokenSecret"
+                            }
+                        }
+                    },
+                    "username": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 5,
+                                "column": 15,
+                                "byte": 83
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 29,
+                                "byte": 97
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "bot@pulumi.com"
+                        },
+                        "literal": "bot@pulumi.com"
+                    },
+                    "zoneId": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 8,
+                                "column": 13,
+                                "byte": 153
+                            },
+                            "end": {
+                                "line": 8,
+                                "column": 24,
+                                "byte": 164
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "zone-id-123"
+                        },
+                        "literal": "zone-id-123"
+                    }
+                }
+            },
+            "environmentVariables": {
+                "range": {
+                    "environment": "nested-unknowns-secrets",
+                    "begin": {
+                        "line": 20,
+                        "column": 5,
+                        "byte": 416
+                    },
+                    "end": {
+                        "line": 20,
+                        "column": 49,
+                        "byte": 460
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "CLOUDFLARE_API_TOKEN": {
+                            "type": "string",
+                            "const": "apiTokenSecret"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "CLOUDFLARE_API_TOKEN"
+                    ]
+                },
+                "keyRanges": {
+                    "CLOUDFLARE_API_TOKEN": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 20,
+                            "column": 5,
+                            "byte": 416
+                        },
+                        "end": {
+                            "line": 20,
+                            "column": 25,
+                            "byte": 436
+                        }
+                    }
+                },
+                "object": {
+                    "CLOUDFLARE_API_TOKEN": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 20,
+                                "column": 27,
+                                "byte": 438
+                            },
+                            "end": {
+                                "line": 20,
+                                "column": 49,
+                                "byte": 460
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "apiTokenSecret"
+                        },
+                        "symbol": [
+                            {
+                                "key": "cloudflare",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 5,
+                                        "byte": 73
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 36,
+                                        "byte": 295
+                                    }
+                                }
+                            },
+                            {
+                                "key": "apiToken",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 7,
+                                        "byte": 185
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 33,
+                                        "byte": 211
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "jsonOutput": {
+                "range": {
+                    "environment": "nested-unknowns-secrets",
+                    "begin": {
+                        "line": 16,
+                        "column": 5,
+                        "byte": 314
+                    },
+                    "end": {
+                        "line": 16,
+                        "column": 30,
+                        "byte": 339
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "fn::toJSON",
+                    "nameRange": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 16,
+                            "column": 5,
+                            "byte": 314
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 15,
+                            "byte": 324
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 16,
+                                "column": 17,
+                                "byte": 326
+                            },
+                            "end": {
+                                "line": 16,
+                                "column": 30,
+                                "byte": 339
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "account": {
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "const": "accountIdSecret"
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "const": "account-name"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "id",
+                                        "name"
+                                    ]
+                                },
+                                "apiKey": {
+                                    "type": "string",
+                                    "const": "apiKeySecret"
+                                },
+                                "apiToken": {
+                                    "type": "string",
+                                    "const": "apiTokenSecret"
+                                },
+                                "username": {
+                                    "type": "string",
+                                    "const": "bot@pulumi.com"
+                                },
+                                "zoneId": {
+                                    "type": "string",
+                                    "const": "zone-id-123"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "account",
+                                "apiKey",
+                                "apiToken",
+                                "username",
+                                "zoneId"
+                            ]
+                        },
+                        "symbol": [
+                            {
+                                "key": "cloudflare",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 5,
+                                        "byte": 73
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 36,
+                                        "byte": 295
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "pulumiConfig": {
+                "range": {
+                    "environment": "nested-unknowns-secrets",
+                    "begin": {
+                        "line": 22,
+                        "column": 5,
+                        "byte": 481
+                    },
+                    "end": {
+                        "line": 23,
+                        "column": 43,
+                        "byte": 559
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "accountId": {
+                            "type": "string",
+                            "const": "accountIdSecret"
+                        },
+                        "refTopLevelSecret": {
+                            "type": "string",
+                            "const": "top-secret"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "accountId",
+                        "refTopLevelSecret"
+                    ]
+                },
+                "keyRanges": {
+                    "accountId": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 22,
+                            "column": 5,
+                            "byte": 481
+                        },
+                        "end": {
+                            "line": 22,
+                            "column": 14,
+                            "byte": 490
+                        }
+                    },
+                    "refTopLevelSecret": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 23,
+                            "column": 5,
+                            "byte": 521
+                        },
+                        "end": {
+                            "line": 23,
+                            "column": 22,
+                            "byte": 538
+                        }
+                    }
+                },
+                "object": {
+                    "accountId": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 22,
+                                "column": 16,
+                                "byte": 492
+                            },
+                            "end": {
+                                "line": 22,
+                                "column": 40,
+                                "byte": 516
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "accountIdSecret"
+                        },
+                        "symbol": [
+                            {
+                                "key": "cloudflare",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 5,
+                                        "byte": 73
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 36,
+                                        "byte": 295
+                                    }
+                                }
+                            },
+                            {
+                                "key": "account",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 7,
+                                        "byte": 231
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 36,
+                                        "byte": 295
+                                    }
+                                }
+                            },
+                            {
+                                "key": "id",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 14,
+                                        "column": 9,
+                                        "byte": 268
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 36,
+                                        "byte": 295
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "refTopLevelSecret": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 23,
+                                "column": 24,
+                                "byte": 540
+                            },
+                            "end": {
+                                "line": 23,
+                                "column": 43,
+                                "byte": 559
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "top-secret"
+                        },
+                        "symbol": [
+                            {
+                                "key": "top-level-secret",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 5,
+                                        "byte": 32
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 27,
+                                        "byte": 54
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "stringOutput": {
+                "range": {
+                    "environment": "nested-unknowns-secrets",
+                    "begin": {
+                        "line": 18,
+                        "column": 5,
+                        "byte": 360
+                    },
+                    "end": {
+                        "line": 18,
+                        "column": 32,
+                        "byte": 387
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "fn::toString",
+                    "nameRange": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 18,
+                            "column": 5,
+                            "byte": 360
+                        },
+                        "end": {
+                            "line": 18,
+                            "column": 17,
+                            "byte": 372
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 18,
+                                "column": 19,
+                                "byte": 374
+                            },
+                            "end": {
+                                "line": 18,
+                                "column": 32,
+                                "byte": 387
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "account": {
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "const": "accountIdSecret"
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "const": "account-name"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "id",
+                                        "name"
+                                    ]
+                                },
+                                "apiKey": {
+                                    "type": "string",
+                                    "const": "apiKeySecret"
+                                },
+                                "apiToken": {
+                                    "type": "string",
+                                    "const": "apiTokenSecret"
+                                },
+                                "username": {
+                                    "type": "string",
+                                    "const": "bot@pulumi.com"
+                                },
+                                "zoneId": {
+                                    "type": "string",
+                                    "const": "zone-id-123"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "account",
+                                "apiKey",
+                                "apiToken",
+                                "username",
+                                "zoneId"
+                            ]
+                        },
+                        "symbol": [
+                            {
+                                "key": "cloudflare",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 5,
+                                        "byte": 73
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 36,
+                                        "byte": 295
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "top-level-secret": {
+                "range": {
+                    "environment": "nested-unknowns-secrets",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 32
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 27,
+                        "byte": 54
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "top-secret"
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 32
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 42
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 3,
+                                "column": 17,
+                                "byte": 44
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 27,
+                                "byte": 54
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "top-secret"
+                        },
+                        "literal": "top-secret"
+                    }
+                }
+            }
+        },
+        "properties": {
+            "cloudflare": {
+                "value": {
+                    "account": {
+                        "value": {
+                            "id": {
+                                "value": "accountIdSecret",
+                                "secret": true,
+                                "trace": {
+                                    "def": {
+                                        "environment": "nested-unknowns-secrets",
+                                        "begin": {
+                                            "line": 14,
+                                            "column": 21,
+                                            "byte": 280
+                                        },
+                                        "end": {
+                                            "line": 14,
+                                            "column": 36,
+                                            "byte": 295
+                                        }
+                                    }
+                                }
+                            },
+                            "name": {
+                                "value": "account-name",
+                                "trace": {
+                                    "def": {
+                                        "environment": "nested-unknowns-secrets",
+                                        "begin": {
+                                            "line": 12,
+                                            "column": 13,
+                                            "byte": 237
+                                        },
+                                        "end": {
+                                            "line": 12,
+                                            "column": 25,
+                                            "byte": 249
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 12,
+                                    "column": 7,
+                                    "byte": 231
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "column": 36,
+                                    "byte": 295
+                                }
+                            }
+                        }
+                    },
+                    "apiKey": {
+                        "value": "apiKeySecret",
+                        "secret": true,
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 19,
+                                    "byte": 128
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 31,
+                                    "byte": 140
+                                }
+                            }
+                        }
+                    },
+                    "apiToken": {
+                        "value": "apiTokenSecret",
+                        "secret": true,
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 19,
+                                    "byte": 197
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 33,
+                                    "byte": 211
+                                }
+                            }
+                        }
+                    },
+                    "username": {
+                        "value": "bot@pulumi.com",
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 15,
+                                    "byte": 83
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 29,
+                                    "byte": 97
+                                }
+                            }
+                        }
+                    },
+                    "zoneId": {
+                        "value": "zone-id-123",
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 13,
+                                    "byte": 153
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 24,
+                                    "byte": 164
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 73
+                        },
+                        "end": {
+                            "line": 14,
+                            "column": 36,
+                            "byte": 295
+                        }
+                    }
+                }
+            },
+            "environmentVariables": {
+                "value": {
+                    "CLOUDFLARE_API_TOKEN": {
+                        "value": "apiTokenSecret",
+                        "secret": true,
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 27,
+                                    "byte": 438
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 49,
+                                    "byte": 460
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 20,
+                            "column": 5,
+                            "byte": 416
+                        },
+                        "end": {
+                            "line": 20,
+                            "column": 49,
+                            "byte": 460
+                        }
+                    }
+                }
+            },
+            "jsonOutput": {
+                "value": "{\"account\":{\"id\":\"accountIdSecret\",\"name\":\"account-name\"},\"apiKey\":\"apiKeySecret\",\"apiToken\":\"apiTokenSecret\",\"username\":\"bot@pulumi.com\",\"zoneId\":\"zone-id-123\"}",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 16,
+                            "column": 5,
+                            "byte": 314
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 30,
+                            "byte": 339
+                        }
+                    }
+                }
+            },
+            "pulumiConfig": {
+                "value": {
+                    "accountId": {
+                        "value": "accountIdSecret",
+                        "secret": true,
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 22,
+                                    "column": 16,
+                                    "byte": 492
+                                },
+                                "end": {
+                                    "line": 22,
+                                    "column": 40,
+                                    "byte": 516
+                                }
+                            }
+                        }
+                    },
+                    "refTopLevelSecret": {
+                        "value": "top-secret",
+                        "secret": true,
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 23,
+                                    "column": 24,
+                                    "byte": 540
+                                },
+                                "end": {
+                                    "line": 23,
+                                    "column": 43,
+                                    "byte": 559
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 22,
+                            "column": 5,
+                            "byte": 481
+                        },
+                        "end": {
+                            "line": 23,
+                            "column": 43,
+                            "byte": 559
+                        }
+                    }
+                }
+            },
+            "stringOutput": {
+                "value": "\"account\"=\"\\\"id\\\"=\\\"accountIdSecret\\\",\\\"name\\\"=\\\"account-name\\\"\",\"apiKey\"=\"apiKeySecret\",\"apiToken\"=\"apiTokenSecret\",\"username\"=\"bot@pulumi.com\",\"zoneId\"=\"zone-id-123\"",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 18,
+                            "column": 5,
+                            "byte": 360
+                        },
+                        "end": {
+                            "line": 18,
+                            "column": 32,
+                            "byte": 387
+                        }
+                    }
+                }
+            },
+            "top-level-secret": {
+                "value": "top-secret",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 3,
+                            "column": 17,
+                            "byte": 44
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 27,
+                            "byte": 54
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "cloudflare": {
+                    "properties": {
+                        "account": {
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "const": "accountIdSecret"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "const": "account-name"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "apiKey": {
+                            "type": "string",
+                            "const": "apiKeySecret"
+                        },
+                        "apiToken": {
+                            "type": "string",
+                            "const": "apiTokenSecret"
+                        },
+                        "username": {
+                            "type": "string",
+                            "const": "bot@pulumi.com"
+                        },
+                        "zoneId": {
+                            "type": "string",
+                            "const": "zone-id-123"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "account",
+                        "apiKey",
+                        "apiToken",
+                        "username",
+                        "zoneId"
+                    ]
+                },
+                "environmentVariables": {
+                    "properties": {
+                        "CLOUDFLARE_API_TOKEN": {
+                            "type": "string",
+                            "const": "apiTokenSecret"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "CLOUDFLARE_API_TOKEN"
+                    ]
+                },
+                "jsonOutput": {
+                    "type": "string"
+                },
+                "pulumiConfig": {
+                    "properties": {
+                        "accountId": {
+                            "type": "string",
+                            "const": "accountIdSecret"
+                        },
+                        "refTopLevelSecret": {
+                            "type": "string",
+                            "const": "top-secret"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "accountId",
+                        "refTopLevelSecret"
+                    ]
+                },
+                "stringOutput": {
+                    "type": "string"
+                },
+                "top-level-secret": {
+                    "type": "string",
+                    "const": "top-secret"
+                }
+            },
+            "type": "object",
+            "required": [
+                "cloudflare",
+                "environmentVariables",
+                "jsonOutput",
+                "pulumiConfig",
+                "stringOutput",
+                "top-level-secret"
+            ]
+        }
+    },
+    "checkJson": {
+        "cloudflare": {
+            "account": {
+                "id": "[secret]",
+                "name": "account-name"
+            },
+            "apiKey": "[secret]",
+            "apiToken": "[secret]",
+            "username": "bot@pulumi.com",
+            "zoneId": "zone-id-123"
+        },
+        "environmentVariables": {
+            "CLOUDFLARE_API_TOKEN": "[secret]"
+        },
+        "jsonOutput": "[secret]",
+        "pulumiConfig": {
+            "accountId": "[secret]",
+            "refTopLevelSecret": "[secret]"
+        },
+        "stringOutput": "[secret]",
+        "top-level-secret": "[secret]"
+    },
+    "eval": {
+        "exprs": {
+            "cloudflare": {
+                "range": {
+                    "environment": "nested-unknowns-secrets",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 73
+                    },
+                    "end": {
+                        "line": 14,
+                        "column": 36,
+                        "byte": 295
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "account": {
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "const": "accountIdSecret"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "const": "account-name"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "apiKey": {
+                            "type": "string",
+                            "const": "apiKeySecret"
+                        },
+                        "apiToken": {
+                            "type": "string",
+                            "const": "apiTokenSecret"
+                        },
+                        "username": {
+                            "type": "string",
+                            "const": "bot@pulumi.com"
+                        },
+                        "zoneId": {
+                            "type": "string",
+                            "const": "zone-id-123"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "account",
+                        "apiKey",
+                        "apiToken",
+                        "username",
+                        "zoneId"
+                    ]
+                },
+                "keyRanges": {
+                    "account": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 11,
+                            "column": 5,
+                            "byte": 216
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 12,
+                            "byte": 223
+                        }
+                    },
+                    "apiKey": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 102
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 11,
+                            "byte": 108
+                        }
+                    },
+                    "apiToken": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 9,
+                            "column": 5,
+                            "byte": 169
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 13,
+                            "byte": 177
+                        }
+                    },
+                    "username": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 73
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 13,
+                            "byte": 81
+                        }
+                    },
+                    "zoneId": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 8,
+                            "column": 5,
+                            "byte": 145
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 11,
+                            "byte": 151
+                        }
+                    }
+                },
+                "object": {
+                    "account": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 12,
+                                "column": 7,
+                                "byte": 231
+                            },
+                            "end": {
+                                "line": 14,
+                                "column": 36,
+                                "byte": 295
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "const": "accountIdSecret"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "const": "account-name"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "keyRanges": {
+                            "id": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 13,
+                                    "column": 7,
+                                    "byte": 256
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 9,
+                                    "byte": 258
+                                }
+                            },
+                            "name": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 12,
+                                    "column": 7,
+                                    "byte": 231
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 11,
+                                    "byte": 235
+                                }
+                            }
+                        },
+                        "object": {
+                            "id": {
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 14,
+                                        "column": 9,
+                                        "byte": 268
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 36,
+                                        "byte": 295
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "accountIdSecret"
+                                },
+                                "builtin": {
+                                    "name": "fn::secret",
+                                    "nameRange": {
+                                        "environment": "nested-unknowns-secrets",
+                                        "begin": {
+                                            "line": 14,
+                                            "column": 9,
+                                            "byte": 268
+                                        },
+                                        "end": {
+                                            "line": 14,
+                                            "column": 19,
+                                            "byte": 278
+                                        }
+                                    },
+                                    "argSchema": true,
+                                    "arg": {
+                                        "range": {
+                                            "environment": "nested-unknowns-secrets",
+                                            "begin": {
+                                                "line": 14,
+                                                "column": 21,
+                                                "byte": 280
+                                            },
+                                            "end": {
+                                                "line": 14,
+                                                "column": 36,
+                                                "byte": 295
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "accountIdSecret"
+                                        },
+                                        "literal": "accountIdSecret"
+                                    }
+                                }
+                            },
+                            "name": {
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 13,
+                                        "byte": 237
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 25,
+                                        "byte": 249
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "account-name"
+                                },
+                                "literal": "account-name"
+                            }
+                        }
+                    },
+                    "apiKey": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 7,
+                                "column": 7,
+                                "byte": 116
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 31,
+                                "byte": 140
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "apiKeySecret"
+                        },
+                        "builtin": {
+                            "name": "fn::secret",
+                            "nameRange": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 7,
+                                    "byte": 116
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 17,
+                                    "byte": 126
+                                }
+                            },
+                            "argSchema": true,
+                            "arg": {
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 19,
+                                        "byte": 128
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 31,
+                                        "byte": 140
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "apiKeySecret"
+                                },
+                                "literal": "apiKeySecret"
+                            }
+                        }
+                    },
+                    "apiToken": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 10,
+                                "column": 7,
+                                "byte": 185
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 33,
+                                "byte": 211
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "apiTokenSecret"
+                        },
+                        "builtin": {
+                            "name": "fn::secret",
+                            "nameRange": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 7,
+                                    "byte": 185
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 17,
+                                    "byte": 195
+                                }
+                            },
+                            "argSchema": true,
+                            "arg": {
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 19,
+                                        "byte": 197
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 33,
+                                        "byte": 211
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "apiTokenSecret"
+                                },
+                                "literal": "apiTokenSecret"
+                            }
+                        }
+                    },
+                    "username": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 5,
+                                "column": 15,
+                                "byte": 83
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 29,
+                                "byte": 97
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "bot@pulumi.com"
+                        },
+                        "literal": "bot@pulumi.com"
+                    },
+                    "zoneId": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 8,
+                                "column": 13,
+                                "byte": 153
+                            },
+                            "end": {
+                                "line": 8,
+                                "column": 24,
+                                "byte": 164
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "zone-id-123"
+                        },
+                        "literal": "zone-id-123"
+                    }
+                }
+            },
+            "environmentVariables": {
+                "range": {
+                    "environment": "nested-unknowns-secrets",
+                    "begin": {
+                        "line": 20,
+                        "column": 5,
+                        "byte": 416
+                    },
+                    "end": {
+                        "line": 20,
+                        "column": 49,
+                        "byte": 460
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "CLOUDFLARE_API_TOKEN": {
+                            "type": "string",
+                            "const": "apiTokenSecret"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "CLOUDFLARE_API_TOKEN"
+                    ]
+                },
+                "keyRanges": {
+                    "CLOUDFLARE_API_TOKEN": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 20,
+                            "column": 5,
+                            "byte": 416
+                        },
+                        "end": {
+                            "line": 20,
+                            "column": 25,
+                            "byte": 436
+                        }
+                    }
+                },
+                "object": {
+                    "CLOUDFLARE_API_TOKEN": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 20,
+                                "column": 27,
+                                "byte": 438
+                            },
+                            "end": {
+                                "line": 20,
+                                "column": 49,
+                                "byte": 460
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "apiTokenSecret"
+                        },
+                        "symbol": [
+                            {
+                                "key": "cloudflare",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 5,
+                                        "byte": 73
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 36,
+                                        "byte": 295
+                                    }
+                                }
+                            },
+                            {
+                                "key": "apiToken",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 7,
+                                        "byte": 185
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 33,
+                                        "byte": 211
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "jsonOutput": {
+                "range": {
+                    "environment": "nested-unknowns-secrets",
+                    "begin": {
+                        "line": 16,
+                        "column": 5,
+                        "byte": 314
+                    },
+                    "end": {
+                        "line": 16,
+                        "column": 30,
+                        "byte": 339
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "fn::toJSON",
+                    "nameRange": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 16,
+                            "column": 5,
+                            "byte": 314
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 15,
+                            "byte": 324
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 16,
+                                "column": 17,
+                                "byte": 326
+                            },
+                            "end": {
+                                "line": 16,
+                                "column": 30,
+                                "byte": 339
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "account": {
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "const": "accountIdSecret"
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "const": "account-name"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "id",
+                                        "name"
+                                    ]
+                                },
+                                "apiKey": {
+                                    "type": "string",
+                                    "const": "apiKeySecret"
+                                },
+                                "apiToken": {
+                                    "type": "string",
+                                    "const": "apiTokenSecret"
+                                },
+                                "username": {
+                                    "type": "string",
+                                    "const": "bot@pulumi.com"
+                                },
+                                "zoneId": {
+                                    "type": "string",
+                                    "const": "zone-id-123"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "account",
+                                "apiKey",
+                                "apiToken",
+                                "username",
+                                "zoneId"
+                            ]
+                        },
+                        "symbol": [
+                            {
+                                "key": "cloudflare",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 5,
+                                        "byte": 73
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 36,
+                                        "byte": 295
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "pulumiConfig": {
+                "range": {
+                    "environment": "nested-unknowns-secrets",
+                    "begin": {
+                        "line": 22,
+                        "column": 5,
+                        "byte": 481
+                    },
+                    "end": {
+                        "line": 23,
+                        "column": 43,
+                        "byte": 559
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "accountId": {
+                            "type": "string",
+                            "const": "accountIdSecret"
+                        },
+                        "refTopLevelSecret": {
+                            "type": "string",
+                            "const": "top-secret"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "accountId",
+                        "refTopLevelSecret"
+                    ]
+                },
+                "keyRanges": {
+                    "accountId": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 22,
+                            "column": 5,
+                            "byte": 481
+                        },
+                        "end": {
+                            "line": 22,
+                            "column": 14,
+                            "byte": 490
+                        }
+                    },
+                    "refTopLevelSecret": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 23,
+                            "column": 5,
+                            "byte": 521
+                        },
+                        "end": {
+                            "line": 23,
+                            "column": 22,
+                            "byte": 538
+                        }
+                    }
+                },
+                "object": {
+                    "accountId": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 22,
+                                "column": 16,
+                                "byte": 492
+                            },
+                            "end": {
+                                "line": 22,
+                                "column": 40,
+                                "byte": 516
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "accountIdSecret"
+                        },
+                        "symbol": [
+                            {
+                                "key": "cloudflare",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 5,
+                                        "byte": 73
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 36,
+                                        "byte": 295
+                                    }
+                                }
+                            },
+                            {
+                                "key": "account",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 7,
+                                        "byte": 231
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 36,
+                                        "byte": 295
+                                    }
+                                }
+                            },
+                            {
+                                "key": "id",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 14,
+                                        "column": 9,
+                                        "byte": 268
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 36,
+                                        "byte": 295
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "refTopLevelSecret": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 23,
+                                "column": 24,
+                                "byte": 540
+                            },
+                            "end": {
+                                "line": 23,
+                                "column": 43,
+                                "byte": 559
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "top-secret"
+                        },
+                        "symbol": [
+                            {
+                                "key": "top-level-secret",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 5,
+                                        "byte": 32
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 27,
+                                        "byte": 54
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "stringOutput": {
+                "range": {
+                    "environment": "nested-unknowns-secrets",
+                    "begin": {
+                        "line": 18,
+                        "column": 5,
+                        "byte": 360
+                    },
+                    "end": {
+                        "line": 18,
+                        "column": 32,
+                        "byte": 387
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "fn::toString",
+                    "nameRange": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 18,
+                            "column": 5,
+                            "byte": 360
+                        },
+                        "end": {
+                            "line": 18,
+                            "column": 17,
+                            "byte": 372
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 18,
+                                "column": 19,
+                                "byte": 374
+                            },
+                            "end": {
+                                "line": 18,
+                                "column": 32,
+                                "byte": 387
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "account": {
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "const": "accountIdSecret"
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "const": "account-name"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "id",
+                                        "name"
+                                    ]
+                                },
+                                "apiKey": {
+                                    "type": "string",
+                                    "const": "apiKeySecret"
+                                },
+                                "apiToken": {
+                                    "type": "string",
+                                    "const": "apiTokenSecret"
+                                },
+                                "username": {
+                                    "type": "string",
+                                    "const": "bot@pulumi.com"
+                                },
+                                "zoneId": {
+                                    "type": "string",
+                                    "const": "zone-id-123"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "account",
+                                "apiKey",
+                                "apiToken",
+                                "username",
+                                "zoneId"
+                            ]
+                        },
+                        "symbol": [
+                            {
+                                "key": "cloudflare",
+                                "value": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 5,
+                                        "byte": 73
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 36,
+                                        "byte": 295
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "top-level-secret": {
+                "range": {
+                    "environment": "nested-unknowns-secrets",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 32
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 27,
+                        "byte": 54
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "top-secret"
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 32
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 42
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "nested-unknowns-secrets",
+                            "begin": {
+                                "line": 3,
+                                "column": 17,
+                                "byte": 44
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 27,
+                                "byte": 54
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "top-secret"
+                        },
+                        "literal": "top-secret"
+                    }
+                }
+            }
+        },
+        "properties": {
+            "cloudflare": {
+                "value": {
+                    "account": {
+                        "value": {
+                            "id": {
+                                "value": "accountIdSecret",
+                                "secret": true,
+                                "trace": {
+                                    "def": {
+                                        "environment": "nested-unknowns-secrets",
+                                        "begin": {
+                                            "line": 14,
+                                            "column": 21,
+                                            "byte": 280
+                                        },
+                                        "end": {
+                                            "line": 14,
+                                            "column": 36,
+                                            "byte": 295
+                                        }
+                                    }
+                                }
+                            },
+                            "name": {
+                                "value": "account-name",
+                                "trace": {
+                                    "def": {
+                                        "environment": "nested-unknowns-secrets",
+                                        "begin": {
+                                            "line": 12,
+                                            "column": 13,
+                                            "byte": 237
+                                        },
+                                        "end": {
+                                            "line": 12,
+                                            "column": 25,
+                                            "byte": 249
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 12,
+                                    "column": 7,
+                                    "byte": 231
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "column": 36,
+                                    "byte": 295
+                                }
+                            }
+                        }
+                    },
+                    "apiKey": {
+                        "value": "apiKeySecret",
+                        "secret": true,
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 19,
+                                    "byte": 128
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 31,
+                                    "byte": 140
+                                }
+                            }
+                        }
+                    },
+                    "apiToken": {
+                        "value": "apiTokenSecret",
+                        "secret": true,
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 19,
+                                    "byte": 197
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 33,
+                                    "byte": 211
+                                }
+                            }
+                        }
+                    },
+                    "username": {
+                        "value": "bot@pulumi.com",
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 15,
+                                    "byte": 83
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 29,
+                                    "byte": 97
+                                }
+                            }
+                        }
+                    },
+                    "zoneId": {
+                        "value": "zone-id-123",
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 13,
+                                    "byte": 153
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 24,
+                                    "byte": 164
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 73
+                        },
+                        "end": {
+                            "line": 14,
+                            "column": 36,
+                            "byte": 295
+                        }
+                    }
+                }
+            },
+            "environmentVariables": {
+                "value": {
+                    "CLOUDFLARE_API_TOKEN": {
+                        "value": "apiTokenSecret",
+                        "secret": true,
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 27,
+                                    "byte": 438
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 49,
+                                    "byte": 460
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 20,
+                            "column": 5,
+                            "byte": 416
+                        },
+                        "end": {
+                            "line": 20,
+                            "column": 49,
+                            "byte": 460
+                        }
+                    }
+                }
+            },
+            "jsonOutput": {
+                "value": "{\"account\":{\"id\":\"accountIdSecret\",\"name\":\"account-name\"},\"apiKey\":\"apiKeySecret\",\"apiToken\":\"apiTokenSecret\",\"username\":\"bot@pulumi.com\",\"zoneId\":\"zone-id-123\"}",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 16,
+                            "column": 5,
+                            "byte": 314
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 30,
+                            "byte": 339
+                        }
+                    }
+                }
+            },
+            "pulumiConfig": {
+                "value": {
+                    "accountId": {
+                        "value": "accountIdSecret",
+                        "secret": true,
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 22,
+                                    "column": 16,
+                                    "byte": 492
+                                },
+                                "end": {
+                                    "line": 22,
+                                    "column": 40,
+                                    "byte": 516
+                                }
+                            }
+                        }
+                    },
+                    "refTopLevelSecret": {
+                        "value": "top-secret",
+                        "secret": true,
+                        "trace": {
+                            "def": {
+                                "environment": "nested-unknowns-secrets",
+                                "begin": {
+                                    "line": 23,
+                                    "column": 24,
+                                    "byte": 540
+                                },
+                                "end": {
+                                    "line": 23,
+                                    "column": 43,
+                                    "byte": 559
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 22,
+                            "column": 5,
+                            "byte": 481
+                        },
+                        "end": {
+                            "line": 23,
+                            "column": 43,
+                            "byte": 559
+                        }
+                    }
+                }
+            },
+            "stringOutput": {
+                "value": "\"account\"=\"\\\"id\\\"=\\\"accountIdSecret\\\",\\\"name\\\"=\\\"account-name\\\"\",\"apiKey\"=\"apiKeySecret\",\"apiToken\"=\"apiTokenSecret\",\"username\"=\"bot@pulumi.com\",\"zoneId\"=\"zone-id-123\"",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 18,
+                            "column": 5,
+                            "byte": 360
+                        },
+                        "end": {
+                            "line": 18,
+                            "column": 32,
+                            "byte": 387
+                        }
+                    }
+                }
+            },
+            "top-level-secret": {
+                "value": "top-secret",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "nested-unknowns-secrets",
+                        "begin": {
+                            "line": 3,
+                            "column": 17,
+                            "byte": 44
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 27,
+                            "byte": 54
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "cloudflare": {
+                    "properties": {
+                        "account": {
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "const": "accountIdSecret"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "const": "account-name"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "id",
+                                "name"
+                            ]
+                        },
+                        "apiKey": {
+                            "type": "string",
+                            "const": "apiKeySecret"
+                        },
+                        "apiToken": {
+                            "type": "string",
+                            "const": "apiTokenSecret"
+                        },
+                        "username": {
+                            "type": "string",
+                            "const": "bot@pulumi.com"
+                        },
+                        "zoneId": {
+                            "type": "string",
+                            "const": "zone-id-123"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "account",
+                        "apiKey",
+                        "apiToken",
+                        "username",
+                        "zoneId"
+                    ]
+                },
+                "environmentVariables": {
+                    "properties": {
+                        "CLOUDFLARE_API_TOKEN": {
+                            "type": "string",
+                            "const": "apiTokenSecret"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "CLOUDFLARE_API_TOKEN"
+                    ]
+                },
+                "jsonOutput": {
+                    "type": "string"
+                },
+                "pulumiConfig": {
+                    "properties": {
+                        "accountId": {
+                            "type": "string",
+                            "const": "accountIdSecret"
+                        },
+                        "refTopLevelSecret": {
+                            "type": "string",
+                            "const": "top-secret"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "accountId",
+                        "refTopLevelSecret"
+                    ]
+                },
+                "stringOutput": {
+                    "type": "string"
+                },
+                "top-level-secret": {
+                    "type": "string",
+                    "const": "top-secret"
+                }
+            },
+            "type": "object",
+            "required": [
+                "cloudflare",
+                "environmentVariables",
+                "jsonOutput",
+                "pulumiConfig",
+                "stringOutput",
+                "top-level-secret"
+            ]
+        }
+    },
+    "evalJson": {
+        "cloudflare": {
+            "account": {
+                "id": "[secret]",
+                "name": "account-name"
+            },
+            "apiKey": "[secret]",
+            "apiToken": "[secret]",
+            "username": "bot@pulumi.com",
+            "zoneId": "zone-id-123"
+        },
+        "environmentVariables": {
+            "CLOUDFLARE_API_TOKEN": "[secret]"
+        },
+        "jsonOutput": "[secret]",
+        "pulumiConfig": {
+            "accountId": "[secret]",
+            "refTopLevelSecret": "[secret]"
+        },
+        "stringOutput": "[secret]",
+        "top-level-secret": "[secret]"
+    }
+}

--- a/eval/testdata/eval/open/expected.json
+++ b/eval/testdata/eval/open/expected.json
@@ -752,7 +752,6 @@
                         }
                     }
                 },
-                "unknown": true,
                 "trace": {
                     "def": {
                         "environment": "open",
@@ -815,7 +814,12 @@
         }
     },
     "checkJson": {
-        "referent": "[unknown]",
+        "referent": {
+            "foo": "[unknown]",
+            "list": "[unknown]",
+            "object": "[unknown]",
+            "test": "[unknown]"
+        },
         "test": "[unknown]"
     },
     "eval": {

--- a/eval/testdata/eval/schema-error/expected.json
+++ b/eval/testdata/eval/schema-error/expected.json
@@ -71,29 +71,6 @@
         },
         {
             "Severity": 1,
-            "Summary": "expected string, got boolean",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 42,
-                    "Column": 14,
-                    "Byte": 1000
-                },
-                "End": {
-                    "Line": 42,
-                    "Column": 29,
-                    "Byte": 1015
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].anyOf"
-        },
-        {
-            "Severity": 1,
             "Summary": "expected number, got boolean",
             "Detail": "",
             "Subject": {
@@ -118,6 +95,29 @@
         {
             "Severity": 1,
             "Summary": "at least one subschema must match",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 42,
+                    "Column": 14,
+                    "Byte": 1000
+                },
+                "End": {
+                    "Line": 42,
+                    "Column": 29,
+                    "Byte": 1015
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].anyOf"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected string, got boolean",
             "Detail": "",
             "Subject": {
                 "Filename": "schema-error",
@@ -255,7 +255,7 @@
         },
         {
             "Severity": 1,
-            "Summary": "dependentReq.bar: missing required property",
+            "Summary": "bar: missing required property",
             "Detail": "",
             "Subject": {
                 "Filename": "schema-error",
@@ -275,6 +275,29 @@
             "EvalContext": null,
             "Extra": null,
             "Path": "values.sink[\"fn::open::schema\"].dependentReq"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected a string of at least length 1",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 55,
+                    "Column": 18,
+                    "Byte": 1460
+                },
+                "End": {
+                    "Line": 55,
+                    "Column": 18,
+                    "Byte": 1460
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].minLength"
         }
     ],
     "check": {

--- a/eval/testdata/eval/schema/expected.json
+++ b/eval/testdata/eval/schema/expected.json
@@ -3945,7 +3945,6 @@
                         }
                     }
                 ],
-                "unknown": true,
                 "trace": {
                     "def": {
                         "environment": "schema",
@@ -4466,7 +4465,14 @@
         }
     },
     "checkJson": {
-        "accesses": "[unknown]",
+        "accesses": [
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]"
+        ],
         "sink": "[unknown]",
         "source": "[unknown]"
     },


### PR DESCRIPTION
Do not treat object and array literals that include unknown or secret
elements as unknown or secret themselves. Instead, leave it up to the
consumer of the literal to handle unknownness and secretness
appropriately (i.e. by combining the unknownness and secretness of each
leaf value the consumer observes).

For example, the following object definition no is no longer unknown
during check or secret during eval:

```yaml
foo:
  bar: 42
  baz:
    fn::secret:
      ciphertext: AjIAEJFDIe==
```

Instead, it is partially-known during check:

```yaml
foo:
  bar: 42
  baz: [unknown]
```

And partially-secret during eval:

```yaml
foo:
  bar: 42
  baz: [secret]
```

But when passed to `fn::toJSON`, the result of the call would be unknown
in check or secret in eval b/c of the nested unknown/secret.

Fixes https://github.com/pulumi/esc/issues/164.
Fixes https://github.com/pulumi/pulumi-service/issues/16162.