### PR TITLE
Reorder test output for easier diff parsing for humans

### DIFF
--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -183,10 +183,10 @@ func TestEval(t *testing.T) {
 	type expectedData struct {
 		LoadDiags  syntax.Diagnostics `json:"loadDiags,omitempty"`
 		CheckDiags syntax.Diagnostics `json:"checkDiags,omitempty"`
-		Check      *esc.Environment   `json:"check,omitempty"`
-		CheckJSON  any                `json:"checkJson,omitempty"`
 		EvalDiags  syntax.Diagnostics `json:"evalDiags,omitempty"`
+		Check      *esc.Environment   `json:"check,omitempty"`
 		Eval       *esc.Environment   `json:"eval,omitempty"`
+		CheckJSON  any                `json:"checkJson,omitempty"`
 		EvalJSON   any                `json:"evalJson,omitempty"`
 	}
 

--- a/eval/testdata/eval/builtin-combine/expected.json
+++ b/eval/testdata/eval/builtin-combine/expected.json
@@ -897,16 +897,6 @@
             ]
         }
     },
-    "checkJson": {
-        "builtins": [
-            "[secret]",
-            "[secret]",
-            "[secret]",
-            "[secret]"
-        ],
-        "open": "[unknown]",
-        "password": "[secret]"
-    },
     "eval": {
         "exprs": {
             "builtins": {
@@ -1851,6 +1841,16 @@
                 "password"
             ]
         }
+    },
+    "checkJson": {
+        "builtins": [
+            "[secret]",
+            "[secret]",
+            "[secret]",
+            "[secret]"
+        ],
+        "open": "[unknown]",
+        "password": "[secret]"
     },
     "evalJson": {
         "builtins": [

--- a/eval/testdata/eval/builtin-errs/expected.json
+++ b/eval/testdata/eval/builtin-errs/expected.json
@@ -162,7 +162,1059 @@
             "Path": "values.builtins[6][\"fn::toString\"]"
         }
     ],
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"missing\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-errs",
+                "Start": {
+                    "Line": 4,
+                    "Column": 25,
+                    "Byte": 57
+                },
+                "End": {
+                    "Line": 4,
+                    "Column": 35,
+                    "Byte": 67
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.builtins[0][\"fn::open::test\"]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"missing\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-errs",
+                "Start": {
+                    "Line": 5,
+                    "Column": 25,
+                    "Byte": 96
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 35,
+                    "Byte": 106
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.builtins[1][\"fn::join\"][1]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected string, got number",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-errs",
+                "Start": {
+                    "Line": 6,
+                    "Column": 27,
+                    "Byte": 139
+                },
+                "End": {
+                    "Line": 6,
+                    "Column": 36,
+                    "Byte": 148
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.builtins[2][\"fn::join\"][1][0]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"missing\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-errs",
+                "Start": {
+                    "Line": 7,
+                    "Column": 23,
+                    "Byte": 179
+                },
+                "End": {
+                    "Line": 7,
+                    "Column": 33,
+                    "Byte": 189
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.builtins[3][\"fn::toBase64\"]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected string, got number",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-errs",
+                "Start": {
+                    "Line": 8,
+                    "Column": 23,
+                    "Byte": 216
+                },
+                "End": {
+                    "Line": 8,
+                    "Column": 32,
+                    "Byte": 225
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.builtins[4][\"fn::toBase64\"]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"missing\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-errs",
+                "Start": {
+                    "Line": 9,
+                    "Column": 21,
+                    "Byte": 250
+                },
+                "End": {
+                    "Line": 9,
+                    "Column": 31,
+                    "Byte": 260
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.builtins[5][\"fn::toJSON\"]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"missing\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-errs",
+                "Start": {
+                    "Line": 10,
+                    "Column": 23,
+                    "Byte": 287
+                },
+                "End": {
+                    "Line": 10,
+                    "Column": 33,
+                    "Byte": 297
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.builtins[6][\"fn::toString\"]"
+        }
+    ],
     "check": {
+        "exprs": {
+            "builtins": {
+                "range": {
+                    "environment": "builtin-errs",
+                    "begin": {
+                        "line": 4,
+                        "column": 5,
+                        "byte": 37
+                    },
+                    "end": {
+                        "line": 10,
+                        "column": 33,
+                        "byte": 297
+                    }
+                },
+                "schema": {
+                    "prefixItems": [
+                        true,
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "items": false,
+                    "type": "array"
+                },
+                "list": [
+                    {
+                        "range": {
+                            "environment": "builtin-errs",
+                            "begin": {
+                                "line": 4,
+                                "column": 7,
+                                "byte": 39
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 35,
+                                "byte": 67
+                            }
+                        },
+                        "schema": true,
+                        "builtin": {
+                            "name": "fn::open::test",
+                            "nameRange": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 9,
+                                    "byte": 41
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 23,
+                                    "byte": 55
+                                }
+                            },
+                            "argSchema": true,
+                            "arg": {
+                                "range": {
+                                    "environment": "builtin-errs",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 25,
+                                        "byte": 57
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 35,
+                                        "byte": 67
+                                    }
+                                },
+                                "schema": true,
+                                "symbol": [
+                                    {
+                                        "key": "missing",
+                                        "value": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 4,
+                                                "column": 25,
+                                                "byte": 57
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 35,
+                                                "byte": 67
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "range": {
+                            "environment": "builtin-errs",
+                            "begin": {
+                                "line": 5,
+                                "column": 7,
+                                "byte": 78
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 35,
+                                "byte": 106
+                            }
+                        },
+                        "schema": {
+                            "type": "string"
+                        },
+                        "builtin": {
+                            "name": "fn::join",
+                            "nameRange": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 9,
+                                    "byte": 80
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 17,
+                                    "byte": 88
+                                }
+                            },
+                            "argSchema": {
+                                "prefixItems": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                ],
+                                "items": false,
+                                "type": "array"
+                            },
+                            "arg": {
+                                "range": {
+                                    "environment": "builtin-errs",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 19,
+                                        "byte": 90
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 35,
+                                        "byte": 106
+                                    }
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 5,
+                                                "column": 20,
+                                                "byte": 91
+                                            },
+                                            "end": {
+                                                "line": 5,
+                                                "column": 21,
+                                                "byte": 92
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": ","
+                                        },
+                                        "literal": ","
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 5,
+                                                "column": 25,
+                                                "byte": 96
+                                            },
+                                            "end": {
+                                                "line": 5,
+                                                "column": 35,
+                                                "byte": 106
+                                            }
+                                        },
+                                        "schema": true,
+                                        "symbol": [
+                                            {
+                                                "key": "missing",
+                                                "value": {
+                                                    "environment": "builtin-errs",
+                                                    "begin": {
+                                                        "line": 5,
+                                                        "column": 25,
+                                                        "byte": 96
+                                                    },
+                                                    "end": {
+                                                        "line": 5,
+                                                        "column": 35,
+                                                        "byte": 106
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "range": {
+                            "environment": "builtin-errs",
+                            "begin": {
+                                "line": 6,
+                                "column": 7,
+                                "byte": 119
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 36,
+                                "byte": 148
+                            }
+                        },
+                        "schema": {
+                            "type": "string"
+                        },
+                        "builtin": {
+                            "name": "fn::join",
+                            "nameRange": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 9,
+                                    "byte": 121
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 17,
+                                    "byte": 129
+                                }
+                            },
+                            "argSchema": {
+                                "prefixItems": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                ],
+                                "items": false,
+                                "type": "array"
+                            },
+                            "arg": {
+                                "range": {
+                                    "environment": "builtin-errs",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 19,
+                                        "byte": 131
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 36,
+                                        "byte": 148
+                                    }
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 6,
+                                                "column": 20,
+                                                "byte": 132
+                                            },
+                                            "end": {
+                                                "line": 6,
+                                                "column": 21,
+                                                "byte": 133
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": ","
+                                        },
+                                        "literal": ","
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 6,
+                                                "column": 25,
+                                                "byte": 137
+                                            },
+                                            "end": {
+                                                "line": 6,
+                                                "column": 36,
+                                                "byte": 148
+                                            }
+                                        },
+                                        "schema": {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 42
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        },
+                                        "list": [
+                                            {
+                                                "range": {
+                                                    "environment": "builtin-errs",
+                                                    "begin": {
+                                                        "line": 6,
+                                                        "column": 27,
+                                                        "byte": 139
+                                                    },
+                                                    "end": {
+                                                        "line": 6,
+                                                        "column": 36,
+                                                        "byte": 148
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "number",
+                                                    "const": 42
+                                                },
+                                                "symbol": [
+                                                    {
+                                                        "key": "number",
+                                                        "value": {
+                                                            "environment": "builtin-errs",
+                                                            "begin": {
+                                                                "line": 2,
+                                                                "column": 11,
+                                                                "byte": 18
+                                                            },
+                                                            "end": {
+                                                                "line": 2,
+                                                                "column": 13,
+                                                                "byte": 20
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "range": {
+                            "environment": "builtin-errs",
+                            "begin": {
+                                "line": 7,
+                                "column": 7,
+                                "byte": 163
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 33,
+                                "byte": 189
+                            }
+                        },
+                        "schema": {
+                            "type": "string"
+                        },
+                        "builtin": {
+                            "name": "fn::toBase64",
+                            "nameRange": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 9,
+                                    "byte": 165
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 21,
+                                    "byte": 177
+                                }
+                            },
+                            "argSchema": {
+                                "type": "string"
+                            },
+                            "arg": {
+                                "range": {
+                                    "environment": "builtin-errs",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 23,
+                                        "byte": 179
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 33,
+                                        "byte": 189
+                                    }
+                                },
+                                "schema": true,
+                                "symbol": [
+                                    {
+                                        "key": "missing",
+                                        "value": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 23,
+                                                "byte": 179
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 33,
+                                                "byte": 189
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "range": {
+                            "environment": "builtin-errs",
+                            "begin": {
+                                "line": 8,
+                                "column": 7,
+                                "byte": 200
+                            },
+                            "end": {
+                                "line": 8,
+                                "column": 32,
+                                "byte": 225
+                            }
+                        },
+                        "schema": {
+                            "type": "string"
+                        },
+                        "builtin": {
+                            "name": "fn::toBase64",
+                            "nameRange": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 9,
+                                    "byte": 202
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 21,
+                                    "byte": 214
+                                }
+                            },
+                            "argSchema": {
+                                "type": "string"
+                            },
+                            "arg": {
+                                "range": {
+                                    "environment": "builtin-errs",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 23,
+                                        "byte": 216
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 32,
+                                        "byte": 225
+                                    }
+                                },
+                                "schema": {
+                                    "type": "number",
+                                    "const": 42
+                                },
+                                "symbol": [
+                                    {
+                                        "key": "number",
+                                        "value": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 2,
+                                                "column": 11,
+                                                "byte": 18
+                                            },
+                                            "end": {
+                                                "line": 2,
+                                                "column": 13,
+                                                "byte": 20
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "range": {
+                            "environment": "builtin-errs",
+                            "begin": {
+                                "line": 9,
+                                "column": 7,
+                                "byte": 236
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 31,
+                                "byte": 260
+                            }
+                        },
+                        "schema": {
+                            "type": "string"
+                        },
+                        "builtin": {
+                            "name": "fn::toJSON",
+                            "nameRange": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 9,
+                                    "byte": 238
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 19,
+                                    "byte": 248
+                                }
+                            },
+                            "argSchema": true,
+                            "arg": {
+                                "range": {
+                                    "environment": "builtin-errs",
+                                    "begin": {
+                                        "line": 9,
+                                        "column": 21,
+                                        "byte": 250
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 31,
+                                        "byte": 260
+                                    }
+                                },
+                                "schema": true,
+                                "symbol": [
+                                    {
+                                        "key": "missing",
+                                        "value": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 9,
+                                                "column": 21,
+                                                "byte": 250
+                                            },
+                                            "end": {
+                                                "line": 9,
+                                                "column": 31,
+                                                "byte": 260
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "range": {
+                            "environment": "builtin-errs",
+                            "begin": {
+                                "line": 10,
+                                "column": 7,
+                                "byte": 271
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 33,
+                                "byte": 297
+                            }
+                        },
+                        "schema": {
+                            "type": "string"
+                        },
+                        "builtin": {
+                            "name": "fn::toString",
+                            "nameRange": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 9,
+                                    "byte": 273
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 21,
+                                    "byte": 285
+                                }
+                            },
+                            "argSchema": true,
+                            "arg": {
+                                "range": {
+                                    "environment": "builtin-errs",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 23,
+                                        "byte": 287
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 33,
+                                        "byte": 297
+                                    }
+                                },
+                                "schema": true,
+                                "symbol": [
+                                    {
+                                        "key": "missing",
+                                        "value": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 10,
+                                                "column": 23,
+                                                "byte": 287
+                                            },
+                                            "end": {
+                                                "line": 10,
+                                                "column": 33,
+                                                "byte": 297
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ]
+            },
+            "number": {
+                "range": {
+                    "environment": "builtin-errs",
+                    "begin": {
+                        "line": 2,
+                        "column": 11,
+                        "byte": 18
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 13,
+                        "byte": 20
+                    }
+                },
+                "schema": {
+                    "type": "number",
+                    "const": 42
+                },
+                "literal": 42
+            }
+        },
+        "properties": {
+            "builtins": {
+                "value": [
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 7,
+                                    "byte": 39
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 35,
+                                    "byte": 67
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 7,
+                                    "byte": 78
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 35,
+                                    "byte": 106
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 7,
+                                    "byte": 119
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 36,
+                                    "byte": 148
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 7,
+                                    "byte": 163
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 33,
+                                    "byte": 189
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 7,
+                                    "byte": 200
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 32,
+                                    "byte": 225
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 7,
+                                    "byte": 236
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 31,
+                                    "byte": 260
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-errs",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 7,
+                                    "byte": 271
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 33,
+                                    "byte": 297
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-errs",
+                        "begin": {
+                            "line": 4,
+                            "column": 5,
+                            "byte": 37
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 33,
+                            "byte": 297
+                        }
+                    }
+                }
+            },
+            "number": {
+                "value": 42,
+                "trace": {
+                    "def": {
+                        "environment": "builtin-errs",
+                        "begin": {
+                            "line": 2,
+                            "column": 11,
+                            "byte": 18
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 13,
+                            "byte": 20
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "builtins": {
+                    "prefixItems": [
+                        true,
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "items": false,
+                    "type": "array"
+                },
+                "number": {
+                    "type": "number",
+                    "const": 42
+                }
+            },
+            "type": "object",
+            "required": [
+                "builtins",
+                "number"
+            ]
+        }
+    },
+    "eval": {
         "exprs": {
             "builtins": {
                 "range": {
@@ -1062,1058 +2114,6 @@
             "[unknown]"
         ],
         "number": 42
-    },
-    "evalDiags": [
-        {
-            "Severity": 1,
-            "Summary": "unknown property \"missing\"",
-            "Detail": "",
-            "Subject": {
-                "Filename": "builtin-errs",
-                "Start": {
-                    "Line": 4,
-                    "Column": 25,
-                    "Byte": 57
-                },
-                "End": {
-                    "Line": 4,
-                    "Column": 35,
-                    "Byte": 67
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.builtins[0][\"fn::open::test\"]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "unknown property \"missing\"",
-            "Detail": "",
-            "Subject": {
-                "Filename": "builtin-errs",
-                "Start": {
-                    "Line": 5,
-                    "Column": 25,
-                    "Byte": 96
-                },
-                "End": {
-                    "Line": 5,
-                    "Column": 35,
-                    "Byte": 106
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.builtins[1][\"fn::join\"][1]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected string, got number",
-            "Detail": "",
-            "Subject": {
-                "Filename": "builtin-errs",
-                "Start": {
-                    "Line": 6,
-                    "Column": 27,
-                    "Byte": 139
-                },
-                "End": {
-                    "Line": 6,
-                    "Column": 36,
-                    "Byte": 148
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.builtins[2][\"fn::join\"][1][0]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "unknown property \"missing\"",
-            "Detail": "",
-            "Subject": {
-                "Filename": "builtin-errs",
-                "Start": {
-                    "Line": 7,
-                    "Column": 23,
-                    "Byte": 179
-                },
-                "End": {
-                    "Line": 7,
-                    "Column": 33,
-                    "Byte": 189
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.builtins[3][\"fn::toBase64\"]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected string, got number",
-            "Detail": "",
-            "Subject": {
-                "Filename": "builtin-errs",
-                "Start": {
-                    "Line": 8,
-                    "Column": 23,
-                    "Byte": 216
-                },
-                "End": {
-                    "Line": 8,
-                    "Column": 32,
-                    "Byte": 225
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.builtins[4][\"fn::toBase64\"]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "unknown property \"missing\"",
-            "Detail": "",
-            "Subject": {
-                "Filename": "builtin-errs",
-                "Start": {
-                    "Line": 9,
-                    "Column": 21,
-                    "Byte": 250
-                },
-                "End": {
-                    "Line": 9,
-                    "Column": 31,
-                    "Byte": 260
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.builtins[5][\"fn::toJSON\"]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "unknown property \"missing\"",
-            "Detail": "",
-            "Subject": {
-                "Filename": "builtin-errs",
-                "Start": {
-                    "Line": 10,
-                    "Column": 23,
-                    "Byte": 287
-                },
-                "End": {
-                    "Line": 10,
-                    "Column": 33,
-                    "Byte": 297
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.builtins[6][\"fn::toString\"]"
-        }
-    ],
-    "eval": {
-        "exprs": {
-            "builtins": {
-                "range": {
-                    "environment": "builtin-errs",
-                    "begin": {
-                        "line": 4,
-                        "column": 5,
-                        "byte": 37
-                    },
-                    "end": {
-                        "line": 10,
-                        "column": 33,
-                        "byte": 297
-                    }
-                },
-                "schema": {
-                    "prefixItems": [
-                        true,
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ],
-                    "items": false,
-                    "type": "array"
-                },
-                "list": [
-                    {
-                        "range": {
-                            "environment": "builtin-errs",
-                            "begin": {
-                                "line": 4,
-                                "column": 7,
-                                "byte": 39
-                            },
-                            "end": {
-                                "line": 4,
-                                "column": 35,
-                                "byte": 67
-                            }
-                        },
-                        "schema": true,
-                        "builtin": {
-                            "name": "fn::open::test",
-                            "nameRange": {
-                                "environment": "builtin-errs",
-                                "begin": {
-                                    "line": 4,
-                                    "column": 9,
-                                    "byte": 41
-                                },
-                                "end": {
-                                    "line": 4,
-                                    "column": 23,
-                                    "byte": 55
-                                }
-                            },
-                            "argSchema": true,
-                            "arg": {
-                                "range": {
-                                    "environment": "builtin-errs",
-                                    "begin": {
-                                        "line": 4,
-                                        "column": 25,
-                                        "byte": 57
-                                    },
-                                    "end": {
-                                        "line": 4,
-                                        "column": 35,
-                                        "byte": 67
-                                    }
-                                },
-                                "schema": true,
-                                "symbol": [
-                                    {
-                                        "key": "missing",
-                                        "value": {
-                                            "environment": "builtin-errs",
-                                            "begin": {
-                                                "line": 4,
-                                                "column": 25,
-                                                "byte": 57
-                                            },
-                                            "end": {
-                                                "line": 4,
-                                                "column": 35,
-                                                "byte": 67
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    {
-                        "range": {
-                            "environment": "builtin-errs",
-                            "begin": {
-                                "line": 5,
-                                "column": 7,
-                                "byte": 78
-                            },
-                            "end": {
-                                "line": 5,
-                                "column": 35,
-                                "byte": 106
-                            }
-                        },
-                        "schema": {
-                            "type": "string"
-                        },
-                        "builtin": {
-                            "name": "fn::join",
-                            "nameRange": {
-                                "environment": "builtin-errs",
-                                "begin": {
-                                    "line": 5,
-                                    "column": 9,
-                                    "byte": 80
-                                },
-                                "end": {
-                                    "line": 5,
-                                    "column": 17,
-                                    "byte": 88
-                                }
-                            },
-                            "argSchema": {
-                                "prefixItems": [
-                                    {
-                                        "type": "string"
-                                    },
-                                    {
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "type": "array"
-                                    }
-                                ],
-                                "items": false,
-                                "type": "array"
-                            },
-                            "arg": {
-                                "range": {
-                                    "environment": "builtin-errs",
-                                    "begin": {
-                                        "line": 5,
-                                        "column": 19,
-                                        "byte": 90
-                                    },
-                                    "end": {
-                                        "line": 5,
-                                        "column": 35,
-                                        "byte": 106
-                                    }
-                                },
-                                "list": [
-                                    {
-                                        "range": {
-                                            "environment": "builtin-errs",
-                                            "begin": {
-                                                "line": 5,
-                                                "column": 20,
-                                                "byte": 91
-                                            },
-                                            "end": {
-                                                "line": 5,
-                                                "column": 21,
-                                                "byte": 92
-                                            }
-                                        },
-                                        "schema": {
-                                            "type": "string",
-                                            "const": ","
-                                        },
-                                        "literal": ","
-                                    },
-                                    {
-                                        "range": {
-                                            "environment": "builtin-errs",
-                                            "begin": {
-                                                "line": 5,
-                                                "column": 25,
-                                                "byte": 96
-                                            },
-                                            "end": {
-                                                "line": 5,
-                                                "column": 35,
-                                                "byte": 106
-                                            }
-                                        },
-                                        "schema": true,
-                                        "symbol": [
-                                            {
-                                                "key": "missing",
-                                                "value": {
-                                                    "environment": "builtin-errs",
-                                                    "begin": {
-                                                        "line": 5,
-                                                        "column": 25,
-                                                        "byte": 96
-                                                    },
-                                                    "end": {
-                                                        "line": 5,
-                                                        "column": 35,
-                                                        "byte": 106
-                                                    }
-                                                }
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    {
-                        "range": {
-                            "environment": "builtin-errs",
-                            "begin": {
-                                "line": 6,
-                                "column": 7,
-                                "byte": 119
-                            },
-                            "end": {
-                                "line": 6,
-                                "column": 36,
-                                "byte": 148
-                            }
-                        },
-                        "schema": {
-                            "type": "string"
-                        },
-                        "builtin": {
-                            "name": "fn::join",
-                            "nameRange": {
-                                "environment": "builtin-errs",
-                                "begin": {
-                                    "line": 6,
-                                    "column": 9,
-                                    "byte": 121
-                                },
-                                "end": {
-                                    "line": 6,
-                                    "column": 17,
-                                    "byte": 129
-                                }
-                            },
-                            "argSchema": {
-                                "prefixItems": [
-                                    {
-                                        "type": "string"
-                                    },
-                                    {
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "type": "array"
-                                    }
-                                ],
-                                "items": false,
-                                "type": "array"
-                            },
-                            "arg": {
-                                "range": {
-                                    "environment": "builtin-errs",
-                                    "begin": {
-                                        "line": 6,
-                                        "column": 19,
-                                        "byte": 131
-                                    },
-                                    "end": {
-                                        "line": 6,
-                                        "column": 36,
-                                        "byte": 148
-                                    }
-                                },
-                                "list": [
-                                    {
-                                        "range": {
-                                            "environment": "builtin-errs",
-                                            "begin": {
-                                                "line": 6,
-                                                "column": 20,
-                                                "byte": 132
-                                            },
-                                            "end": {
-                                                "line": 6,
-                                                "column": 21,
-                                                "byte": 133
-                                            }
-                                        },
-                                        "schema": {
-                                            "type": "string",
-                                            "const": ","
-                                        },
-                                        "literal": ","
-                                    },
-                                    {
-                                        "range": {
-                                            "environment": "builtin-errs",
-                                            "begin": {
-                                                "line": 6,
-                                                "column": 25,
-                                                "byte": 137
-                                            },
-                                            "end": {
-                                                "line": 6,
-                                                "column": 36,
-                                                "byte": 148
-                                            }
-                                        },
-                                        "schema": {
-                                            "prefixItems": [
-                                                {
-                                                    "type": "number",
-                                                    "const": 42
-                                                }
-                                            ],
-                                            "items": false,
-                                            "type": "array"
-                                        },
-                                        "list": [
-                                            {
-                                                "range": {
-                                                    "environment": "builtin-errs",
-                                                    "begin": {
-                                                        "line": 6,
-                                                        "column": 27,
-                                                        "byte": 139
-                                                    },
-                                                    "end": {
-                                                        "line": 6,
-                                                        "column": 36,
-                                                        "byte": 148
-                                                    }
-                                                },
-                                                "schema": {
-                                                    "type": "number",
-                                                    "const": 42
-                                                },
-                                                "symbol": [
-                                                    {
-                                                        "key": "number",
-                                                        "value": {
-                                                            "environment": "builtin-errs",
-                                                            "begin": {
-                                                                "line": 2,
-                                                                "column": 11,
-                                                                "byte": 18
-                                                            },
-                                                            "end": {
-                                                                "line": 2,
-                                                                "column": 13,
-                                                                "byte": 20
-                                                            }
-                                                        }
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    {
-                        "range": {
-                            "environment": "builtin-errs",
-                            "begin": {
-                                "line": 7,
-                                "column": 7,
-                                "byte": 163
-                            },
-                            "end": {
-                                "line": 7,
-                                "column": 33,
-                                "byte": 189
-                            }
-                        },
-                        "schema": {
-                            "type": "string"
-                        },
-                        "builtin": {
-                            "name": "fn::toBase64",
-                            "nameRange": {
-                                "environment": "builtin-errs",
-                                "begin": {
-                                    "line": 7,
-                                    "column": 9,
-                                    "byte": 165
-                                },
-                                "end": {
-                                    "line": 7,
-                                    "column": 21,
-                                    "byte": 177
-                                }
-                            },
-                            "argSchema": {
-                                "type": "string"
-                            },
-                            "arg": {
-                                "range": {
-                                    "environment": "builtin-errs",
-                                    "begin": {
-                                        "line": 7,
-                                        "column": 23,
-                                        "byte": 179
-                                    },
-                                    "end": {
-                                        "line": 7,
-                                        "column": 33,
-                                        "byte": 189
-                                    }
-                                },
-                                "schema": true,
-                                "symbol": [
-                                    {
-                                        "key": "missing",
-                                        "value": {
-                                            "environment": "builtin-errs",
-                                            "begin": {
-                                                "line": 7,
-                                                "column": 23,
-                                                "byte": 179
-                                            },
-                                            "end": {
-                                                "line": 7,
-                                                "column": 33,
-                                                "byte": 189
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    {
-                        "range": {
-                            "environment": "builtin-errs",
-                            "begin": {
-                                "line": 8,
-                                "column": 7,
-                                "byte": 200
-                            },
-                            "end": {
-                                "line": 8,
-                                "column": 32,
-                                "byte": 225
-                            }
-                        },
-                        "schema": {
-                            "type": "string"
-                        },
-                        "builtin": {
-                            "name": "fn::toBase64",
-                            "nameRange": {
-                                "environment": "builtin-errs",
-                                "begin": {
-                                    "line": 8,
-                                    "column": 9,
-                                    "byte": 202
-                                },
-                                "end": {
-                                    "line": 8,
-                                    "column": 21,
-                                    "byte": 214
-                                }
-                            },
-                            "argSchema": {
-                                "type": "string"
-                            },
-                            "arg": {
-                                "range": {
-                                    "environment": "builtin-errs",
-                                    "begin": {
-                                        "line": 8,
-                                        "column": 23,
-                                        "byte": 216
-                                    },
-                                    "end": {
-                                        "line": 8,
-                                        "column": 32,
-                                        "byte": 225
-                                    }
-                                },
-                                "schema": {
-                                    "type": "number",
-                                    "const": 42
-                                },
-                                "symbol": [
-                                    {
-                                        "key": "number",
-                                        "value": {
-                                            "environment": "builtin-errs",
-                                            "begin": {
-                                                "line": 2,
-                                                "column": 11,
-                                                "byte": 18
-                                            },
-                                            "end": {
-                                                "line": 2,
-                                                "column": 13,
-                                                "byte": 20
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    {
-                        "range": {
-                            "environment": "builtin-errs",
-                            "begin": {
-                                "line": 9,
-                                "column": 7,
-                                "byte": 236
-                            },
-                            "end": {
-                                "line": 9,
-                                "column": 31,
-                                "byte": 260
-                            }
-                        },
-                        "schema": {
-                            "type": "string"
-                        },
-                        "builtin": {
-                            "name": "fn::toJSON",
-                            "nameRange": {
-                                "environment": "builtin-errs",
-                                "begin": {
-                                    "line": 9,
-                                    "column": 9,
-                                    "byte": 238
-                                },
-                                "end": {
-                                    "line": 9,
-                                    "column": 19,
-                                    "byte": 248
-                                }
-                            },
-                            "argSchema": true,
-                            "arg": {
-                                "range": {
-                                    "environment": "builtin-errs",
-                                    "begin": {
-                                        "line": 9,
-                                        "column": 21,
-                                        "byte": 250
-                                    },
-                                    "end": {
-                                        "line": 9,
-                                        "column": 31,
-                                        "byte": 260
-                                    }
-                                },
-                                "schema": true,
-                                "symbol": [
-                                    {
-                                        "key": "missing",
-                                        "value": {
-                                            "environment": "builtin-errs",
-                                            "begin": {
-                                                "line": 9,
-                                                "column": 21,
-                                                "byte": 250
-                                            },
-                                            "end": {
-                                                "line": 9,
-                                                "column": 31,
-                                                "byte": 260
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    {
-                        "range": {
-                            "environment": "builtin-errs",
-                            "begin": {
-                                "line": 10,
-                                "column": 7,
-                                "byte": 271
-                            },
-                            "end": {
-                                "line": 10,
-                                "column": 33,
-                                "byte": 297
-                            }
-                        },
-                        "schema": {
-                            "type": "string"
-                        },
-                        "builtin": {
-                            "name": "fn::toString",
-                            "nameRange": {
-                                "environment": "builtin-errs",
-                                "begin": {
-                                    "line": 10,
-                                    "column": 9,
-                                    "byte": 273
-                                },
-                                "end": {
-                                    "line": 10,
-                                    "column": 21,
-                                    "byte": 285
-                                }
-                            },
-                            "argSchema": true,
-                            "arg": {
-                                "range": {
-                                    "environment": "builtin-errs",
-                                    "begin": {
-                                        "line": 10,
-                                        "column": 23,
-                                        "byte": 287
-                                    },
-                                    "end": {
-                                        "line": 10,
-                                        "column": 33,
-                                        "byte": 297
-                                    }
-                                },
-                                "schema": true,
-                                "symbol": [
-                                    {
-                                        "key": "missing",
-                                        "value": {
-                                            "environment": "builtin-errs",
-                                            "begin": {
-                                                "line": 10,
-                                                "column": 23,
-                                                "byte": 287
-                                            },
-                                            "end": {
-                                                "line": 10,
-                                                "column": 33,
-                                                "byte": 297
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            "number": {
-                "range": {
-                    "environment": "builtin-errs",
-                    "begin": {
-                        "line": 2,
-                        "column": 11,
-                        "byte": 18
-                    },
-                    "end": {
-                        "line": 2,
-                        "column": 13,
-                        "byte": 20
-                    }
-                },
-                "schema": {
-                    "type": "number",
-                    "const": 42
-                },
-                "literal": 42
-            }
-        },
-        "properties": {
-            "builtins": {
-                "value": [
-                    {
-                        "unknown": true,
-                        "trace": {
-                            "def": {
-                                "environment": "builtin-errs",
-                                "begin": {
-                                    "line": 4,
-                                    "column": 7,
-                                    "byte": 39
-                                },
-                                "end": {
-                                    "line": 4,
-                                    "column": 35,
-                                    "byte": 67
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "unknown": true,
-                        "trace": {
-                            "def": {
-                                "environment": "builtin-errs",
-                                "begin": {
-                                    "line": 5,
-                                    "column": 7,
-                                    "byte": 78
-                                },
-                                "end": {
-                                    "line": 5,
-                                    "column": 35,
-                                    "byte": 106
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "unknown": true,
-                        "trace": {
-                            "def": {
-                                "environment": "builtin-errs",
-                                "begin": {
-                                    "line": 6,
-                                    "column": 7,
-                                    "byte": 119
-                                },
-                                "end": {
-                                    "line": 6,
-                                    "column": 36,
-                                    "byte": 148
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "unknown": true,
-                        "trace": {
-                            "def": {
-                                "environment": "builtin-errs",
-                                "begin": {
-                                    "line": 7,
-                                    "column": 7,
-                                    "byte": 163
-                                },
-                                "end": {
-                                    "line": 7,
-                                    "column": 33,
-                                    "byte": 189
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "unknown": true,
-                        "trace": {
-                            "def": {
-                                "environment": "builtin-errs",
-                                "begin": {
-                                    "line": 8,
-                                    "column": 7,
-                                    "byte": 200
-                                },
-                                "end": {
-                                    "line": 8,
-                                    "column": 32,
-                                    "byte": 225
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "unknown": true,
-                        "trace": {
-                            "def": {
-                                "environment": "builtin-errs",
-                                "begin": {
-                                    "line": 9,
-                                    "column": 7,
-                                    "byte": 236
-                                },
-                                "end": {
-                                    "line": 9,
-                                    "column": 31,
-                                    "byte": 260
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "unknown": true,
-                        "trace": {
-                            "def": {
-                                "environment": "builtin-errs",
-                                "begin": {
-                                    "line": 10,
-                                    "column": 7,
-                                    "byte": 271
-                                },
-                                "end": {
-                                    "line": 10,
-                                    "column": 33,
-                                    "byte": 297
-                                }
-                            }
-                        }
-                    }
-                ],
-                "trace": {
-                    "def": {
-                        "environment": "builtin-errs",
-                        "begin": {
-                            "line": 4,
-                            "column": 5,
-                            "byte": 37
-                        },
-                        "end": {
-                            "line": 10,
-                            "column": 33,
-                            "byte": 297
-                        }
-                    }
-                }
-            },
-            "number": {
-                "value": 42,
-                "trace": {
-                    "def": {
-                        "environment": "builtin-errs",
-                        "begin": {
-                            "line": 2,
-                            "column": 11,
-                            "byte": 18
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 13,
-                            "byte": 20
-                        }
-                    }
-                }
-            }
-        },
-        "schema": {
-            "properties": {
-                "builtins": {
-                    "prefixItems": [
-                        true,
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ],
-                    "items": false,
-                    "type": "array"
-                },
-                "number": {
-                    "type": "number",
-                    "const": 42
-                }
-            },
-            "type": "object",
-            "required": [
-                "builtins",
-                "number"
-            ]
-        }
     },
     "evalJson": {
         "builtins": [

--- a/eval/testdata/eval/ciphertext-invalid/expected.json
+++ b/eval/testdata/eval/ciphertext-invalid/expected.json
@@ -24,7 +24,140 @@
             "Path": "values.password"
         }
     ],
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "invalid ciphertext: EOF",
+            "Detail": "",
+            "Subject": {
+                "Filename": "ciphertext-invalid",
+                "Start": {
+                    "Line": 3,
+                    "Column": 5,
+                    "Byte": 24
+                },
+                "End": {
+                    "Line": 4,
+                    "Column": 27,
+                    "Byte": 62
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.password"
+        }
+    ],
     "check": {
+        "exprs": {
+            "password": {
+                "range": {
+                    "environment": "ciphertext-invalid",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 24
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 27,
+                        "byte": 62
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "ciphertext-invalid",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 24
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 34
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "ciphertext-invalid",
+                            "begin": {
+                                "line": 4,
+                                "column": 7,
+                                "byte": 42
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 27,
+                                "byte": 62
+                            }
+                        },
+                        "object": {
+                            "ciphertext": {
+                                "range": {
+                                    "environment": "ciphertext-invalid",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 19,
+                                        "byte": 54
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 27,
+                                        "byte": 62
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "hunter23"
+                                },
+                                "literal": "hunter23"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "password": {
+                "secret": true,
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "ciphertext-invalid",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 24
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 27,
+                            "byte": 62
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "password": {
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "required": [
+                "password"
+            ]
+        }
+    },
+    "eval": {
         "exprs": {
             "password": {
                 "range": {
@@ -134,139 +267,6 @@
     },
     "checkJson": {
         "password": "[secret]"
-    },
-    "evalDiags": [
-        {
-            "Severity": 1,
-            "Summary": "invalid ciphertext: EOF",
-            "Detail": "",
-            "Subject": {
-                "Filename": "ciphertext-invalid",
-                "Start": {
-                    "Line": 3,
-                    "Column": 5,
-                    "Byte": 24
-                },
-                "End": {
-                    "Line": 4,
-                    "Column": 27,
-                    "Byte": 62
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.password"
-        }
-    ],
-    "eval": {
-        "exprs": {
-            "password": {
-                "range": {
-                    "environment": "ciphertext-invalid",
-                    "begin": {
-                        "line": 3,
-                        "column": 5,
-                        "byte": 24
-                    },
-                    "end": {
-                        "line": 4,
-                        "column": 27,
-                        "byte": 62
-                    }
-                },
-                "schema": {
-                    "type": "string"
-                },
-                "builtin": {
-                    "name": "fn::secret",
-                    "nameRange": {
-                        "environment": "ciphertext-invalid",
-                        "begin": {
-                            "line": 3,
-                            "column": 5,
-                            "byte": 24
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 15,
-                            "byte": 34
-                        }
-                    },
-                    "argSchema": true,
-                    "arg": {
-                        "range": {
-                            "environment": "ciphertext-invalid",
-                            "begin": {
-                                "line": 4,
-                                "column": 7,
-                                "byte": 42
-                            },
-                            "end": {
-                                "line": 4,
-                                "column": 27,
-                                "byte": 62
-                            }
-                        },
-                        "object": {
-                            "ciphertext": {
-                                "range": {
-                                    "environment": "ciphertext-invalid",
-                                    "begin": {
-                                        "line": 4,
-                                        "column": 19,
-                                        "byte": 54
-                                    },
-                                    "end": {
-                                        "line": 4,
-                                        "column": 27,
-                                        "byte": 62
-                                    }
-                                },
-                                "schema": {
-                                    "type": "string",
-                                    "const": "hunter23"
-                                },
-                                "literal": "hunter23"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "properties": {
-            "password": {
-                "secret": true,
-                "unknown": true,
-                "trace": {
-                    "def": {
-                        "environment": "ciphertext-invalid",
-                        "begin": {
-                            "line": 3,
-                            "column": 5,
-                            "byte": 24
-                        },
-                        "end": {
-                            "line": 4,
-                            "column": 27,
-                            "byte": 62
-                        }
-                    }
-                }
-            }
-        },
-        "schema": {
-            "properties": {
-                "password": {
-                    "type": "string"
-                }
-            },
-            "type": "object",
-            "required": [
-                "password"
-            ]
-        }
     },
     "evalJson": {
         "password": "[secret]"

--- a/eval/testdata/eval/ciphertext/expected.json
+++ b/eval/testdata/eval/ciphertext/expected.json
@@ -107,9 +107,6 @@
             ]
         }
     },
-    "checkJson": {
-        "password": "[secret]"
-    },
     "eval": {
         "exprs": {
             "password": {
@@ -217,6 +214,9 @@
                 "password"
             ]
         }
+    },
+    "checkJson": {
+        "password": "[secret]"
     },
     "evalJson": {
         "password": "[secret]"

--- a/eval/testdata/eval/cycle/expected.json
+++ b/eval/testdata/eval/cycle/expected.json
@@ -47,7 +47,482 @@
             "Path": "values.b.p"
         }
     ],
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "cyclic reference to a.p",
+            "Detail": "",
+            "Subject": {
+                "Filename": "cycle",
+                "Start": {
+                    "Line": 3,
+                    "Column": 8,
+                    "Byte": 20
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 14,
+                    "Byte": 26
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.a.p"
+        },
+        {
+            "Severity": 1,
+            "Summary": "cyclic reference to b.p",
+            "Detail": "",
+            "Subject": {
+                "Filename": "cycle",
+                "Start": {
+                    "Line": 5,
+                    "Column": 8,
+                    "Byte": 39
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 14,
+                    "Byte": 45
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.b.p"
+        }
+    ],
     "check": {
+        "exprs": {
+            "a": {
+                "range": {
+                    "environment": "cycle",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 17
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 14,
+                        "byte": 26
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "p": true
+                    },
+                    "type": "object",
+                    "required": [
+                        "p"
+                    ]
+                },
+                "keyRanges": {
+                    "p": {
+                        "environment": "cycle",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 17
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 6,
+                            "byte": 18
+                        }
+                    }
+                },
+                "object": {
+                    "p": {
+                        "range": {
+                            "environment": "cycle",
+                            "begin": {
+                                "line": 3,
+                                "column": 8,
+                                "byte": 20
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 14,
+                                "byte": 26
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "a",
+                                "value": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 5,
+                                        "byte": 17
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 14,
+                                        "byte": 26
+                                    }
+                                }
+                            },
+                            {
+                                "key": "p",
+                                "value": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 8,
+                                        "byte": 20
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 14,
+                                        "byte": 26
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "b": {
+                "range": {
+                    "environment": "cycle",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 36
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 14,
+                        "byte": 45
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "p": true
+                    },
+                    "type": "object",
+                    "required": [
+                        "p"
+                    ]
+                },
+                "keyRanges": {
+                    "p": {
+                        "environment": "cycle",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 36
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 6,
+                            "byte": 37
+                        }
+                    }
+                },
+                "object": {
+                    "p": {
+                        "range": {
+                            "environment": "cycle",
+                            "begin": {
+                                "line": 5,
+                                "column": 8,
+                                "byte": 39
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 14,
+                                "byte": 45
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "c",
+                                "value": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 5,
+                                        "byte": 55
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 14,
+                                        "byte": 64
+                                    }
+                                }
+                            },
+                            {
+                                "key": "p",
+                                "value": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 8,
+                                        "byte": 58
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 14,
+                                        "byte": 64
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "c": {
+                "range": {
+                    "environment": "cycle",
+                    "begin": {
+                        "line": 7,
+                        "column": 5,
+                        "byte": 55
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 14,
+                        "byte": 64
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "p": true
+                    },
+                    "type": "object",
+                    "required": [
+                        "p"
+                    ]
+                },
+                "keyRanges": {
+                    "p": {
+                        "environment": "cycle",
+                        "begin": {
+                            "line": 7,
+                            "column": 5,
+                            "byte": 55
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 6,
+                            "byte": 56
+                        }
+                    }
+                },
+                "object": {
+                    "p": {
+                        "range": {
+                            "environment": "cycle",
+                            "begin": {
+                                "line": 7,
+                                "column": 8,
+                                "byte": 58
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 14,
+                                "byte": 64
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "b",
+                                "value": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 5,
+                                        "byte": 36
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 14,
+                                        "byte": 45
+                                    }
+                                }
+                            },
+                            {
+                                "key": "p",
+                                "value": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 8,
+                                        "byte": 39
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 14,
+                                        "byte": 45
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "properties": {
+            "a": {
+                "value": {
+                    "p": {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "cycle",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 8,
+                                    "byte": 20
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 14,
+                                    "byte": 26
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "cycle",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 17
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 14,
+                            "byte": 26
+                        }
+                    }
+                }
+            },
+            "b": {
+                "value": {
+                    "p": {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "cycle",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 8,
+                                    "byte": 39
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 14,
+                                    "byte": 45
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "cycle",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 36
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 14,
+                            "byte": 45
+                        }
+                    }
+                }
+            },
+            "c": {
+                "value": {
+                    "p": {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "cycle",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 8,
+                                    "byte": 58
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 14,
+                                    "byte": 64
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "cycle",
+                        "begin": {
+                            "line": 7,
+                            "column": 5,
+                            "byte": 55
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 14,
+                            "byte": 64
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "a": {
+                    "properties": {
+                        "p": true
+                    },
+                    "type": "object",
+                    "required": [
+                        "p"
+                    ]
+                },
+                "b": {
+                    "properties": {
+                        "p": true
+                    },
+                    "type": "object",
+                    "required": [
+                        "p"
+                    ]
+                },
+                "c": {
+                    "properties": {
+                        "p": true
+                    },
+                    "type": "object",
+                    "required": [
+                        "p"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "a",
+                "b",
+                "c"
+            ]
+        }
+    },
+    "eval": {
         "exprs": {
             "a": {
                 "range": {
@@ -483,481 +958,6 @@
         },
         "c": {
             "p": "[unknown]"
-        }
-    },
-    "evalDiags": [
-        {
-            "Severity": 1,
-            "Summary": "cyclic reference to a.p",
-            "Detail": "",
-            "Subject": {
-                "Filename": "cycle",
-                "Start": {
-                    "Line": 3,
-                    "Column": 8,
-                    "Byte": 20
-                },
-                "End": {
-                    "Line": 3,
-                    "Column": 14,
-                    "Byte": 26
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.a.p"
-        },
-        {
-            "Severity": 1,
-            "Summary": "cyclic reference to b.p",
-            "Detail": "",
-            "Subject": {
-                "Filename": "cycle",
-                "Start": {
-                    "Line": 5,
-                    "Column": 8,
-                    "Byte": 39
-                },
-                "End": {
-                    "Line": 5,
-                    "Column": 14,
-                    "Byte": 45
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.b.p"
-        }
-    ],
-    "eval": {
-        "exprs": {
-            "a": {
-                "range": {
-                    "environment": "cycle",
-                    "begin": {
-                        "line": 3,
-                        "column": 5,
-                        "byte": 17
-                    },
-                    "end": {
-                        "line": 3,
-                        "column": 14,
-                        "byte": 26
-                    }
-                },
-                "schema": {
-                    "properties": {
-                        "p": true
-                    },
-                    "type": "object",
-                    "required": [
-                        "p"
-                    ]
-                },
-                "keyRanges": {
-                    "p": {
-                        "environment": "cycle",
-                        "begin": {
-                            "line": 3,
-                            "column": 5,
-                            "byte": 17
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 6,
-                            "byte": 18
-                        }
-                    }
-                },
-                "object": {
-                    "p": {
-                        "range": {
-                            "environment": "cycle",
-                            "begin": {
-                                "line": 3,
-                                "column": 8,
-                                "byte": 20
-                            },
-                            "end": {
-                                "line": 3,
-                                "column": 14,
-                                "byte": 26
-                            }
-                        },
-                        "schema": true,
-                        "symbol": [
-                            {
-                                "key": "a",
-                                "value": {
-                                    "environment": "cycle",
-                                    "begin": {
-                                        "line": 3,
-                                        "column": 5,
-                                        "byte": 17
-                                    },
-                                    "end": {
-                                        "line": 3,
-                                        "column": 14,
-                                        "byte": 26
-                                    }
-                                }
-                            },
-                            {
-                                "key": "p",
-                                "value": {
-                                    "environment": "cycle",
-                                    "begin": {
-                                        "line": 3,
-                                        "column": 8,
-                                        "byte": 20
-                                    },
-                                    "end": {
-                                        "line": 3,
-                                        "column": 14,
-                                        "byte": 26
-                                    }
-                                }
-                            }
-                        ]
-                    }
-                }
-            },
-            "b": {
-                "range": {
-                    "environment": "cycle",
-                    "begin": {
-                        "line": 5,
-                        "column": 5,
-                        "byte": 36
-                    },
-                    "end": {
-                        "line": 5,
-                        "column": 14,
-                        "byte": 45
-                    }
-                },
-                "schema": {
-                    "properties": {
-                        "p": true
-                    },
-                    "type": "object",
-                    "required": [
-                        "p"
-                    ]
-                },
-                "keyRanges": {
-                    "p": {
-                        "environment": "cycle",
-                        "begin": {
-                            "line": 5,
-                            "column": 5,
-                            "byte": 36
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 6,
-                            "byte": 37
-                        }
-                    }
-                },
-                "object": {
-                    "p": {
-                        "range": {
-                            "environment": "cycle",
-                            "begin": {
-                                "line": 5,
-                                "column": 8,
-                                "byte": 39
-                            },
-                            "end": {
-                                "line": 5,
-                                "column": 14,
-                                "byte": 45
-                            }
-                        },
-                        "schema": true,
-                        "symbol": [
-                            {
-                                "key": "c",
-                                "value": {
-                                    "environment": "cycle",
-                                    "begin": {
-                                        "line": 7,
-                                        "column": 5,
-                                        "byte": 55
-                                    },
-                                    "end": {
-                                        "line": 7,
-                                        "column": 14,
-                                        "byte": 64
-                                    }
-                                }
-                            },
-                            {
-                                "key": "p",
-                                "value": {
-                                    "environment": "cycle",
-                                    "begin": {
-                                        "line": 7,
-                                        "column": 8,
-                                        "byte": 58
-                                    },
-                                    "end": {
-                                        "line": 7,
-                                        "column": 14,
-                                        "byte": 64
-                                    }
-                                }
-                            }
-                        ]
-                    }
-                }
-            },
-            "c": {
-                "range": {
-                    "environment": "cycle",
-                    "begin": {
-                        "line": 7,
-                        "column": 5,
-                        "byte": 55
-                    },
-                    "end": {
-                        "line": 7,
-                        "column": 14,
-                        "byte": 64
-                    }
-                },
-                "schema": {
-                    "properties": {
-                        "p": true
-                    },
-                    "type": "object",
-                    "required": [
-                        "p"
-                    ]
-                },
-                "keyRanges": {
-                    "p": {
-                        "environment": "cycle",
-                        "begin": {
-                            "line": 7,
-                            "column": 5,
-                            "byte": 55
-                        },
-                        "end": {
-                            "line": 7,
-                            "column": 6,
-                            "byte": 56
-                        }
-                    }
-                },
-                "object": {
-                    "p": {
-                        "range": {
-                            "environment": "cycle",
-                            "begin": {
-                                "line": 7,
-                                "column": 8,
-                                "byte": 58
-                            },
-                            "end": {
-                                "line": 7,
-                                "column": 14,
-                                "byte": 64
-                            }
-                        },
-                        "schema": true,
-                        "symbol": [
-                            {
-                                "key": "b",
-                                "value": {
-                                    "environment": "cycle",
-                                    "begin": {
-                                        "line": 5,
-                                        "column": 5,
-                                        "byte": 36
-                                    },
-                                    "end": {
-                                        "line": 5,
-                                        "column": 14,
-                                        "byte": 45
-                                    }
-                                }
-                            },
-                            {
-                                "key": "p",
-                                "value": {
-                                    "environment": "cycle",
-                                    "begin": {
-                                        "line": 5,
-                                        "column": 8,
-                                        "byte": 39
-                                    },
-                                    "end": {
-                                        "line": 5,
-                                        "column": 14,
-                                        "byte": 45
-                                    }
-                                }
-                            }
-                        ]
-                    }
-                }
-            }
-        },
-        "properties": {
-            "a": {
-                "value": {
-                    "p": {
-                        "unknown": true,
-                        "trace": {
-                            "def": {
-                                "environment": "cycle",
-                                "begin": {
-                                    "line": 3,
-                                    "column": 8,
-                                    "byte": 20
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 14,
-                                    "byte": 26
-                                }
-                            }
-                        }
-                    }
-                },
-                "trace": {
-                    "def": {
-                        "environment": "cycle",
-                        "begin": {
-                            "line": 3,
-                            "column": 5,
-                            "byte": 17
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 14,
-                            "byte": 26
-                        }
-                    }
-                }
-            },
-            "b": {
-                "value": {
-                    "p": {
-                        "unknown": true,
-                        "trace": {
-                            "def": {
-                                "environment": "cycle",
-                                "begin": {
-                                    "line": 5,
-                                    "column": 8,
-                                    "byte": 39
-                                },
-                                "end": {
-                                    "line": 5,
-                                    "column": 14,
-                                    "byte": 45
-                                }
-                            }
-                        }
-                    }
-                },
-                "trace": {
-                    "def": {
-                        "environment": "cycle",
-                        "begin": {
-                            "line": 5,
-                            "column": 5,
-                            "byte": 36
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 14,
-                            "byte": 45
-                        }
-                    }
-                }
-            },
-            "c": {
-                "value": {
-                    "p": {
-                        "unknown": true,
-                        "trace": {
-                            "def": {
-                                "environment": "cycle",
-                                "begin": {
-                                    "line": 7,
-                                    "column": 8,
-                                    "byte": 58
-                                },
-                                "end": {
-                                    "line": 7,
-                                    "column": 14,
-                                    "byte": 64
-                                }
-                            }
-                        }
-                    }
-                },
-                "trace": {
-                    "def": {
-                        "environment": "cycle",
-                        "begin": {
-                            "line": 7,
-                            "column": 5,
-                            "byte": 55
-                        },
-                        "end": {
-                            "line": 7,
-                            "column": 14,
-                            "byte": 64
-                        }
-                    }
-                }
-            }
-        },
-        "schema": {
-            "properties": {
-                "a": {
-                    "properties": {
-                        "p": true
-                    },
-                    "type": "object",
-                    "required": [
-                        "p"
-                    ]
-                },
-                "b": {
-                    "properties": {
-                        "p": true
-                    },
-                    "type": "object",
-                    "required": [
-                        "p"
-                    ]
-                },
-                "c": {
-                    "properties": {
-                        "p": true
-                    },
-                    "type": "object",
-                    "required": [
-                        "p"
-                    ]
-                }
-            },
-            "type": "object",
-            "required": [
-                "a",
-                "b",
-                "c"
-            ]
         }
     },
     "evalJson": {

--- a/eval/testdata/eval/duplicate-keys/expected.json
+++ b/eval/testdata/eval/duplicate-keys/expected.json
@@ -47,7 +47,225 @@
             "Path": "values.qux.foo"
         }
     ],
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "duplicate key \"foo\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "duplicate-keys",
+                "Start": {
+                    "Line": 3,
+                    "Column": 3,
+                    "Byte": 21
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 6,
+                    "Byte": 24
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.foo"
+        },
+        {
+            "Severity": 1,
+            "Summary": "duplicate key \"foo\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "duplicate-keys",
+                "Start": {
+                    "Line": 6,
+                    "Column": 5,
+                    "Byte": 54
+                },
+                "End": {
+                    "Line": 6,
+                    "Column": 8,
+                    "Byte": 57
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.qux.foo"
+        }
+    ],
     "check": {
+        "exprs": {
+            "foo": {
+                "range": {
+                    "environment": "duplicate-keys",
+                    "begin": {
+                        "line": 2,
+                        "column": 8,
+                        "byte": 15
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 11,
+                        "byte": 18
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "bar"
+                },
+                "literal": "bar"
+            },
+            "qux": {
+                "range": {
+                    "environment": "duplicate-keys",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 41
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 13,
+                        "byte": 62
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "foo": {
+                            "type": "string",
+                            "const": "bar"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "foo"
+                    ]
+                },
+                "keyRanges": {
+                    "foo": {
+                        "environment": "duplicate-keys",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 54
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 8,
+                            "byte": 57
+                        }
+                    }
+                },
+                "object": {
+                    "foo": {
+                        "range": {
+                            "environment": "duplicate-keys",
+                            "begin": {
+                                "line": 5,
+                                "column": 10,
+                                "byte": 46
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 13,
+                                "byte": 49
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "bar"
+                        },
+                        "literal": "bar"
+                    }
+                }
+            }
+        },
+        "properties": {
+            "foo": {
+                "value": "bar",
+                "trace": {
+                    "def": {
+                        "environment": "duplicate-keys",
+                        "begin": {
+                            "line": 2,
+                            "column": 8,
+                            "byte": 15
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 11,
+                            "byte": 18
+                        }
+                    }
+                }
+            },
+            "qux": {
+                "value": {
+                    "foo": {
+                        "value": "bar",
+                        "trace": {
+                            "def": {
+                                "environment": "duplicate-keys",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 10,
+                                    "byte": 46
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 13,
+                                    "byte": 49
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "duplicate-keys",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 41
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 13,
+                            "byte": 62
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "foo": {
+                    "type": "string",
+                    "const": "bar"
+                },
+                "qux": {
+                    "properties": {
+                        "foo": {
+                            "type": "string",
+                            "const": "bar"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "foo"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "foo",
+                "qux"
+            ]
+        }
+    },
+    "eval": {
         "exprs": {
             "foo": {
                 "range": {
@@ -221,224 +439,6 @@
         "foo": "bar",
         "qux": {
             "foo": "bar"
-        }
-    },
-    "evalDiags": [
-        {
-            "Severity": 1,
-            "Summary": "duplicate key \"foo\"",
-            "Detail": "",
-            "Subject": {
-                "Filename": "duplicate-keys",
-                "Start": {
-                    "Line": 3,
-                    "Column": 3,
-                    "Byte": 21
-                },
-                "End": {
-                    "Line": 3,
-                    "Column": 6,
-                    "Byte": 24
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.foo"
-        },
-        {
-            "Severity": 1,
-            "Summary": "duplicate key \"foo\"",
-            "Detail": "",
-            "Subject": {
-                "Filename": "duplicate-keys",
-                "Start": {
-                    "Line": 6,
-                    "Column": 5,
-                    "Byte": 54
-                },
-                "End": {
-                    "Line": 6,
-                    "Column": 8,
-                    "Byte": 57
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.qux.foo"
-        }
-    ],
-    "eval": {
-        "exprs": {
-            "foo": {
-                "range": {
-                    "environment": "duplicate-keys",
-                    "begin": {
-                        "line": 2,
-                        "column": 8,
-                        "byte": 15
-                    },
-                    "end": {
-                        "line": 2,
-                        "column": 11,
-                        "byte": 18
-                    }
-                },
-                "schema": {
-                    "type": "string",
-                    "const": "bar"
-                },
-                "literal": "bar"
-            },
-            "qux": {
-                "range": {
-                    "environment": "duplicate-keys",
-                    "begin": {
-                        "line": 5,
-                        "column": 5,
-                        "byte": 41
-                    },
-                    "end": {
-                        "line": 6,
-                        "column": 13,
-                        "byte": 62
-                    }
-                },
-                "schema": {
-                    "properties": {
-                        "foo": {
-                            "type": "string",
-                            "const": "bar"
-                        }
-                    },
-                    "type": "object",
-                    "required": [
-                        "foo"
-                    ]
-                },
-                "keyRanges": {
-                    "foo": {
-                        "environment": "duplicate-keys",
-                        "begin": {
-                            "line": 6,
-                            "column": 5,
-                            "byte": 54
-                        },
-                        "end": {
-                            "line": 6,
-                            "column": 8,
-                            "byte": 57
-                        }
-                    }
-                },
-                "object": {
-                    "foo": {
-                        "range": {
-                            "environment": "duplicate-keys",
-                            "begin": {
-                                "line": 5,
-                                "column": 10,
-                                "byte": 46
-                            },
-                            "end": {
-                                "line": 5,
-                                "column": 13,
-                                "byte": 49
-                            }
-                        },
-                        "schema": {
-                            "type": "string",
-                            "const": "bar"
-                        },
-                        "literal": "bar"
-                    }
-                }
-            }
-        },
-        "properties": {
-            "foo": {
-                "value": "bar",
-                "trace": {
-                    "def": {
-                        "environment": "duplicate-keys",
-                        "begin": {
-                            "line": 2,
-                            "column": 8,
-                            "byte": 15
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 11,
-                            "byte": 18
-                        }
-                    }
-                }
-            },
-            "qux": {
-                "value": {
-                    "foo": {
-                        "value": "bar",
-                        "trace": {
-                            "def": {
-                                "environment": "duplicate-keys",
-                                "begin": {
-                                    "line": 5,
-                                    "column": 10,
-                                    "byte": 46
-                                },
-                                "end": {
-                                    "line": 5,
-                                    "column": 13,
-                                    "byte": 49
-                                }
-                            }
-                        }
-                    }
-                },
-                "trace": {
-                    "def": {
-                        "environment": "duplicate-keys",
-                        "begin": {
-                            "line": 5,
-                            "column": 5,
-                            "byte": 41
-                        },
-                        "end": {
-                            "line": 6,
-                            "column": 13,
-                            "byte": 62
-                        }
-                    }
-                }
-            }
-        },
-        "schema": {
-            "properties": {
-                "foo": {
-                    "type": "string",
-                    "const": "bar"
-                },
-                "qux": {
-                    "properties": {
-                        "foo": {
-                            "type": "string",
-                            "const": "bar"
-                        }
-                    },
-                    "type": "object",
-                    "required": [
-                        "foo"
-                    ]
-                }
-            },
-            "type": "object",
-            "required": [
-                "foo",
-                "qux"
-            ]
         }
     },
     "evalJson": {

--- a/eval/testdata/eval/escape-keys/expected.json
+++ b/eval/testdata/eval/escape-keys/expected.json
@@ -248,13 +248,6 @@
             ]
         }
     },
-    "checkJson": {
-        "object": {
-            "\"quoted\"": "baz",
-            "0leadingDigit": "bar",
-            "with-hyphen": "foo"
-        }
-    },
     "eval": {
         "exprs": {
             "object": {
@@ -502,6 +495,13 @@
             "required": [
                 "object"
             ]
+        }
+    },
+    "checkJson": {
+        "object": {
+            "\"quoted\"": "baz",
+            "0leadingDigit": "bar",
+            "with-hyphen": "foo"
         }
     },
     "evalJson": {

--- a/eval/testdata/eval/imports/expected.json
+++ b/eval/testdata/eval/imports/expected.json
@@ -1096,23 +1096,6 @@
             ]
         }
     },
-    "checkJson": {
-        "some_list": [
-            "hello",
-            "world"
-        ],
-        "some_number": 42,
-        "some_object": {
-            "alpha": null,
-            "baz": "qux",
-            "beta": "bar",
-            "foo": "bar",
-            "goodbye": "for now",
-            "hello": "world",
-            "zed": "bar"
-        },
-        "some_string": "hello"
-    },
     "eval": {
         "exprs": {
             "some_list": {
@@ -2209,6 +2192,23 @@
                 "some_string"
             ]
         }
+    },
+    "checkJson": {
+        "some_list": [
+            "hello",
+            "world"
+        ],
+        "some_number": 42,
+        "some_object": {
+            "alpha": null,
+            "baz": "qux",
+            "beta": "bar",
+            "foo": "bar",
+            "goodbye": "for now",
+            "hello": "world",
+            "zed": "bar"
+        },
+        "some_string": "hello"
     },
     "evalJson": {
         "some_list": [

--- a/eval/testdata/eval/interp/expected.json
+++ b/eval/testdata/eval/interp/expected.json
@@ -1434,35 +1434,6 @@
             ]
         }
     },
-    "checkJson": {
-        "34": "this should be okay",
-        "35": {
-            "okay": "also okay"
-        },
-        "a": {
-            "p": "foo",
-            "q": "foo",
-            "u": {
-                "\"baz": "merp"
-            }
-        },
-        "b": {
-            "p": "foo"
-        },
-        "c": {
-            "a": [
-                "foo",
-                "hello, world!",
-                "foo bar"
-            ],
-            "b": "world!",
-            "s": [
-                "merp",
-                "this should be okay",
-                "also okay"
-            ]
-        }
-    },
     "eval": {
         "exprs": {
             "34": {
@@ -2895,6 +2866,35 @@
                 "a",
                 "b",
                 "c"
+            ]
+        }
+    },
+    "checkJson": {
+        "34": "this should be okay",
+        "35": {
+            "okay": "also okay"
+        },
+        "a": {
+            "p": "foo",
+            "q": "foo",
+            "u": {
+                "\"baz": "merp"
+            }
+        },
+        "b": {
+            "p": "foo"
+        },
+        "c": {
+            "a": [
+                "foo",
+                "hello, world!",
+                "foo bar"
+            ],
+            "b": "world!",
+            "s": [
+                "merp",
+                "this should be okay",
+                "also okay"
             ]
         }
     },

--- a/eval/testdata/eval/invalid-access/expected.json
+++ b/eval/testdata/eval/invalid-access/expected.json
@@ -300,6 +300,307 @@
             "Path": "values.errors[12]"
         }
     ],
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "receiver must be an array or an object",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access",
+                "Start": {
+                    "Line": 29,
+                    "Column": 7,
+                    "Byte": 517
+                },
+                "End": {
+                    "Line": 29,
+                    "Column": 20,
+                    "Byte": 530
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.errors[0]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "cannot access an array element using a property name",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access",
+                "Start": {
+                    "Line": 30,
+                    "Column": 7,
+                    "Byte": 537
+                },
+                "End": {
+                    "Line": 30,
+                    "Column": 19,
+                    "Byte": 549
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.errors[1]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "cannot access an array element using a property name",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access",
+                "Start": {
+                    "Line": 31,
+                    "Column": 7,
+                    "Byte": 556
+                },
+                "End": {
+                    "Line": 31,
+                    "Column": 22,
+                    "Byte": 571
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.errors[2]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "array index 3 out-of-bounds for array of length 3",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access",
+                "Start": {
+                    "Line": 32,
+                    "Column": 7,
+                    "Byte": 578
+                },
+                "End": {
+                    "Line": 32,
+                    "Column": 18,
+                    "Byte": 589
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.errors[3]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "array indices must not be negative",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access",
+                "Start": {
+                    "Line": 33,
+                    "Column": 7,
+                    "Byte": 596
+                },
+                "End": {
+                    "Line": 33,
+                    "Column": 19,
+                    "Byte": 608
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.errors[4]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "cannot access an object property using an integer index",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access",
+                "Start": {
+                    "Line": 34,
+                    "Column": 7,
+                    "Byte": 615
+                },
+                "End": {
+                    "Line": 34,
+                    "Column": 19,
+                    "Byte": 627
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.errors[5]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"bar\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access",
+                "Start": {
+                    "Line": 35,
+                    "Column": 7,
+                    "Byte": 634
+                },
+                "End": {
+                    "Line": 35,
+                    "Column": 20,
+                    "Byte": 647
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.errors[6]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"bar\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access",
+                "Start": {
+                    "Line": 36,
+                    "Column": 7,
+                    "Byte": 654
+                },
+                "End": {
+                    "Line": 36,
+                    "Column": 22,
+                    "Byte": 669
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.errors[7]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "cannot access an object property using an integer index",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access",
+                "Start": {
+                    "Line": 37,
+                    "Column": 7,
+                    "Byte": 676
+                },
+                "End": {
+                    "Line": 37,
+                    "Column": 24,
+                    "Byte": 693
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.errors[8]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "receiver must be an array or an object",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access",
+                "Start": {
+                    "Line": 38,
+                    "Column": 7,
+                    "Byte": 700
+                },
+                "End": {
+                    "Line": 38,
+                    "Column": 25,
+                    "Byte": 718
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.errors[9]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "cannot access an array element using a property name",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access",
+                "Start": {
+                    "Line": 39,
+                    "Column": 7,
+                    "Byte": 725
+                },
+                "End": {
+                    "Line": 39,
+                    "Column": 24,
+                    "Byte": 742
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.errors[10]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "cannot access an array element using a property name",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access",
+                "Start": {
+                    "Line": 40,
+                    "Column": 7,
+                    "Byte": 749
+                },
+                "End": {
+                    "Line": 40,
+                    "Column": 27,
+                    "Byte": 769
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.errors[11]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "cannot access an object property using an integer index",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access",
+                "Start": {
+                    "Line": 41,
+                    "Column": 7,
+                    "Byte": 776
+                },
+                "End": {
+                    "Line": 41,
+                    "Column": 24,
+                    "Byte": 793
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.errors[12]"
+        }
+    ],
     "check": {
         "exprs": {
             "array": {
@@ -3864,341 +4165,6 @@
             ]
         }
     },
-    "checkJson": {
-        "array": [
-            1,
-            2,
-            3
-        ],
-        "errors": [
-            "[unknown]",
-            "[unknown]",
-            "[unknown]",
-            "[unknown]",
-            "[unknown]",
-            "[unknown]",
-            "[unknown]",
-            "[unknown]",
-            "[unknown]",
-            "[unknown]",
-            "[unknown]",
-            "[unknown]",
-            "[unknown]"
-        ],
-        "myObject": {
-            "foo": "bar"
-        },
-        "object": {
-            "baz": "qux",
-            "hello": "world"
-        },
-        "open": "[unknown]",
-        "otherObject": {
-            "foo": "bar"
-        },
-        "string": "esc"
-    },
-    "evalDiags": [
-        {
-            "Severity": 1,
-            "Summary": "receiver must be an array or an object",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-access",
-                "Start": {
-                    "Line": 29,
-                    "Column": 7,
-                    "Byte": 517
-                },
-                "End": {
-                    "Line": 29,
-                    "Column": 20,
-                    "Byte": 530
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.errors[0]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "cannot access an array element using a property name",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-access",
-                "Start": {
-                    "Line": 30,
-                    "Column": 7,
-                    "Byte": 537
-                },
-                "End": {
-                    "Line": 30,
-                    "Column": 19,
-                    "Byte": 549
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.errors[1]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "cannot access an array element using a property name",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-access",
-                "Start": {
-                    "Line": 31,
-                    "Column": 7,
-                    "Byte": 556
-                },
-                "End": {
-                    "Line": 31,
-                    "Column": 22,
-                    "Byte": 571
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.errors[2]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "array index 3 out-of-bounds for array of length 3",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-access",
-                "Start": {
-                    "Line": 32,
-                    "Column": 7,
-                    "Byte": 578
-                },
-                "End": {
-                    "Line": 32,
-                    "Column": 18,
-                    "Byte": 589
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.errors[3]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "array indices must not be negative",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-access",
-                "Start": {
-                    "Line": 33,
-                    "Column": 7,
-                    "Byte": 596
-                },
-                "End": {
-                    "Line": 33,
-                    "Column": 19,
-                    "Byte": 608
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.errors[4]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "cannot access an object property using an integer index",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-access",
-                "Start": {
-                    "Line": 34,
-                    "Column": 7,
-                    "Byte": 615
-                },
-                "End": {
-                    "Line": 34,
-                    "Column": 19,
-                    "Byte": 627
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.errors[5]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "unknown property \"bar\"",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-access",
-                "Start": {
-                    "Line": 35,
-                    "Column": 7,
-                    "Byte": 634
-                },
-                "End": {
-                    "Line": 35,
-                    "Column": 20,
-                    "Byte": 647
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.errors[6]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "unknown property \"bar\"",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-access",
-                "Start": {
-                    "Line": 36,
-                    "Column": 7,
-                    "Byte": 654
-                },
-                "End": {
-                    "Line": 36,
-                    "Column": 22,
-                    "Byte": 669
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.errors[7]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "cannot access an object property using an integer index",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-access",
-                "Start": {
-                    "Line": 37,
-                    "Column": 7,
-                    "Byte": 676
-                },
-                "End": {
-                    "Line": 37,
-                    "Column": 24,
-                    "Byte": 693
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.errors[8]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "receiver must be an array or an object",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-access",
-                "Start": {
-                    "Line": 38,
-                    "Column": 7,
-                    "Byte": 700
-                },
-                "End": {
-                    "Line": 38,
-                    "Column": 25,
-                    "Byte": 718
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.errors[9]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "cannot access an array element using a property name",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-access",
-                "Start": {
-                    "Line": 39,
-                    "Column": 7,
-                    "Byte": 725
-                },
-                "End": {
-                    "Line": 39,
-                    "Column": 24,
-                    "Byte": 742
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.errors[10]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "cannot access an array element using a property name",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-access",
-                "Start": {
-                    "Line": 40,
-                    "Column": 7,
-                    "Byte": 749
-                },
-                "End": {
-                    "Line": 40,
-                    "Column": 27,
-                    "Byte": 769
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.errors[11]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "cannot access an object property using an integer index",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-access",
-                "Start": {
-                    "Line": 41,
-                    "Column": 7,
-                    "Byte": 776
-                },
-                "End": {
-                    "Line": 41,
-                    "Column": 24,
-                    "Byte": 793
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.errors[12]"
-        }
-    ],
     "eval": {
         "exprs": {
             "array": {
@@ -8121,6 +8087,40 @@
                 "string"
             ]
         }
+    },
+    "checkJson": {
+        "array": [
+            1,
+            2,
+            3
+        ],
+        "errors": [
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]"
+        ],
+        "myObject": {
+            "foo": "bar"
+        },
+        "object": {
+            "baz": "qux",
+            "hello": "world"
+        },
+        "open": "[unknown]",
+        "otherObject": {
+            "foo": "bar"
+        },
+        "string": "esc"
     },
     "evalJson": {
         "array": [

--- a/eval/testdata/eval/literals/expected.json
+++ b/eval/testdata/eval/literals/expected.json
@@ -496,20 +496,6 @@
             ]
         }
     },
-    "checkJson": {
-        "some_bool": true,
-        "some_list": [
-            "hello",
-            "world"
-        ],
-        "some_null": null,
-        "some_number": 42,
-        "some_object": {
-            "goodbye": "for now",
-            "hello": "world"
-        },
-        "some_string": "hello"
-    },
     "eval": {
         "exprs": {
             "some_bool": {
@@ -1006,6 +992,20 @@
                 "some_string"
             ]
         }
+    },
+    "checkJson": {
+        "some_bool": true,
+        "some_list": [
+            "hello",
+            "world"
+        ],
+        "some_null": null,
+        "some_number": 42,
+        "some_object": {
+            "goodbye": "for now",
+            "hello": "world"
+        },
+        "some_string": "hello"
     },
     "evalJson": {
         "some_bool": true,

--- a/eval/testdata/eval/merge-replace/expected.json
+++ b/eval/testdata/eval/merge-replace/expected.json
@@ -164,11 +164,6 @@
             ]
         }
     },
-    "checkJson": {
-        "foo": {
-            "bar": "baz"
-        }
-    },
     "eval": {
         "exprs": {
             "foo": {
@@ -332,6 +327,11 @@
             "required": [
                 "foo"
             ]
+        }
+    },
+    "checkJson": {
+        "foo": {
+            "bar": "baz"
         }
     },
     "evalJson": {

--- a/eval/testdata/eval/merge-unknown/expected.json
+++ b/eval/testdata/eval/merge-unknown/expected.json
@@ -600,14 +600,6 @@
             ]
         }
     },
-    "checkJson": {
-        "open": {
-            "baz": {
-                "qux": "zed"
-            },
-            "foo": "bar"
-        }
-    },
     "eval": {
         "exprs": {
             "open": {
@@ -1144,6 +1136,14 @@
             "required": [
                 "open"
             ]
+        }
+    },
+    "checkJson": {
+        "open": {
+            "baz": {
+                "qux": "zed"
+            },
+            "foo": "bar"
         }
     },
     "evalJson": {

--- a/eval/testdata/eval/nested-unknowns-secrets/expected.json
+++ b/eval/testdata/eval/nested-unknowns-secrets/expected.json
@@ -2845,47 +2845,6 @@
             ]
         }
     },
-    "checkJson": {
-        "base64OutputSecret": "[secret]",
-        "base64OutputUnknown": "[unknown]",
-        "cloudflare": {
-            "account": {
-                "id": "[secret]",
-                "name": "account-name"
-            },
-            "apiKey": "[secret]",
-            "apiToken": "[secret]",
-            "username": "bot@pulumi.com",
-            "zoneId": "zone-id-123"
-        },
-        "comboSecretAndUnknown": {
-            "cloudflareApi": "[secret]",
-            "provider": "[unknown]"
-        },
-        "deeplyNestedProvider": {
-            "oneStep": {
-                "twoStep": {
-                    "threeStep": {
-                        "fourStep": "[unknown]"
-                    }
-                }
-            }
-        },
-        "environmentVariables": {
-            "CLOUDFLARE_API_TOKEN": "[secret]"
-        },
-        "jsonOutputCombo": "[secret]",
-        "jsonOutputSecret": "[secret]",
-        "jsonOutputUnknown": "[unknown]",
-        "pulumiConfig": {
-            "accountId": "[secret]",
-            "refTopLevelSecret": "[secret]"
-        },
-        "stringOutputCombo": "[secret]",
-        "stringOutputSecret": "[secret]",
-        "stringOutputUnknown": "[unknown]",
-        "top-level-secret": "[secret]"
-    },
     "eval": {
         "exprs": {
             "base64OutputSecret": {
@@ -5856,6 +5815,47 @@
                 "top-level-secret"
             ]
         }
+    },
+    "checkJson": {
+        "base64OutputSecret": "[secret]",
+        "base64OutputUnknown": "[unknown]",
+        "cloudflare": {
+            "account": {
+                "id": "[secret]",
+                "name": "account-name"
+            },
+            "apiKey": "[secret]",
+            "apiToken": "[secret]",
+            "username": "bot@pulumi.com",
+            "zoneId": "zone-id-123"
+        },
+        "comboSecretAndUnknown": {
+            "cloudflareApi": "[secret]",
+            "provider": "[unknown]"
+        },
+        "deeplyNestedProvider": {
+            "oneStep": {
+                "twoStep": {
+                    "threeStep": {
+                        "fourStep": "[unknown]"
+                    }
+                }
+            }
+        },
+        "environmentVariables": {
+            "CLOUDFLARE_API_TOKEN": "[secret]"
+        },
+        "jsonOutputCombo": "[secret]",
+        "jsonOutputSecret": "[secret]",
+        "jsonOutputUnknown": "[unknown]",
+        "pulumiConfig": {
+            "accountId": "[secret]",
+            "refTopLevelSecret": "[secret]"
+        },
+        "stringOutputCombo": "[secret]",
+        "stringOutputSecret": "[secret]",
+        "stringOutputUnknown": "[unknown]",
+        "top-level-secret": "[secret]"
     },
     "evalJson": {
         "base64OutputSecret": "[secret]",

--- a/eval/testdata/eval/omnibus/expected.json
+++ b/eval/testdata/eval/omnibus/expected.json
@@ -1384,23 +1384,6 @@
             ]
         }
     },
-    "checkJson": {
-        "access": "[unknown]",
-        "fromBase64": "hello,world",
-        "fromJSON": "[unknown]",
-        "interp": "[unknown]",
-        "join": "hello,world",
-        "open": "[unknown]",
-        "open2": "[unknown]",
-        "secret": "[secret]",
-        "strings": [
-            "hello",
-            "world"
-        ],
-        "toBase64": "aGVsbG8sd29ybGQ=",
-        "toJSON": "[unknown]",
-        "toString": "[unknown]"
-    },
     "eval": {
         "exprs": {
             "access": {
@@ -3540,6 +3523,23 @@
                 "toString"
             ]
         }
+    },
+    "checkJson": {
+        "access": "[unknown]",
+        "fromBase64": "hello,world",
+        "fromJSON": "[unknown]",
+        "interp": "[unknown]",
+        "join": "hello,world",
+        "open": "[unknown]",
+        "open2": "[unknown]",
+        "secret": "[secret]",
+        "strings": [
+            "hello",
+            "world"
+        ],
+        "toBase64": "aGVsbG8sd29ybGQ=",
+        "toJSON": "[unknown]",
+        "toString": "[unknown]"
     },
     "evalJson": {
         "access": "qux",

--- a/eval/testdata/eval/open-unknown/expected.json
+++ b/eval/testdata/eval/open-unknown/expected.json
@@ -1,5 +1,308 @@
 {
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "testing",
+            "Detail": "",
+            "Subject": {
+                "Filename": "open-unknown",
+                "Start": {
+                    "Line": 3,
+                    "Column": 5,
+                    "Byte": 21
+                },
+                "End": {
+                    "Line": 4,
+                    "Column": 19,
+                    "Byte": 56
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.error"
+        }
+    ],
     "check": {
+        "exprs": {
+            "dependent": {
+                "range": {
+                    "environment": "open-unknown",
+                    "begin": {
+                        "line": 6,
+                        "column": 5,
+                        "byte": 74
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 20,
+                        "byte": 110
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::open::error",
+                    "nameRange": {
+                        "environment": "open-unknown",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 74
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 20,
+                            "byte": 89
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "why": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "why"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "open-unknown",
+                            "begin": {
+                                "line": 7,
+                                "column": 7,
+                                "byte": 97
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 20,
+                                "byte": 110
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "why": true
+                            },
+                            "type": "object",
+                            "required": [
+                                "why"
+                            ]
+                        },
+                        "keyRanges": {
+                            "why": {
+                                "environment": "open-unknown",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 7,
+                                    "byte": 97
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 10,
+                                    "byte": 100
+                                }
+                            }
+                        },
+                        "object": {
+                            "why": {
+                                "range": {
+                                    "environment": "open-unknown",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 12,
+                                        "byte": 102
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 20,
+                                        "byte": 110
+                                    }
+                                },
+                                "schema": true,
+                                "symbol": [
+                                    {
+                                        "key": "error",
+                                        "value": {
+                                            "environment": "open-unknown",
+                                            "begin": {
+                                                "line": 3,
+                                                "column": 5,
+                                                "byte": 21
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 19,
+                                                "byte": 56
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+            "error": {
+                "range": {
+                    "environment": "open-unknown",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 21
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 19,
+                        "byte": 56
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::open::error",
+                    "nameRange": {
+                        "environment": "open-unknown",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 21
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 20,
+                            "byte": 36
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "why": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "why"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "open-unknown",
+                            "begin": {
+                                "line": 4,
+                                "column": 7,
+                                "byte": 44
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 19,
+                                "byte": 56
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "why": {
+                                    "type": "string",
+                                    "const": "testing"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "why"
+                            ]
+                        },
+                        "keyRanges": {
+                            "why": {
+                                "environment": "open-unknown",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 7,
+                                    "byte": 44
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 10,
+                                    "byte": 47
+                                }
+                            }
+                        },
+                        "object": {
+                            "why": {
+                                "range": {
+                                    "environment": "open-unknown",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 12,
+                                        "byte": 49
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 19,
+                                        "byte": 56
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "testing"
+                                },
+                                "literal": "testing"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "dependent": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "open-unknown",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 74
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 20,
+                            "byte": 110
+                        }
+                    }
+                }
+            },
+            "error": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "open-unknown",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 21
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 19,
+                            "byte": 56
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "dependent": true,
+                "error": true
+            },
+            "type": "object",
+            "required": [
+                "dependent",
+                "error"
+            ]
+        }
+    },
+    "eval": {
         "exprs": {
             "dependent": {
                 "range": {
@@ -280,309 +583,6 @@
     "checkJson": {
         "dependent": "[unknown]",
         "error": "[unknown]"
-    },
-    "evalDiags": [
-        {
-            "Severity": 1,
-            "Summary": "testing",
-            "Detail": "",
-            "Subject": {
-                "Filename": "open-unknown",
-                "Start": {
-                    "Line": 3,
-                    "Column": 5,
-                    "Byte": 21
-                },
-                "End": {
-                    "Line": 4,
-                    "Column": 19,
-                    "Byte": 56
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.error"
-        }
-    ],
-    "eval": {
-        "exprs": {
-            "dependent": {
-                "range": {
-                    "environment": "open-unknown",
-                    "begin": {
-                        "line": 6,
-                        "column": 5,
-                        "byte": 74
-                    },
-                    "end": {
-                        "line": 7,
-                        "column": 20,
-                        "byte": 110
-                    }
-                },
-                "schema": true,
-                "builtin": {
-                    "name": "fn::open::error",
-                    "nameRange": {
-                        "environment": "open-unknown",
-                        "begin": {
-                            "line": 6,
-                            "column": 5,
-                            "byte": 74
-                        },
-                        "end": {
-                            "line": 6,
-                            "column": 20,
-                            "byte": 89
-                        }
-                    },
-                    "argSchema": {
-                        "properties": {
-                            "why": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object",
-                        "required": [
-                            "why"
-                        ]
-                    },
-                    "arg": {
-                        "range": {
-                            "environment": "open-unknown",
-                            "begin": {
-                                "line": 7,
-                                "column": 7,
-                                "byte": 97
-                            },
-                            "end": {
-                                "line": 7,
-                                "column": 20,
-                                "byte": 110
-                            }
-                        },
-                        "schema": {
-                            "properties": {
-                                "why": true
-                            },
-                            "type": "object",
-                            "required": [
-                                "why"
-                            ]
-                        },
-                        "keyRanges": {
-                            "why": {
-                                "environment": "open-unknown",
-                                "begin": {
-                                    "line": 7,
-                                    "column": 7,
-                                    "byte": 97
-                                },
-                                "end": {
-                                    "line": 7,
-                                    "column": 10,
-                                    "byte": 100
-                                }
-                            }
-                        },
-                        "object": {
-                            "why": {
-                                "range": {
-                                    "environment": "open-unknown",
-                                    "begin": {
-                                        "line": 7,
-                                        "column": 12,
-                                        "byte": 102
-                                    },
-                                    "end": {
-                                        "line": 7,
-                                        "column": 20,
-                                        "byte": 110
-                                    }
-                                },
-                                "schema": true,
-                                "symbol": [
-                                    {
-                                        "key": "error",
-                                        "value": {
-                                            "environment": "open-unknown",
-                                            "begin": {
-                                                "line": 3,
-                                                "column": 5,
-                                                "byte": 21
-                                            },
-                                            "end": {
-                                                "line": 4,
-                                                "column": 19,
-                                                "byte": 56
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            },
-            "error": {
-                "range": {
-                    "environment": "open-unknown",
-                    "begin": {
-                        "line": 3,
-                        "column": 5,
-                        "byte": 21
-                    },
-                    "end": {
-                        "line": 4,
-                        "column": 19,
-                        "byte": 56
-                    }
-                },
-                "schema": true,
-                "builtin": {
-                    "name": "fn::open::error",
-                    "nameRange": {
-                        "environment": "open-unknown",
-                        "begin": {
-                            "line": 3,
-                            "column": 5,
-                            "byte": 21
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 20,
-                            "byte": 36
-                        }
-                    },
-                    "argSchema": {
-                        "properties": {
-                            "why": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object",
-                        "required": [
-                            "why"
-                        ]
-                    },
-                    "arg": {
-                        "range": {
-                            "environment": "open-unknown",
-                            "begin": {
-                                "line": 4,
-                                "column": 7,
-                                "byte": 44
-                            },
-                            "end": {
-                                "line": 4,
-                                "column": 19,
-                                "byte": 56
-                            }
-                        },
-                        "schema": {
-                            "properties": {
-                                "why": {
-                                    "type": "string",
-                                    "const": "testing"
-                                }
-                            },
-                            "type": "object",
-                            "required": [
-                                "why"
-                            ]
-                        },
-                        "keyRanges": {
-                            "why": {
-                                "environment": "open-unknown",
-                                "begin": {
-                                    "line": 4,
-                                    "column": 7,
-                                    "byte": 44
-                                },
-                                "end": {
-                                    "line": 4,
-                                    "column": 10,
-                                    "byte": 47
-                                }
-                            }
-                        },
-                        "object": {
-                            "why": {
-                                "range": {
-                                    "environment": "open-unknown",
-                                    "begin": {
-                                        "line": 4,
-                                        "column": 12,
-                                        "byte": 49
-                                    },
-                                    "end": {
-                                        "line": 4,
-                                        "column": 19,
-                                        "byte": 56
-                                    }
-                                },
-                                "schema": {
-                                    "type": "string",
-                                    "const": "testing"
-                                },
-                                "literal": "testing"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "properties": {
-            "dependent": {
-                "unknown": true,
-                "trace": {
-                    "def": {
-                        "environment": "open-unknown",
-                        "begin": {
-                            "line": 6,
-                            "column": 5,
-                            "byte": 74
-                        },
-                        "end": {
-                            "line": 7,
-                            "column": 20,
-                            "byte": 110
-                        }
-                    }
-                }
-            },
-            "error": {
-                "unknown": true,
-                "trace": {
-                    "def": {
-                        "environment": "open-unknown",
-                        "begin": {
-                            "line": 3,
-                            "column": 5,
-                            "byte": 21
-                        },
-                        "end": {
-                            "line": 4,
-                            "column": 19,
-                            "byte": 56
-                        }
-                    }
-                }
-            }
-        },
-        "schema": {
-            "properties": {
-                "dependent": true,
-                "error": true
-            },
-            "type": "object",
-            "required": [
-                "dependent",
-                "error"
-            ]
-        }
     },
     "evalJson": {
         "dependent": "[unknown]",

--- a/eval/testdata/eval/open/expected.json
+++ b/eval/testdata/eval/open/expected.json
@@ -813,15 +813,6 @@
             ]
         }
     },
-    "checkJson": {
-        "referent": {
-            "foo": "[unknown]",
-            "list": "[unknown]",
-            "object": "[unknown]",
-            "test": "[unknown]"
-        },
-        "test": "[unknown]"
-    },
     "eval": {
         "exprs": {
             "referent": {
@@ -2140,6 +2131,15 @@
                 "test"
             ]
         }
+    },
+    "checkJson": {
+        "referent": {
+            "foo": "[unknown]",
+            "list": "[unknown]",
+            "object": "[unknown]",
+            "test": "[unknown]"
+        },
+        "test": "[unknown]"
     },
     "evalJson": {
         "referent": {

--- a/eval/testdata/eval/plaintext/expected.json
+++ b/eval/testdata/eval/plaintext/expected.json
@@ -92,9 +92,6 @@
             ]
         }
     },
-    "checkJson": {
-        "password": "[secret]"
-    },
     "eval": {
         "exprs": {
             "password": {
@@ -187,6 +184,9 @@
                 "password"
             ]
         }
+    },
+    "checkJson": {
+        "password": "[secret]"
     },
     "evalJson": {
         "password": "[secret]"

--- a/eval/testdata/eval/reserved-keys/expected.json
+++ b/eval/testdata/eval/reserved-keys/expected.json
@@ -47,12 +47,6 @@
             "Path": "values.context"
         }
     ],
-    "check": {
-        "schema": {
-            "type": "object"
-        }
-    },
-    "checkJson": {},
     "evalDiags": [
         {
             "Severity": 1,
@@ -101,10 +95,16 @@
             "Path": "values.context"
         }
     ],
+    "check": {
+        "schema": {
+            "type": "object"
+        }
+    },
     "eval": {
         "schema": {
             "type": "object"
         }
     },
+    "checkJson": {},
     "evalJson": {}
 }

--- a/eval/testdata/eval/schema-error/expected.json
+++ b/eval/testdata/eval/schema-error/expected.json
@@ -300,6 +300,652 @@
             "Path": "values.sink[\"fn::open::schema\"].minLength"
         }
     ],
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "expected boolean, got null",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 38,
+                    "Column": 16,
+                    "Byte": 880
+                },
+                "End": {
+                    "Line": 38,
+                    "Column": 30,
+                    "Byte": 894
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].boolean"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected string, got array",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 39,
+                    "Column": 15,
+                    "Byte": 909
+                },
+                "End": {
+                    "Line": 39,
+                    "Column": 30,
+                    "Byte": 924
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].string"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected number, got object",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 40,
+                    "Column": 15,
+                    "Byte": 939
+                },
+                "End": {
+                    "Line": 40,
+                    "Column": 31,
+                    "Byte": 955
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].number"
+        },
+        {
+            "Severity": 1,
+            "Summary": "missing required properties: foo",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 41,
+                    "Column": 15,
+                    "Byte": 970
+                },
+                "End": {
+                    "Line": 41,
+                    "Column": 31,
+                    "Byte": 986
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].record"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected number, got boolean",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 42,
+                    "Column": 14,
+                    "Byte": 1000
+                },
+                "End": {
+                    "Line": 42,
+                    "Column": 29,
+                    "Byte": 1015
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].anyOf"
+        },
+        {
+            "Severity": 1,
+            "Summary": "at least one subschema must match",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 42,
+                    "Column": 14,
+                    "Byte": 1000
+                },
+                "End": {
+                    "Line": 42,
+                    "Column": 29,
+                    "Byte": 1015
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].anyOf"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected string, got boolean",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 42,
+                    "Column": 14,
+                    "Byte": 1000
+                },
+                "End": {
+                    "Line": 42,
+                    "Column": 29,
+                    "Byte": 1015
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].anyOf"
+        },
+        {
+            "Severity": 1,
+            "Summary": "exactly one subschema must match",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 43,
+                    "Column": 14,
+                    "Byte": 1029
+                },
+                "End": {
+                    "Line": 43,
+                    "Column": 29,
+                    "Byte": 1044
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].oneOf"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected number, got boolean",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 43,
+                    "Column": 14,
+                    "Byte": 1029
+                },
+                "End": {
+                    "Line": 43,
+                    "Column": 29,
+                    "Byte": 1044
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].oneOf"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected string, got boolean",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 43,
+                    "Column": 14,
+                    "Byte": 1029
+                },
+                "End": {
+                    "Line": 43,
+                    "Column": 29,
+                    "Byte": 1044
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].oneOf"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected [\"hello\",42]",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 44,
+                    "Column": 20,
+                    "Byte": 1064
+                },
+                "End": {
+                    "Line": 44,
+                    "Column": 36,
+                    "Byte": 1080
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"][\"const-array\"]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected array, got string",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 44,
+                    "Column": 20,
+                    "Byte": 1064
+                },
+                "End": {
+                    "Line": 44,
+                    "Column": 36,
+                    "Byte": 1080
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"][\"const-array\"]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected object, got string",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 45,
+                    "Column": 21,
+                    "Byte": 1101
+                },
+                "End": {
+                    "Line": 45,
+                    "Column": 37,
+                    "Byte": 1117
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"][\"const-object\"]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected {\"hello\":\"world\"}",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 45,
+                    "Column": 21,
+                    "Byte": 1101
+                },
+                "End": {
+                    "Line": 45,
+                    "Column": 37,
+                    "Byte": 1117
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"][\"const-object\"]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected one of [\"foo\",\"bar\"]",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 46,
+                    "Column": 13,
+                    "Byte": 1130
+                },
+                "End": {
+                    "Line": 46,
+                    "Column": 29,
+                    "Byte": 1146
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].enum"
+        },
+        {
+            "Severity": 1,
+            "Summary": "missing required properties: bar",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 49,
+                    "Column": 21,
+                    "Byte": 1229
+                },
+                "End": {
+                    "Line": 49,
+                    "Column": 37,
+                    "Byte": 1245
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].dependentReq"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected a multiple of 2",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 50,
+                    "Column": 17,
+                    "Byte": 1262
+                },
+                "End": {
+                    "Line": 50,
+                    "Column": 29,
+                    "Byte": 1274
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].multiple"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected a number greater than or equal to 1",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 51,
+                    "Column": 16,
+                    "Byte": 1290
+                },
+                "End": {
+                    "Line": 51,
+                    "Column": 42,
+                    "Byte": 1316
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].minimum"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected a number greater than 1",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 52,
+                    "Column": 25,
+                    "Byte": 1341
+                },
+                "End": {
+                    "Line": 52,
+                    "Column": 42,
+                    "Byte": 1358
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].exclusiveMinimum"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected a number less than or equal to1",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 53,
+                    "Column": 16,
+                    "Byte": 1374
+                },
+                "End": {
+                    "Line": 53,
+                    "Column": 42,
+                    "Byte": 1400
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].maximum"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected a number less than 1",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 54,
+                    "Column": 25,
+                    "Byte": 1425
+                },
+                "End": {
+                    "Line": 54,
+                    "Column": 42,
+                    "Byte": 1442
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].exclusiveMaximum"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected a string of at least length 1",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 55,
+                    "Column": 18,
+                    "Byte": 1460
+                },
+                "End": {
+                    "Line": 55,
+                    "Column": 18,
+                    "Byte": 1460
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].minLength"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected a string of at most length 1",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 56,
+                    "Column": 18,
+                    "Byte": 1480
+                },
+                "End": {
+                    "Line": 56,
+                    "Column": 34,
+                    "Byte": 1496
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].maxLength"
+        },
+        {
+            "Severity": 1,
+            "Summary": "string must match the pattern \"^foo[0-9]+$\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 57,
+                    "Column": 16,
+                    "Byte": 1512
+                },
+                "End": {
+                    "Line": 57,
+                    "Column": 32,
+                    "Byte": 1528
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].pattern"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected an array with at least 3 items",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 58,
+                    "Column": 17,
+                    "Byte": 1545
+                },
+                "End": {
+                    "Line": 58,
+                    "Column": 33,
+                    "Byte": 1561
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].minItems"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected an array with at most 2 items",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 59,
+                    "Column": 17,
+                    "Byte": 1578
+                },
+                "End": {
+                    "Line": 59,
+                    "Column": 33,
+                    "Byte": 1594
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].maxItems"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected an object with at least 1 properties",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 60,
+                    "Column": 22,
+                    "Byte": 1616
+                },
+                "End": {
+                    "Line": 60,
+                    "Column": 38,
+                    "Byte": 1632
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].minProperties"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected an object with at most 1 properties",
+            "Detail": "",
+            "Subject": {
+                "Filename": "schema-error",
+                "Start": {
+                    "Line": 61,
+                    "Column": 22,
+                    "Byte": 1654
+                },
+                "End": {
+                    "Line": 61,
+                    "Column": 44,
+                    "Byte": 1676
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.sink[\"fn::open::schema\"].maxProperties"
+        }
+    ],
     "check": {
         "exprs": {
             "sink": {
@@ -5702,656 +6348,6 @@
             ]
         }
     },
-    "checkJson": {
-        "sink": "[unknown]",
-        "source": "[unknown]"
-    },
-    "evalDiags": [
-        {
-            "Severity": 1,
-            "Summary": "expected boolean, got null",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 38,
-                    "Column": 16,
-                    "Byte": 880
-                },
-                "End": {
-                    "Line": 38,
-                    "Column": 30,
-                    "Byte": 894
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].boolean"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected string, got array",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 39,
-                    "Column": 15,
-                    "Byte": 909
-                },
-                "End": {
-                    "Line": 39,
-                    "Column": 30,
-                    "Byte": 924
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].string"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected number, got object",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 40,
-                    "Column": 15,
-                    "Byte": 939
-                },
-                "End": {
-                    "Line": 40,
-                    "Column": 31,
-                    "Byte": 955
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].number"
-        },
-        {
-            "Severity": 1,
-            "Summary": "missing required properties: foo",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 41,
-                    "Column": 15,
-                    "Byte": 970
-                },
-                "End": {
-                    "Line": 41,
-                    "Column": 31,
-                    "Byte": 986
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].record"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected number, got boolean",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 42,
-                    "Column": 14,
-                    "Byte": 1000
-                },
-                "End": {
-                    "Line": 42,
-                    "Column": 29,
-                    "Byte": 1015
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].anyOf"
-        },
-        {
-            "Severity": 1,
-            "Summary": "at least one subschema must match",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 42,
-                    "Column": 14,
-                    "Byte": 1000
-                },
-                "End": {
-                    "Line": 42,
-                    "Column": 29,
-                    "Byte": 1015
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].anyOf"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected string, got boolean",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 42,
-                    "Column": 14,
-                    "Byte": 1000
-                },
-                "End": {
-                    "Line": 42,
-                    "Column": 29,
-                    "Byte": 1015
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].anyOf"
-        },
-        {
-            "Severity": 1,
-            "Summary": "exactly one subschema must match",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 43,
-                    "Column": 14,
-                    "Byte": 1029
-                },
-                "End": {
-                    "Line": 43,
-                    "Column": 29,
-                    "Byte": 1044
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].oneOf"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected number, got boolean",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 43,
-                    "Column": 14,
-                    "Byte": 1029
-                },
-                "End": {
-                    "Line": 43,
-                    "Column": 29,
-                    "Byte": 1044
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].oneOf"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected string, got boolean",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 43,
-                    "Column": 14,
-                    "Byte": 1029
-                },
-                "End": {
-                    "Line": 43,
-                    "Column": 29,
-                    "Byte": 1044
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].oneOf"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected [\"hello\",42]",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 44,
-                    "Column": 20,
-                    "Byte": 1064
-                },
-                "End": {
-                    "Line": 44,
-                    "Column": 36,
-                    "Byte": 1080
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"][\"const-array\"]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected array, got string",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 44,
-                    "Column": 20,
-                    "Byte": 1064
-                },
-                "End": {
-                    "Line": 44,
-                    "Column": 36,
-                    "Byte": 1080
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"][\"const-array\"]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected object, got string",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 45,
-                    "Column": 21,
-                    "Byte": 1101
-                },
-                "End": {
-                    "Line": 45,
-                    "Column": 37,
-                    "Byte": 1117
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"][\"const-object\"]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected {\"hello\":\"world\"}",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 45,
-                    "Column": 21,
-                    "Byte": 1101
-                },
-                "End": {
-                    "Line": 45,
-                    "Column": 37,
-                    "Byte": 1117
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"][\"const-object\"]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected one of [\"foo\",\"bar\"]",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 46,
-                    "Column": 13,
-                    "Byte": 1130
-                },
-                "End": {
-                    "Line": 46,
-                    "Column": 29,
-                    "Byte": 1146
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].enum"
-        },
-        {
-            "Severity": 1,
-            "Summary": "missing required properties: bar",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 49,
-                    "Column": 21,
-                    "Byte": 1229
-                },
-                "End": {
-                    "Line": 49,
-                    "Column": 37,
-                    "Byte": 1245
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].dependentReq"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected a multiple of 2",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 50,
-                    "Column": 17,
-                    "Byte": 1262
-                },
-                "End": {
-                    "Line": 50,
-                    "Column": 29,
-                    "Byte": 1274
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].multiple"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected a number greater than or equal to 1",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 51,
-                    "Column": 16,
-                    "Byte": 1290
-                },
-                "End": {
-                    "Line": 51,
-                    "Column": 42,
-                    "Byte": 1316
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].minimum"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected a number greater than 1",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 52,
-                    "Column": 25,
-                    "Byte": 1341
-                },
-                "End": {
-                    "Line": 52,
-                    "Column": 42,
-                    "Byte": 1358
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].exclusiveMinimum"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected a number less than or equal to1",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 53,
-                    "Column": 16,
-                    "Byte": 1374
-                },
-                "End": {
-                    "Line": 53,
-                    "Column": 42,
-                    "Byte": 1400
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].maximum"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected a number less than 1",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 54,
-                    "Column": 25,
-                    "Byte": 1425
-                },
-                "End": {
-                    "Line": 54,
-                    "Column": 42,
-                    "Byte": 1442
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].exclusiveMaximum"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected a string of at least length 1",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 55,
-                    "Column": 18,
-                    "Byte": 1460
-                },
-                "End": {
-                    "Line": 55,
-                    "Column": 18,
-                    "Byte": 1460
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].minLength"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected a string of at most length 1",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 56,
-                    "Column": 18,
-                    "Byte": 1480
-                },
-                "End": {
-                    "Line": 56,
-                    "Column": 34,
-                    "Byte": 1496
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].maxLength"
-        },
-        {
-            "Severity": 1,
-            "Summary": "string must match the pattern \"^foo[0-9]+$\"",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 57,
-                    "Column": 16,
-                    "Byte": 1512
-                },
-                "End": {
-                    "Line": 57,
-                    "Column": 32,
-                    "Byte": 1528
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].pattern"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected an array with at least 3 items",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 58,
-                    "Column": 17,
-                    "Byte": 1545
-                },
-                "End": {
-                    "Line": 58,
-                    "Column": 33,
-                    "Byte": 1561
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].minItems"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected an array with at most 2 items",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 59,
-                    "Column": 17,
-                    "Byte": 1578
-                },
-                "End": {
-                    "Line": 59,
-                    "Column": 33,
-                    "Byte": 1594
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].maxItems"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected an object with at least 1 properties",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 60,
-                    "Column": 22,
-                    "Byte": 1616
-                },
-                "End": {
-                    "Line": 60,
-                    "Column": 38,
-                    "Byte": 1632
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].minProperties"
-        },
-        {
-            "Severity": 1,
-            "Summary": "expected an object with at most 1 properties",
-            "Detail": "",
-            "Subject": {
-                "Filename": "schema-error",
-                "Start": {
-                    "Line": 61,
-                    "Column": 22,
-                    "Byte": 1654
-                },
-                "End": {
-                    "Line": 61,
-                    "Column": 44,
-                    "Byte": 1676
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.sink[\"fn::open::schema\"].maxProperties"
-        }
-    ],
     "eval": {
         "exprs": {
             "sink": {
@@ -13059,6 +13055,10 @@
                 "source"
             ]
         }
+    },
+    "checkJson": {
+        "sink": "[unknown]",
+        "source": "[unknown]"
     },
     "evalJson": {
         "sink": "[unknown]",

--- a/eval/testdata/eval/schema/expected.json
+++ b/eval/testdata/eval/schema/expected.json
@@ -4464,18 +4464,6 @@
             ]
         }
     },
-    "checkJson": {
-        "accesses": [
-            "[unknown]",
-            "[unknown]",
-            "[unknown]",
-            "[unknown]",
-            "[unknown]",
-            "[unknown]"
-        ],
-        "sink": "[unknown]",
-        "source": "[unknown]"
-    },
     "eval": {
         "exprs": {
             "accesses": {
@@ -11463,6 +11451,18 @@
                 "source"
             ]
         }
+    },
+    "checkJson": {
+        "accesses": [
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]"
+        ],
+        "sink": "[unknown]",
+        "source": "[unknown]"
     },
     "evalJson": {
         "accesses": [

--- a/eval/testdata/eval/unicode/expected.json
+++ b/eval/testdata/eval/unicode/expected.json
@@ -353,17 +353,6 @@
             ]
         }
     },
-    "checkJson": {
-        "danmark": {
-            "hovedstad": "københavn"
-        },
-        "hello": "世界",
-        "linear-b": [
-            "𐀀",
-            "𐀁"
-        ],
-        "世界": "hello"
-    },
     "eval": {
         "exprs": {
             "danmark": {
@@ -717,6 +706,17 @@
                 "世界"
             ]
         }
+    },
+    "checkJson": {
+        "danmark": {
+            "hovedstad": "københavn"
+        },
+        "hello": "世界",
+        "linear-b": [
+            "𐀀",
+            "𐀁"
+        ],
+        "世界": "hello"
     },
     "evalJson": {
         "danmark": {


### PR DESCRIPTION
Reorders the test output so both json outputs are displayed together. Perhaps subjective, but having the two JSON outputs together in the file is a lot easier to read through than having to jump around the larger environment structs.