### PR TITLE
fix: env run interactive should exec

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
+* `env run` in interaactive mode replaces itself using the `exec` command, reducing memory usage and
+  enabling using `esc` to replace the current shell with one with an opened environment.
+
 ### Bug Fixes
 
 * Fix a nil pointer dereference in Syntax.NodeError. [#180](https://github.com/pulumi/esc/pull/180)

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -563,6 +563,14 @@ func (c *testExec) Run(cmd *exec.Cmd) error {
 	return c.runScript(script, cmd)
 }
 
+func (c *testExec) Exec(cmd *exec.Cmd) error {
+	script, ok := c.commands[filepath.Base(cmd.Path)]
+	if !ok {
+		return errors.New("command not found")
+	}
+	return c.runScript(script, cmd)
+}
+
 func (c *testExec) runScript(script string, cmd *exec.Cmd) error {
 	file, err := shsyntax.NewParser().Parse(strings.NewReader(script), cmd.Path)
 	if err != nil {

--- a/cmd/esc/cli/exec.go
+++ b/cmd/esc/cli/exec.go
@@ -2,11 +2,15 @@
 
 package cli
 
-import "os/exec"
+import (
+	"os/exec"
+	"syscall"
+)
 
 type cmdExec interface {
 	LookPath(command string) (string, error)
 	Run(cmd *exec.Cmd) error
+	Exec(cmd *exec.Cmd) error
 }
 
 type defaultCmdExec int
@@ -21,4 +25,11 @@ func (defaultCmdExec) LookPath(command string) (string, error) {
 
 func (defaultCmdExec) Run(cmd *exec.Cmd) error {
 	return cmd.Run()
+}
+
+func (defaultCmdExec) Exec(cmd *exec.Cmd) error {
+	// Exec expects the first argument to be the command name, see execve(2).
+	args := append([]string{cmd.Path}, cmd.Args...)
+	//nolint:gosec
+	return syscall.Exec(cmd.Path, args, cmd.Env)
 }


### PR DESCRIPTION
This behavior is closer to what I would expect the command to do, and doesn't leave `pulumi` or the `esc` CLI running after starting the interactive process. Reduces memory usage and allows this to replace the current shell with one that has credentials:

```shell
exec env run [environment] -i $SHELL
```

That shell command may be executed an arbitrary number of times without memory usage increasing, as each shell replaces the previous in place.

This provides for a nice way to automatically refresh credentials in a shell, e.g., in a `~/.bashrc`:

```bash
export PULUMI_ENVIRONMENT_LAST_OPEN_AT=${PULUMI_ENVIRONMENT_LAST_OPEN_AT:-"0"}

refresh_credentials() {
  if [[ -z "${PULUMI_ENVIRONMENT:-""}" ]]; then
    return
  fi

  local now
  now=$(date +%s)
  local elapsed=$((now - PULUMI_ENVIRONMENT_LAST_OPEN_AT))

  if [[ $elapsed -gt 3600 ]]; then
    echo "Refreshing credentials..."
    PULUMI_ENVIRONMENT_LAST_OPEN_AT=$(date +%s)
    exec pulumi env run "$PULUMI_ENVIRONMENT" -i "$SHELL"
  fi
}

refresh_credentials

PROMPT_COMMAND+="refresh_credentials;"
```
