### PR TITLE
eval: detect cyclic imports

### DIFF
--- a/eval/testdata/eval/import-cycle-2/a.yaml
+++ b/eval/testdata/eval/import-cycle-2/a.yaml
@@ -1,0 +1,2 @@
+imports:
+  - b

--- a/eval/testdata/eval/import-cycle-2/b.yaml
+++ b/eval/testdata/eval/import-cycle-2/b.yaml
@@ -1,0 +1,2 @@
+imports:
+  - a

--- a/eval/testdata/eval/import-cycle-2/env.yaml
+++ b/eval/testdata/eval/import-cycle-2/env.yaml
@@ -1,0 +1,2 @@
+imports:
+  - a

--- a/eval/testdata/eval/import-cycle-2/expected.json
+++ b/eval/testdata/eval/import-cycle-2/expected.json
@@ -1,0 +1,64 @@
+{
+    "checkDiags": [
+        {
+            "Severity": 1,
+            "Summary": "cyclic import of a",
+            "Detail": "",
+            "Subject": {
+                "Filename": "b",
+                "Start": {
+                    "Line": 2,
+                    "Column": 5,
+                    "Byte": 13
+                },
+                "End": {
+                    "Line": 2,
+                    "Column": 6,
+                    "Byte": 14
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "imports[0]"
+        }
+    ],
+    "check": {
+        "schema": {
+            "type": "object"
+        }
+    },
+    "checkJson": {},
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "cyclic import of a",
+            "Detail": "",
+            "Subject": {
+                "Filename": "b",
+                "Start": {
+                    "Line": 2,
+                    "Column": 5,
+                    "Byte": 13
+                },
+                "End": {
+                    "Line": 2,
+                    "Column": 6,
+                    "Byte": 14
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "imports[0]"
+        }
+    ],
+    "eval": {
+        "schema": {
+            "type": "object"
+        }
+    },
+    "evalJson": {}
+}

--- a/eval/testdata/eval/import-cycle/env.yaml
+++ b/eval/testdata/eval/import-cycle/env.yaml
@@ -1,0 +1,2 @@
+imports:
+  - env

--- a/eval/testdata/eval/import-cycle/expected.json
+++ b/eval/testdata/eval/import-cycle/expected.json
@@ -1,0 +1,64 @@
+{
+    "checkDiags": [
+        {
+            "Severity": 1,
+            "Summary": "cyclic import of env",
+            "Detail": "",
+            "Subject": {
+                "Filename": "env",
+                "Start": {
+                    "Line": 2,
+                    "Column": 5,
+                    "Byte": 13
+                },
+                "End": {
+                    "Line": 2,
+                    "Column": 8,
+                    "Byte": 16
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "imports[0]"
+        }
+    ],
+    "check": {
+        "schema": {
+            "type": "object"
+        }
+    },
+    "checkJson": {},
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "cyclic import of env",
+            "Detail": "",
+            "Subject": {
+                "Filename": "env",
+                "Start": {
+                    "Line": 2,
+                    "Column": 5,
+                    "Byte": 13
+                },
+                "End": {
+                    "Line": 2,
+                    "Column": 8,
+                    "Byte": 16
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "imports[0]"
+        }
+    ],
+    "eval": {
+        "schema": {
+            "type": "object"
+        }
+    },
+    "evalJson": {}
+}


### PR DESCRIPTION
Issue errors for cyclic imports. Cycles are detected by tracking whether or not an environment is being evaluated in the imports map. If an environment is imported while it is being evaluated, then there is a cycle.