### PR TITLE
cli: add a convenience method for client creation

### DIFF
--- a/cmd/esc/cli/client.go
+++ b/cmd/esc/cli/client.go
@@ -1,0 +1,31 @@
+// Copyright 2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+
+	"github.com/pulumi/esc/cmd/esc/cli/client"
+	"github.com/pulumi/esc/cmd/esc/cli/workspace"
+)
+
+// NewClient returns a new client.Client with the same credentials as would be used by the ESC CLI.
+func NewClient(ctx context.Context) (*workspace.Account, client.Client, error) {
+	esc := newESC(&Options{})
+	if err := esc.getCachedClient(ctx); err != nil {
+		return nil, nil, err
+	}
+	return &esc.account, esc.client, nil
+}


### PR DESCRIPTION
This method, `NewClient`, returns an API client that uses the same credentials as the `esc` CLI. This is primarily useful for integration into other tools.