### PR TITLE
fromJSON: Mark nested structures as secret if the JSON string is secret

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,4 @@
 ### Bug Fixes
 
 * Fix a nil pointer dereference in Syntax.NodeError. [#180](https://github.com/pulumi/esc/pull/180)
+* Mark nested structures as secret if the JSON string is secret. [#191](https://github.com/pulumi/esc/pull/191)

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -919,13 +919,12 @@ func (e *evalContext) evaluateBuiltinFromJSON(x *expr, repr *fromJSONExpr) *valu
 			return v
 		}
 
-		ev, err := esc.FromJSON(jv)
+		ev, err := esc.FromJSON(jv, v.secret)
 		if err != nil {
 			e.errorf(repr.syntax(), "internal error: decoding JSON value: %v", err)
 			v.unknown = true
 			return v
 		}
-		ev.Secret = v.secret
 
 		return unexport(ev, x)
 	}

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -342,7 +342,7 @@ func (e *evalContext) evaluate() (*value, syntax.Diagnostics) {
 	return v, e.diags
 }
 
-// evaluateImports evalutes an environment's imports.
+// evaluateImports evaluates an environment's imports.
 func (e *evalContext) evaluateImports() {
 	mine := &imported{evaluating: true}
 	defer func() { mine.evaluating = false }()
@@ -925,6 +925,7 @@ func (e *evalContext) evaluateBuiltinFromJSON(x *expr, repr *fromJSONExpr) *valu
 			v.unknown = true
 			return v
 		}
+		ev.Secret = v.secret
 
 		return unexport(ev, x)
 	}

--- a/eval/testdata/eval/builtin-combine/expected.json
+++ b/eval/testdata/eval/builtin-combine/expected.json
@@ -1852,7 +1852,7 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
         "builtins": [
             "[secret]",
             "[secret]",
@@ -1863,5 +1863,17 @@
             "foo": "bar"
         },
         "password": "[secret]"
+    },
+    "evalJSONRevealed": {
+        "builtins": [
+            "hunter2,bar",
+            "aHVudGVyMiBiYXI=",
+            "\"hunter2 bar\"",
+            "hunter2 bar"
+        ],
+        "open": {
+            "foo": "bar"
+        },
+        "password": "hunter2"
     }
 }

--- a/eval/testdata/eval/builtin-errs/expected.json
+++ b/eval/testdata/eval/builtin-errs/expected.json
@@ -2115,7 +2115,19 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
+        "builtins": [
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]"
+        ],
+        "number": 42
+    },
+    "evalJSONRevealed": {
         "builtins": [
             "[unknown]",
             "[unknown]",

--- a/eval/testdata/eval/ciphertext-invalid/expected.json
+++ b/eval/testdata/eval/ciphertext-invalid/expected.json
@@ -268,7 +268,10 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
         "password": "[secret]"
+    },
+    "evalJSONRevealed": {
+        "password": "[unknown]"
     }
 }

--- a/eval/testdata/eval/ciphertext/expected.json
+++ b/eval/testdata/eval/ciphertext/expected.json
@@ -218,7 +218,10 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
         "password": "[secret]"
+    },
+    "evalJSONRevealed": {
+        "password": "hunter2"
     }
 }

--- a/eval/testdata/eval/cycle/expected.json
+++ b/eval/testdata/eval/cycle/expected.json
@@ -960,7 +960,18 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
+        "a": {
+            "p": "[unknown]"
+        },
+        "b": {
+            "p": "[unknown]"
+        },
+        "c": {
+            "p": "[unknown]"
+        }
+    },
+    "evalJSONRevealed": {
         "a": {
             "p": "[unknown]"
         },

--- a/eval/testdata/eval/duplicate-keys/expected.json
+++ b/eval/testdata/eval/duplicate-keys/expected.json
@@ -441,7 +441,13 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
+        "foo": "bar",
+        "qux": {
+            "foo": "bar"
+        }
+    },
+    "evalJSONRevealed": {
         "foo": "bar",
         "qux": {
             "foo": "bar"

--- a/eval/testdata/eval/escape-keys/expected.json
+++ b/eval/testdata/eval/escape-keys/expected.json
@@ -504,7 +504,14 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
+        "object": {
+            "\"quoted\"": "baz",
+            "0leadingDigit": "bar",
+            "with-hyphen": "foo"
+        }
+    },
+    "evalJSONRevealed": {
         "object": {
             "\"quoted\"": "baz",
             "0leadingDigit": "bar",

--- a/eval/testdata/eval/import-cycle-2/expected.json
+++ b/eval/testdata/eval/import-cycle-2/expected.json
@@ -60,5 +60,6 @@
             "type": "object"
         }
     },
-    "evalJson": {}
+    "evalJsonRedacted": {},
+    "evalJSONRevealed": {}
 }

--- a/eval/testdata/eval/import-cycle/expected.json
+++ b/eval/testdata/eval/import-cycle/expected.json
@@ -60,5 +60,6 @@
             "type": "object"
         }
     },
-    "evalJson": {}
+    "evalJsonRedacted": {},
+    "evalJSONRevealed": {}
 }

--- a/eval/testdata/eval/imports/expected.json
+++ b/eval/testdata/eval/imports/expected.json
@@ -2210,7 +2210,24 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
+        "some_list": [
+            "hello",
+            "world"
+        ],
+        "some_number": 42,
+        "some_object": {
+            "alpha": null,
+            "baz": "qux",
+            "beta": "bar",
+            "foo": "bar",
+            "goodbye": "for now",
+            "hello": "world",
+            "zed": "bar"
+        },
+        "some_string": "hello"
+    },
+    "evalJSONRevealed": {
         "some_list": [
             "hello",
             "world"

--- a/eval/testdata/eval/interp/expected.json
+++ b/eval/testdata/eval/interp/expected.json
@@ -2898,7 +2898,36 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
+        "34": "this should be okay",
+        "35": {
+            "okay": "also okay"
+        },
+        "a": {
+            "p": "foo",
+            "q": "foo",
+            "u": {
+                "\"baz": "merp"
+            }
+        },
+        "b": {
+            "p": "foo"
+        },
+        "c": {
+            "a": [
+                "foo",
+                "hello, world!",
+                "foo bar"
+            ],
+            "b": "world!",
+            "s": [
+                "merp",
+                "this should be okay",
+                "also okay"
+            ]
+        }
+    },
+    "evalJSONRevealed": {
         "34": "this should be okay",
         "35": {
             "okay": "also okay"

--- a/eval/testdata/eval/invalid-access/expected.json
+++ b/eval/testdata/eval/invalid-access/expected.json
@@ -8122,7 +8122,76 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
+        "array": [
+            1,
+            2,
+            3
+        ],
+        "errors": [
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]"
+        ],
+        "myObject": {
+            "foo": "bar"
+        },
+        "object": {
+            "baz": "qux",
+            "hello": "world"
+        },
+        "open": {
+            "anyOf": "hello",
+            "array": [
+                2,
+                "items",
+                {
+                    "some": "object"
+                },
+                [
+                    "array"
+                ]
+            ],
+            "boolean": true,
+            "false": false,
+            "hello": "hello",
+            "map": {
+                "blue": 42,
+                "hello": "world"
+            },
+            "null": null,
+            "number": 42,
+            "oneOf": 42,
+            "pi": 3.14,
+            "record": {
+                "foo": "bar"
+            },
+            "ref": {
+                "baz": "qux"
+            },
+            "string": "esc",
+            "true": true,
+            "tuple": [
+                "hello",
+                "world"
+            ]
+        },
+        "otherObject": {
+            "foo": "bar"
+        },
+        "string": "esc"
+    },
+    "evalJSONRevealed": {
         "array": [
             1,
             2,

--- a/eval/testdata/eval/literals/expected.json
+++ b/eval/testdata/eval/literals/expected.json
@@ -1007,7 +1007,21 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
+        "some_bool": true,
+        "some_list": [
+            "hello",
+            "world"
+        ],
+        "some_null": null,
+        "some_number": 42,
+        "some_object": {
+            "goodbye": "for now",
+            "hello": "world"
+        },
+        "some_string": "hello"
+    },
+    "evalJSONRevealed": {
         "some_bool": true,
         "some_list": [
             "hello",

--- a/eval/testdata/eval/merge-replace/expected.json
+++ b/eval/testdata/eval/merge-replace/expected.json
@@ -334,7 +334,12 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
+        "foo": {
+            "bar": "baz"
+        }
+    },
+    "evalJSONRevealed": {
         "foo": {
             "bar": "baz"
         }

--- a/eval/testdata/eval/merge-unknown/expected.json
+++ b/eval/testdata/eval/merge-unknown/expected.json
@@ -1146,7 +1146,15 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
+        "open": {
+            "baz": {
+                "qux": "zed"
+            },
+            "foo": "bar"
+        }
+    },
+    "evalJSONRevealed": {
         "open": {
             "baz": {
                 "qux": "zed"

--- a/eval/testdata/eval/nested-unknowns-secrets/expected.json
+++ b/eval/testdata/eval/nested-unknowns-secrets/expected.json
@@ -5857,7 +5857,7 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
         "base64OutputSecret": "[secret]",
         "base64OutputUnknown": "YmFy",
         "cloudflare": {
@@ -5899,5 +5899,48 @@
         "stringOutputSecret": "[secret]",
         "stringOutputUnknown": "\"oneStep\"=\"\\\"twoStep\\\"=\\\"\\\\\\\"threeStep\\\\\\\"=\\\\\\\"\\\\\\\\\\\\\\\"fourStep\\\\\\\\\\\\\\\"=\\\\\\\\\\\\\\\"\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"foo\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"=\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"bar\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"\\\\\\\\\\\\\\\"\\\\\\\"\\\"\"",
         "top-level-secret": "[secret]"
+    },
+    "evalJSONRevealed": {
+        "base64OutputSecret": "YXBpS2V5U2VjcmV0",
+        "base64OutputUnknown": "YmFy",
+        "cloudflare": {
+            "account": {
+                "id": "accountIdSecret",
+                "name": "account-name"
+            },
+            "apiKey": "apiKeySecret",
+            "apiToken": "apiTokenSecret",
+            "username": "bot@pulumi.com",
+            "zoneId": "zone-id-123"
+        },
+        "comboSecretAndUnknown": {
+            "cloudflareApi": "apiKeySecret",
+            "provider": "bar"
+        },
+        "deeplyNestedProvider": {
+            "oneStep": {
+                "twoStep": {
+                    "threeStep": {
+                        "fourStep": {
+                            "foo": "bar"
+                        }
+                    }
+                }
+            }
+        },
+        "environmentVariables": {
+            "CLOUDFLARE_API_TOKEN": "apiTokenSecret"
+        },
+        "jsonOutputCombo": "{\"cloudflareApi\":\"apiKeySecret\",\"provider\":\"bar\"}",
+        "jsonOutputSecret": "{\"account\":{\"id\":\"accountIdSecret\",\"name\":\"account-name\"},\"apiKey\":\"apiKeySecret\",\"apiToken\":\"apiTokenSecret\",\"username\":\"bot@pulumi.com\",\"zoneId\":\"zone-id-123\"}",
+        "jsonOutputUnknown": "{\"oneStep\":{\"twoStep\":{\"threeStep\":{\"fourStep\":{\"foo\":\"bar\"}}}}}",
+        "pulumiConfig": {
+            "accountId": "accountIdSecret",
+            "refTopLevelSecret": "top-secret"
+        },
+        "stringOutputCombo": "\"cloudflareApi\"=\"apiKeySecret\",\"provider\"=\"bar\"",
+        "stringOutputSecret": "\"account\"=\"\\\"id\\\"=\\\"accountIdSecret\\\",\\\"name\\\"=\\\"account-name\\\"\",\"apiKey\"=\"apiKeySecret\",\"apiToken\"=\"apiTokenSecret\",\"username\"=\"bot@pulumi.com\",\"zoneId\"=\"zone-id-123\"",
+        "stringOutputUnknown": "\"oneStep\"=\"\\\"twoStep\\\"=\\\"\\\\\\\"threeStep\\\\\\\"=\\\\\\\"\\\\\\\\\\\\\\\"fourStep\\\\\\\\\\\\\\\"=\\\\\\\\\\\\\\\"\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"foo\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"=\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"bar\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"\\\\\\\\\\\\\\\"\\\\\\\"\\\"\"",
+        "top-level-secret": "top-secret"
     }
 }

--- a/eval/testdata/eval/omnibus/expected.json
+++ b/eval/testdata/eval/omnibus/expected.json
@@ -3541,7 +3541,7 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
         "access": "qux",
         "fromBase64": "hello,world",
         "fromJSON": {
@@ -3577,6 +3577,50 @@
             "foo": "bar"
         },
         "secret": "[secret]",
+        "strings": [
+            "hello",
+            "world"
+        ],
+        "toBase64": "aGVsbG8sd29ybGQ=",
+        "toJSON": "{\"a\":null,\"b\":true,\"baz\":\"qux\",\"c\":42,\"d\":[\"hello\"],\"foo\":\"bar\"}",
+        "toString": "\"a\"=\"\",\"b\"=\"true\",\"baz\"=\"qux\",\"c\"=\"42\",\"d\"=\"\\\"hello\\\"\""
+    },
+    "evalJSONRevealed": {
+        "access": "qux",
+        "fromBase64": "hello,world",
+        "fromJSON": {
+            "a": null,
+            "b": true,
+            "baz": "qux",
+            "c": 42,
+            "d": [
+                "hello"
+            ],
+            "foo": "bar"
+        },
+        "interp": "hello, \"a\"=\"\",\"b\"=\"true\",\"baz\"=\"qux\",\"c\"=\"42\",\"d\"=\"\\\"hello\\\"\"",
+        "join": "hello,world",
+        "open": {
+            "a": null,
+            "b": true,
+            "baz": "qux",
+            "c": 42,
+            "d": [
+                "hello"
+            ],
+            "foo": "bar"
+        },
+        "open2": {
+            "a": null,
+            "b": true,
+            "baz": "qux",
+            "c": 42,
+            "d": [
+                "hello"
+            ],
+            "foo": "bar"
+        },
+        "secret": "hunter2",
         "strings": [
             "hello",
             "world"

--- a/eval/testdata/eval/open-unknown/expected.json
+++ b/eval/testdata/eval/open-unknown/expected.json
@@ -584,7 +584,11 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
+        "dependent": "[unknown]",
+        "error": "[unknown]"
+    },
+    "evalJSONRevealed": {
         "dependent": "[unknown]",
         "error": "[unknown]"
     }

--- a/eval/testdata/eval/open/expected.json
+++ b/eval/testdata/eval/open/expected.json
@@ -2141,7 +2141,36 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
+        "referent": {
+            "foo": "bar",
+            "list": "a",
+            "object": "value",
+            "test": {
+                "baz": "qux",
+                "foo": "bar",
+                "list": [
+                    "a",
+                    "list"
+                ],
+                "object": {
+                    "key": "value"
+                }
+            }
+        },
+        "test": {
+            "baz": "qux",
+            "foo": "bar",
+            "list": [
+                "a",
+                "list"
+            ],
+            "object": {
+                "key": "value"
+            }
+        }
+    },
+    "evalJSONRevealed": {
         "referent": {
             "foo": "bar",
             "list": "a",

--- a/eval/testdata/eval/plaintext/expected.json
+++ b/eval/testdata/eval/plaintext/expected.json
@@ -188,7 +188,10 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
         "password": "[secret]"
+    },
+    "evalJSONRevealed": {
+        "password": "hunter2"
     }
 }

--- a/eval/testdata/eval/reserved-keys/expected.json
+++ b/eval/testdata/eval/reserved-keys/expected.json
@@ -106,5 +106,6 @@
             "type": "object"
         }
     },
-    "evalJson": {}
+    "evalJsonRedacted": {},
+    "evalJSONRevealed": {}
 }

--- a/eval/testdata/eval/schema-error/expected.json
+++ b/eval/testdata/eval/schema-error/expected.json
@@ -13060,7 +13060,82 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
+        "sink": "[unknown]",
+        "source": {
+            "always": {},
+            "anyOf": "hello",
+            "array": [
+                2,
+                "items",
+                {
+                    "some": "object"
+                },
+                [
+                    "array"
+                ]
+            ],
+            "boolean": true,
+            "const-array": [
+                "hello",
+                42
+            ],
+            "const-object": {
+                "hello": "world"
+            },
+            "dependentReq": {
+                "bar": 42,
+                "foo": "bar"
+            },
+            "double": [
+                "hello",
+                42
+            ],
+            "enum": "foo",
+            "exclusiveMaximum": 0,
+            "exclusiveMinimum": 2,
+            "false": false,
+            "hello": "hello",
+            "map": {
+                "blue": 42,
+                "hello": "world"
+            },
+            "maxLength": "a",
+            "maxProperties": {
+                "foo": "bar"
+            },
+            "maximum": 1,
+            "minLength": "a",
+            "minProperties": {
+                "foo": "bar"
+            },
+            "minimum": 1,
+            "multiple": 4,
+            "null": null,
+            "number": 42,
+            "oneOf": 42,
+            "pattern": "foo42",
+            "pi": 3.14,
+            "record": {
+                "foo": "bar"
+            },
+            "ref": {
+                "baz": "qux"
+            },
+            "string": "esc",
+            "triple": [
+                "hello",
+                42,
+                true
+            ],
+            "true": true,
+            "tuple": [
+                "hello",
+                "world"
+            ]
+        }
+    },
+    "evalJSONRevealed": {
         "sink": "[unknown]",
         "source": {
             "always": {},

--- a/eval/testdata/eval/schema/expected.json
+++ b/eval/testdata/eval/schema/expected.json
@@ -11464,7 +11464,161 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
+        "accesses": [
+            "bar",
+            "hello",
+            "world",
+            "items",
+            "object",
+            "array"
+        ],
+        "sink": {
+            "always": {},
+            "anyOf": "hello",
+            "array": [
+                2,
+                "items",
+                {
+                    "some": "object"
+                },
+                [
+                    "array"
+                ]
+            ],
+            "boolean": true,
+            "const-array": [
+                "hello",
+                42
+            ],
+            "const-object": {
+                "hello": "world"
+            },
+            "dependentReq": {
+                "bar": 42,
+                "foo": "bar"
+            },
+            "double": [
+                "hello",
+                42
+            ],
+            "enum": "foo",
+            "exclusiveMaximum": 0,
+            "exclusiveMinimum": 2,
+            "false": false,
+            "hello": "hello",
+            "map": {
+                "blue": 42,
+                "hello": "world"
+            },
+            "maxLength": "a",
+            "maxProperties": {
+                "foo": "bar"
+            },
+            "maximum": 1,
+            "minLength": "a",
+            "minProperties": {
+                "foo": "bar"
+            },
+            "minimum": 1,
+            "multiple": 4,
+            "null": null,
+            "number": 42,
+            "oneOf": 42,
+            "pattern": "foo42",
+            "pi": 3.14,
+            "record": {
+                "foo": "bar"
+            },
+            "ref": {
+                "baz": "qux"
+            },
+            "string": "esc",
+            "triple": [
+                "hello",
+                42,
+                true
+            ],
+            "true": true,
+            "tuple": [
+                "hello",
+                "world"
+            ]
+        },
+        "source": {
+            "always": {},
+            "anyOf": "hello",
+            "array": [
+                2,
+                "items",
+                {
+                    "some": "object"
+                },
+                [
+                    "array"
+                ]
+            ],
+            "boolean": true,
+            "const-array": [
+                "hello",
+                42
+            ],
+            "const-object": {
+                "hello": "world"
+            },
+            "dependentReq": {
+                "bar": 42,
+                "foo": "bar"
+            },
+            "double": [
+                "hello",
+                42
+            ],
+            "enum": "foo",
+            "exclusiveMaximum": 0,
+            "exclusiveMinimum": 2,
+            "false": false,
+            "hello": "hello",
+            "map": {
+                "blue": 42,
+                "hello": "world"
+            },
+            "maxLength": "a",
+            "maxProperties": {
+                "foo": "bar"
+            },
+            "maximum": 1,
+            "minLength": "a",
+            "minProperties": {
+                "foo": "bar"
+            },
+            "minimum": 1,
+            "multiple": 4,
+            "null": null,
+            "number": 42,
+            "oneOf": 42,
+            "pattern": "foo42",
+            "pi": 3.14,
+            "record": {
+                "foo": "bar"
+            },
+            "ref": {
+                "baz": "qux"
+            },
+            "string": "esc",
+            "triple": [
+                "hello",
+                42,
+                true
+            ],
+            "true": true,
+            "tuple": [
+                "hello",
+                "world"
+            ]
+        }
+    },
+    "evalJSONRevealed": {
         "accesses": [
             "bar",
             "hello",

--- a/eval/testdata/eval/secret-objects/env.yaml
+++ b/eval/testdata/eval/secret-objects/env.yaml
@@ -1,0 +1,5 @@
+values:
+  secret_object:
+    fn::secret: '{"haha":"business","also":"secret"}'
+  unmarshalled_secret_object:
+    fn::fromJSON: ${secret_object}

--- a/eval/testdata/eval/secret-objects/env.yaml
+++ b/eval/testdata/eval/secret-objects/env.yaml
@@ -7,3 +7,5 @@ values:
     fn::secret: '["haha","business","also","secret"]'
   unmarshalled_secret_array:
     fn::fromJSON: ${secret_array}
+  item_from_secret_array: ${unmarshalled_secret_array[0]}
+  item_from_secret_object: ${unmarshalled_secret_object.haha}

--- a/eval/testdata/eval/secret-objects/env.yaml
+++ b/eval/testdata/eval/secret-objects/env.yaml
@@ -3,3 +3,7 @@ values:
     fn::secret: '{"haha":"business","also":"secret"}'
   unmarshalled_secret_object:
     fn::fromJSON: ${secret_object}
+  secret_array:
+    fn::secret: '["haha","business","also","secret"]'
+  unmarshalled_secret_array:
+    fn::fromJSON: ${secret_array}

--- a/eval/testdata/eval/secret-objects/expected.json
+++ b/eval/testdata/eval/secret-objects/expected.json
@@ -203,6 +203,7 @@
                         }
                     }
                 },
+                "secret": true,
                 "trace": {
                     "def": {
                         "environment": "secret-objects",
@@ -253,10 +254,7 @@
     },
     "checkJson": {
         "secret_object": "[secret]",
-        "unmarshalled_secret_object": {
-            "also": "secret",
-            "haha": "business"
-        }
+        "unmarshalled_secret_object": "[secret]"
     },
     "eval": {
         "exprs": {
@@ -462,6 +460,7 @@
                         }
                     }
                 },
+                "secret": true,
                 "trace": {
                     "def": {
                         "environment": "secret-objects",
@@ -510,8 +509,12 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
         "secret_object": "[secret]",
+        "unmarshalled_secret_object": "[secret]"
+    },
+    "evalJSONRevealed": {
+        "secret_object": "{\"haha\":\"business\",\"also\":\"secret\"}",
         "unmarshalled_secret_object": {
             "also": "secret",
             "haha": "business"

--- a/eval/testdata/eval/secret-objects/expected.json
+++ b/eval/testdata/eval/secret-objects/expected.json
@@ -1,6 +1,62 @@
 {
     "check": {
         "exprs": {
+            "secret_array": {
+                "range": {
+                    "environment": "secret-objects",
+                    "begin": {
+                        "line": 7,
+                        "column": 5,
+                        "byte": 164
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 52,
+                        "byte": 211
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "[\"haha\",\"business\",\"also\",\"secret\"]"
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 7,
+                            "column": 5,
+                            "byte": 164
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 15,
+                            "byte": 174
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 7,
+                                "column": 17,
+                                "byte": 176
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 52,
+                                "byte": 211
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "[\"haha\",\"business\",\"also\",\"secret\"]"
+                        },
+                        "literal": "[\"haha\",\"business\",\"also\",\"secret\"]"
+                    }
+                }
+            },
             "secret_object": {
                 "range": {
                     "environment": "secret-objects",
@@ -54,6 +110,97 @@
                             "const": "{\"haha\":\"business\",\"also\":\"secret\"}"
                         },
                         "literal": "{\"haha\":\"business\",\"also\":\"secret\"}"
+                    }
+                }
+            },
+            "unmarshalled_secret_array": {
+                "range": {
+                    "environment": "secret-objects",
+                    "begin": {
+                        "line": 9,
+                        "column": 5,
+                        "byte": 247
+                    },
+                    "end": {
+                        "line": 9,
+                        "column": 34,
+                        "byte": 276
+                    }
+                },
+                "schema": {
+                    "prefixItems": [
+                        {
+                            "type": "string",
+                            "const": "haha"
+                        },
+                        {
+                            "type": "string",
+                            "const": "business"
+                        },
+                        {
+                            "type": "string",
+                            "const": "also"
+                        },
+                        {
+                            "type": "string",
+                            "const": "secret"
+                        }
+                    ],
+                    "items": false,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::fromJSON",
+                    "nameRange": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 9,
+                            "column": 5,
+                            "byte": 247
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 17,
+                            "byte": 259
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 9,
+                                "column": 19,
+                                "byte": 261
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 34,
+                                "byte": 276
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "[\"haha\",\"business\",\"also\",\"secret\"]"
+                        },
+                        "symbol": [
+                            {
+                                "key": "secret_array",
+                                "value": {
+                                    "environment": "secret-objects",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 5,
+                                        "byte": 164
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 52,
+                                        "byte": 211
+                                    }
+                                }
+                            }
+                        ]
                     }
                 }
             },
@@ -145,6 +292,25 @@
             }
         },
         "properties": {
+            "secret_array": {
+                "value": "[\"haha\",\"business\",\"also\",\"secret\"]",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 7,
+                            "column": 17,
+                            "byte": 176
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 52,
+                            "byte": 211
+                        }
+                    }
+                }
+            },
             "secret_object": {
                 "value": "{\"haha\":\"business\",\"also\":\"secret\"}",
                 "secret": true,
@@ -160,6 +326,98 @@
                             "line": 3,
                             "column": 52,
                             "byte": 76
+                        }
+                    }
+                }
+            },
+            "unmarshalled_secret_array": {
+                "value": [
+                    {
+                        "value": "haha",
+                        "trace": {
+                            "def": {
+                                "environment": "secret-objects",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 5,
+                                    "byte": 247
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 34,
+                                    "byte": 276
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "business",
+                        "trace": {
+                            "def": {
+                                "environment": "secret-objects",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 5,
+                                    "byte": 247
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 34,
+                                    "byte": 276
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "also",
+                        "trace": {
+                            "def": {
+                                "environment": "secret-objects",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 5,
+                                    "byte": 247
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 34,
+                                    "byte": 276
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "secret",
+                        "trace": {
+                            "def": {
+                                "environment": "secret-objects",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 5,
+                                    "byte": 247
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 34,
+                                    "byte": 276
+                                }
+                            }
+                        }
+                    }
+                ],
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 9,
+                            "column": 5,
+                            "byte": 247
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 34,
+                            "byte": 276
                         }
                     }
                 }
@@ -223,9 +481,35 @@
         },
         "schema": {
             "properties": {
+                "secret_array": {
+                    "type": "string",
+                    "const": "[\"haha\",\"business\",\"also\",\"secret\"]"
+                },
                 "secret_object": {
                     "type": "string",
                     "const": "{\"haha\":\"business\",\"also\":\"secret\"}"
+                },
+                "unmarshalled_secret_array": {
+                    "prefixItems": [
+                        {
+                            "type": "string",
+                            "const": "haha"
+                        },
+                        {
+                            "type": "string",
+                            "const": "business"
+                        },
+                        {
+                            "type": "string",
+                            "const": "also"
+                        },
+                        {
+                            "type": "string",
+                            "const": "secret"
+                        }
+                    ],
+                    "items": false,
+                    "type": "array"
                 },
                 "unmarshalled_secret_object": {
                     "properties": {
@@ -247,17 +531,77 @@
             },
             "type": "object",
             "required": [
+                "secret_array",
                 "secret_object",
+                "unmarshalled_secret_array",
                 "unmarshalled_secret_object"
             ]
         }
     },
     "checkJson": {
+        "secret_array": "[secret]",
         "secret_object": "[secret]",
+        "unmarshalled_secret_array": "[secret]",
         "unmarshalled_secret_object": "[secret]"
     },
     "eval": {
         "exprs": {
+            "secret_array": {
+                "range": {
+                    "environment": "secret-objects",
+                    "begin": {
+                        "line": 7,
+                        "column": 5,
+                        "byte": 164
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 52,
+                        "byte": 211
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "[\"haha\",\"business\",\"also\",\"secret\"]"
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 7,
+                            "column": 5,
+                            "byte": 164
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 15,
+                            "byte": 174
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 7,
+                                "column": 17,
+                                "byte": 176
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 52,
+                                "byte": 211
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "[\"haha\",\"business\",\"also\",\"secret\"]"
+                        },
+                        "literal": "[\"haha\",\"business\",\"also\",\"secret\"]"
+                    }
+                }
+            },
             "secret_object": {
                 "range": {
                     "environment": "secret-objects",
@@ -311,6 +655,97 @@
                             "const": "{\"haha\":\"business\",\"also\":\"secret\"}"
                         },
                         "literal": "{\"haha\":\"business\",\"also\":\"secret\"}"
+                    }
+                }
+            },
+            "unmarshalled_secret_array": {
+                "range": {
+                    "environment": "secret-objects",
+                    "begin": {
+                        "line": 9,
+                        "column": 5,
+                        "byte": 247
+                    },
+                    "end": {
+                        "line": 9,
+                        "column": 34,
+                        "byte": 276
+                    }
+                },
+                "schema": {
+                    "prefixItems": [
+                        {
+                            "type": "string",
+                            "const": "haha"
+                        },
+                        {
+                            "type": "string",
+                            "const": "business"
+                        },
+                        {
+                            "type": "string",
+                            "const": "also"
+                        },
+                        {
+                            "type": "string",
+                            "const": "secret"
+                        }
+                    ],
+                    "items": false,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::fromJSON",
+                    "nameRange": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 9,
+                            "column": 5,
+                            "byte": 247
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 17,
+                            "byte": 259
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 9,
+                                "column": 19,
+                                "byte": 261
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 34,
+                                "byte": 276
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "[\"haha\",\"business\",\"also\",\"secret\"]"
+                        },
+                        "symbol": [
+                            {
+                                "key": "secret_array",
+                                "value": {
+                                    "environment": "secret-objects",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 5,
+                                        "byte": 164
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 52,
+                                        "byte": 211
+                                    }
+                                }
+                            }
+                        ]
                     }
                 }
             },
@@ -402,6 +837,25 @@
             }
         },
         "properties": {
+            "secret_array": {
+                "value": "[\"haha\",\"business\",\"also\",\"secret\"]",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 7,
+                            "column": 17,
+                            "byte": 176
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 52,
+                            "byte": 211
+                        }
+                    }
+                }
+            },
             "secret_object": {
                 "value": "{\"haha\":\"business\",\"also\":\"secret\"}",
                 "secret": true,
@@ -417,6 +871,98 @@
                             "line": 3,
                             "column": 52,
                             "byte": 76
+                        }
+                    }
+                }
+            },
+            "unmarshalled_secret_array": {
+                "value": [
+                    {
+                        "value": "haha",
+                        "trace": {
+                            "def": {
+                                "environment": "secret-objects",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 5,
+                                    "byte": 247
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 34,
+                                    "byte": 276
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "business",
+                        "trace": {
+                            "def": {
+                                "environment": "secret-objects",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 5,
+                                    "byte": 247
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 34,
+                                    "byte": 276
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "also",
+                        "trace": {
+                            "def": {
+                                "environment": "secret-objects",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 5,
+                                    "byte": 247
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 34,
+                                    "byte": 276
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "secret",
+                        "trace": {
+                            "def": {
+                                "environment": "secret-objects",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 5,
+                                    "byte": 247
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 34,
+                                    "byte": 276
+                                }
+                            }
+                        }
+                    }
+                ],
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 9,
+                            "column": 5,
+                            "byte": 247
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 34,
+                            "byte": 276
                         }
                     }
                 }
@@ -480,9 +1026,35 @@
         },
         "schema": {
             "properties": {
+                "secret_array": {
+                    "type": "string",
+                    "const": "[\"haha\",\"business\",\"also\",\"secret\"]"
+                },
                 "secret_object": {
                     "type": "string",
                     "const": "{\"haha\":\"business\",\"also\":\"secret\"}"
+                },
+                "unmarshalled_secret_array": {
+                    "prefixItems": [
+                        {
+                            "type": "string",
+                            "const": "haha"
+                        },
+                        {
+                            "type": "string",
+                            "const": "business"
+                        },
+                        {
+                            "type": "string",
+                            "const": "also"
+                        },
+                        {
+                            "type": "string",
+                            "const": "secret"
+                        }
+                    ],
+                    "items": false,
+                    "type": "array"
                 },
                 "unmarshalled_secret_object": {
                     "properties": {
@@ -504,17 +1076,28 @@
             },
             "type": "object",
             "required": [
+                "secret_array",
                 "secret_object",
+                "unmarshalled_secret_array",
                 "unmarshalled_secret_object"
             ]
         }
     },
     "evalJsonRedacted": {
+        "secret_array": "[secret]",
         "secret_object": "[secret]",
+        "unmarshalled_secret_array": "[secret]",
         "unmarshalled_secret_object": "[secret]"
     },
     "evalJSONRevealed": {
+        "secret_array": "[\"haha\",\"business\",\"also\",\"secret\"]",
         "secret_object": "{\"haha\":\"business\",\"also\":\"secret\"}",
+        "unmarshalled_secret_array": [
+            "haha",
+            "business",
+            "also",
+            "secret"
+        ],
         "unmarshalled_secret_object": {
             "also": "secret",
             "haha": "business"

--- a/eval/testdata/eval/secret-objects/expected.json
+++ b/eval/testdata/eval/secret-objects/expected.json
@@ -1,6 +1,112 @@
 {
     "check": {
         "exprs": {
+            "item_from_secret_array": {
+                "range": {
+                    "environment": "secret-objects",
+                    "begin": {
+                        "line": 10,
+                        "column": 27,
+                        "byte": 303
+                    },
+                    "end": {
+                        "line": 10,
+                        "column": 58,
+                        "byte": 334
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "haha"
+                },
+                "symbol": [
+                    {
+                        "key": "unmarshalled_secret_array",
+                        "value": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 9,
+                                "column": 5,
+                                "byte": 247
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 34,
+                                "byte": 276
+                            }
+                        }
+                    },
+                    {
+                        "index": 0,
+                        "value": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 9,
+                                "column": 5,
+                                "byte": 247
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 34,
+                                "byte": 276
+                            }
+                        }
+                    }
+                ]
+            },
+            "item_from_secret_object": {
+                "range": {
+                    "environment": "secret-objects",
+                    "begin": {
+                        "line": 11,
+                        "column": 28,
+                        "byte": 362
+                    },
+                    "end": {
+                        "line": 11,
+                        "column": 62,
+                        "byte": 396
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "business"
+                },
+                "symbol": [
+                    {
+                        "key": "unmarshalled_secret_object",
+                        "value": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 5,
+                                "column": 5,
+                                "byte": 113
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 35,
+                                "byte": 143
+                            }
+                        }
+                    },
+                    {
+                        "key": "haha",
+                        "value": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 5,
+                                "column": 5,
+                                "byte": 113
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 35,
+                                "byte": 143
+                            }
+                        }
+                    }
+                ]
+            },
             "secret_array": {
                 "range": {
                     "environment": "secret-objects",
@@ -292,6 +398,42 @@
             }
         },
         "properties": {
+            "item_from_secret_array": {
+                "value": "haha",
+                "trace": {
+                    "def": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 10,
+                            "column": 27,
+                            "byte": 303
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 58,
+                            "byte": 334
+                        }
+                    }
+                }
+            },
+            "item_from_secret_object": {
+                "value": "business",
+                "trace": {
+                    "def": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 11,
+                            "column": 28,
+                            "byte": 362
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 62,
+                            "byte": 396
+                        }
+                    }
+                }
+            },
             "secret_array": {
                 "value": "[\"haha\",\"business\",\"also\",\"secret\"]",
                 "secret": true,
@@ -481,6 +623,14 @@
         },
         "schema": {
             "properties": {
+                "item_from_secret_array": {
+                    "type": "string",
+                    "const": "haha"
+                },
+                "item_from_secret_object": {
+                    "type": "string",
+                    "const": "business"
+                },
                 "secret_array": {
                     "type": "string",
                     "const": "[\"haha\",\"business\",\"also\",\"secret\"]"
@@ -531,6 +681,8 @@
             },
             "type": "object",
             "required": [
+                "item_from_secret_array",
+                "item_from_secret_object",
                 "secret_array",
                 "secret_object",
                 "unmarshalled_secret_array",
@@ -539,6 +691,8 @@
         }
     },
     "checkJson": {
+        "item_from_secret_array": "haha",
+        "item_from_secret_object": "business",
         "secret_array": "[secret]",
         "secret_object": "[secret]",
         "unmarshalled_secret_array": "[secret]",
@@ -546,6 +700,112 @@
     },
     "eval": {
         "exprs": {
+            "item_from_secret_array": {
+                "range": {
+                    "environment": "secret-objects",
+                    "begin": {
+                        "line": 10,
+                        "column": 27,
+                        "byte": 303
+                    },
+                    "end": {
+                        "line": 10,
+                        "column": 58,
+                        "byte": 334
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "haha"
+                },
+                "symbol": [
+                    {
+                        "key": "unmarshalled_secret_array",
+                        "value": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 9,
+                                "column": 5,
+                                "byte": 247
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 34,
+                                "byte": 276
+                            }
+                        }
+                    },
+                    {
+                        "index": 0,
+                        "value": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 9,
+                                "column": 5,
+                                "byte": 247
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 34,
+                                "byte": 276
+                            }
+                        }
+                    }
+                ]
+            },
+            "item_from_secret_object": {
+                "range": {
+                    "environment": "secret-objects",
+                    "begin": {
+                        "line": 11,
+                        "column": 28,
+                        "byte": 362
+                    },
+                    "end": {
+                        "line": 11,
+                        "column": 62,
+                        "byte": 396
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "business"
+                },
+                "symbol": [
+                    {
+                        "key": "unmarshalled_secret_object",
+                        "value": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 5,
+                                "column": 5,
+                                "byte": 113
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 35,
+                                "byte": 143
+                            }
+                        }
+                    },
+                    {
+                        "key": "haha",
+                        "value": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 5,
+                                "column": 5,
+                                "byte": 113
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 35,
+                                "byte": 143
+                            }
+                        }
+                    }
+                ]
+            },
             "secret_array": {
                 "range": {
                     "environment": "secret-objects",
@@ -837,6 +1097,42 @@
             }
         },
         "properties": {
+            "item_from_secret_array": {
+                "value": "haha",
+                "trace": {
+                    "def": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 10,
+                            "column": 27,
+                            "byte": 303
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 58,
+                            "byte": 334
+                        }
+                    }
+                }
+            },
+            "item_from_secret_object": {
+                "value": "business",
+                "trace": {
+                    "def": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 11,
+                            "column": 28,
+                            "byte": 362
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 62,
+                            "byte": 396
+                        }
+                    }
+                }
+            },
             "secret_array": {
                 "value": "[\"haha\",\"business\",\"also\",\"secret\"]",
                 "secret": true,
@@ -1026,6 +1322,14 @@
         },
         "schema": {
             "properties": {
+                "item_from_secret_array": {
+                    "type": "string",
+                    "const": "haha"
+                },
+                "item_from_secret_object": {
+                    "type": "string",
+                    "const": "business"
+                },
                 "secret_array": {
                     "type": "string",
                     "const": "[\"haha\",\"business\",\"also\",\"secret\"]"
@@ -1076,6 +1380,8 @@
             },
             "type": "object",
             "required": [
+                "item_from_secret_array",
+                "item_from_secret_object",
                 "secret_array",
                 "secret_object",
                 "unmarshalled_secret_array",
@@ -1084,12 +1390,16 @@
         }
     },
     "evalJsonRedacted": {
+        "item_from_secret_array": "haha",
+        "item_from_secret_object": "business",
         "secret_array": "[secret]",
         "secret_object": "[secret]",
         "unmarshalled_secret_array": "[secret]",
         "unmarshalled_secret_object": "[secret]"
     },
     "evalJSONRevealed": {
+        "item_from_secret_array": "haha",
+        "item_from_secret_object": "business",
         "secret_array": "[\"haha\",\"business\",\"also\",\"secret\"]",
         "secret_object": "{\"haha\":\"business\",\"also\":\"secret\"}",
         "unmarshalled_secret_array": [

--- a/eval/testdata/eval/secret-objects/expected.json
+++ b/eval/testdata/eval/secret-objects/expected.json
@@ -400,6 +400,7 @@
         "properties": {
             "item_from_secret_array": {
                 "value": "haha",
+                "secret": true,
                 "trace": {
                     "def": {
                         "environment": "secret-objects",
@@ -418,6 +419,7 @@
             },
             "item_from_secret_object": {
                 "value": "business",
+                "secret": true,
                 "trace": {
                     "def": {
                         "environment": "secret-objects",
@@ -476,6 +478,7 @@
                 "value": [
                     {
                         "value": "haha",
+                        "secret": true,
                         "trace": {
                             "def": {
                                 "environment": "secret-objects",
@@ -494,6 +497,7 @@
                     },
                     {
                         "value": "business",
+                        "secret": true,
                         "trace": {
                             "def": {
                                 "environment": "secret-objects",
@@ -512,6 +516,7 @@
                     },
                     {
                         "value": "also",
+                        "secret": true,
                         "trace": {
                             "def": {
                                 "environment": "secret-objects",
@@ -530,6 +535,7 @@
                     },
                     {
                         "value": "secret",
+                        "secret": true,
                         "trace": {
                             "def": {
                                 "environment": "secret-objects",
@@ -568,6 +574,7 @@
                 "value": {
                     "also": {
                         "value": "secret",
+                        "secret": true,
                         "trace": {
                             "def": {
                                 "environment": "secret-objects",
@@ -586,6 +593,7 @@
                     },
                     "haha": {
                         "value": "business",
+                        "secret": true,
                         "trace": {
                             "def": {
                                 "environment": "secret-objects",
@@ -691,8 +699,8 @@
         }
     },
     "checkJson": {
-        "item_from_secret_array": "haha",
-        "item_from_secret_object": "business",
+        "item_from_secret_array": "[secret]",
+        "item_from_secret_object": "[secret]",
         "secret_array": "[secret]",
         "secret_object": "[secret]",
         "unmarshalled_secret_array": "[secret]",
@@ -1099,6 +1107,7 @@
         "properties": {
             "item_from_secret_array": {
                 "value": "haha",
+                "secret": true,
                 "trace": {
                     "def": {
                         "environment": "secret-objects",
@@ -1117,6 +1126,7 @@
             },
             "item_from_secret_object": {
                 "value": "business",
+                "secret": true,
                 "trace": {
                     "def": {
                         "environment": "secret-objects",
@@ -1175,6 +1185,7 @@
                 "value": [
                     {
                         "value": "haha",
+                        "secret": true,
                         "trace": {
                             "def": {
                                 "environment": "secret-objects",
@@ -1193,6 +1204,7 @@
                     },
                     {
                         "value": "business",
+                        "secret": true,
                         "trace": {
                             "def": {
                                 "environment": "secret-objects",
@@ -1211,6 +1223,7 @@
                     },
                     {
                         "value": "also",
+                        "secret": true,
                         "trace": {
                             "def": {
                                 "environment": "secret-objects",
@@ -1229,6 +1242,7 @@
                     },
                     {
                         "value": "secret",
+                        "secret": true,
                         "trace": {
                             "def": {
                                 "environment": "secret-objects",
@@ -1267,6 +1281,7 @@
                 "value": {
                     "also": {
                         "value": "secret",
+                        "secret": true,
                         "trace": {
                             "def": {
                                 "environment": "secret-objects",
@@ -1285,6 +1300,7 @@
                     },
                     "haha": {
                         "value": "business",
+                        "secret": true,
                         "trace": {
                             "def": {
                                 "environment": "secret-objects",
@@ -1390,8 +1406,8 @@
         }
     },
     "evalJsonRedacted": {
-        "item_from_secret_array": "haha",
-        "item_from_secret_object": "business",
+        "item_from_secret_array": "[secret]",
+        "item_from_secret_object": "[secret]",
         "secret_array": "[secret]",
         "secret_object": "[secret]",
         "unmarshalled_secret_array": "[secret]",

--- a/eval/testdata/eval/secret-objects/expected.json
+++ b/eval/testdata/eval/secret-objects/expected.json
@@ -1,0 +1,520 @@
+{
+    "check": {
+        "exprs": {
+            "secret_object": {
+                "range": {
+                    "environment": "secret-objects",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 29
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 52,
+                        "byte": 76
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "{\"haha\":\"business\",\"also\":\"secret\"}"
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 29
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 39
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 3,
+                                "column": 17,
+                                "byte": 41
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 52,
+                                "byte": 76
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "{\"haha\":\"business\",\"also\":\"secret\"}"
+                        },
+                        "literal": "{\"haha\":\"business\",\"also\":\"secret\"}"
+                    }
+                }
+            },
+            "unmarshalled_secret_object": {
+                "range": {
+                    "environment": "secret-objects",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 113
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 35,
+                        "byte": 143
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "also": {
+                            "type": "string",
+                            "const": "secret"
+                        },
+                        "haha": {
+                            "type": "string",
+                            "const": "business"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "also",
+                        "haha"
+                    ]
+                },
+                "builtin": {
+                    "name": "fn::fromJSON",
+                    "nameRange": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 113
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 17,
+                            "byte": 125
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 5,
+                                "column": 19,
+                                "byte": 127
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 35,
+                                "byte": 143
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "{\"haha\":\"business\",\"also\":\"secret\"}"
+                        },
+                        "symbol": [
+                            {
+                                "key": "secret_object",
+                                "value": {
+                                    "environment": "secret-objects",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 5,
+                                        "byte": 29
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 52,
+                                        "byte": 76
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "properties": {
+            "secret_object": {
+                "value": "{\"haha\":\"business\",\"also\":\"secret\"}",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 3,
+                            "column": 17,
+                            "byte": 41
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 52,
+                            "byte": 76
+                        }
+                    }
+                }
+            },
+            "unmarshalled_secret_object": {
+                "value": {
+                    "also": {
+                        "value": "secret",
+                        "trace": {
+                            "def": {
+                                "environment": "secret-objects",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 5,
+                                    "byte": 113
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 35,
+                                    "byte": 143
+                                }
+                            }
+                        }
+                    },
+                    "haha": {
+                        "value": "business",
+                        "trace": {
+                            "def": {
+                                "environment": "secret-objects",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 5,
+                                    "byte": 113
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 35,
+                                    "byte": 143
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 113
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 35,
+                            "byte": 143
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "secret_object": {
+                    "type": "string",
+                    "const": "{\"haha\":\"business\",\"also\":\"secret\"}"
+                },
+                "unmarshalled_secret_object": {
+                    "properties": {
+                        "also": {
+                            "type": "string",
+                            "const": "secret"
+                        },
+                        "haha": {
+                            "type": "string",
+                            "const": "business"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "also",
+                        "haha"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "secret_object",
+                "unmarshalled_secret_object"
+            ]
+        }
+    },
+    "checkJson": {
+        "secret_object": "[secret]",
+        "unmarshalled_secret_object": {
+            "also": "secret",
+            "haha": "business"
+        }
+    },
+    "eval": {
+        "exprs": {
+            "secret_object": {
+                "range": {
+                    "environment": "secret-objects",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 29
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 52,
+                        "byte": 76
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "{\"haha\":\"business\",\"also\":\"secret\"}"
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 29
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 39
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 3,
+                                "column": 17,
+                                "byte": 41
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 52,
+                                "byte": 76
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "{\"haha\":\"business\",\"also\":\"secret\"}"
+                        },
+                        "literal": "{\"haha\":\"business\",\"also\":\"secret\"}"
+                    }
+                }
+            },
+            "unmarshalled_secret_object": {
+                "range": {
+                    "environment": "secret-objects",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 113
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 35,
+                        "byte": 143
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "also": {
+                            "type": "string",
+                            "const": "secret"
+                        },
+                        "haha": {
+                            "type": "string",
+                            "const": "business"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "also",
+                        "haha"
+                    ]
+                },
+                "builtin": {
+                    "name": "fn::fromJSON",
+                    "nameRange": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 113
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 17,
+                            "byte": 125
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 5,
+                                "column": 19,
+                                "byte": 127
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 35,
+                                "byte": 143
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "{\"haha\":\"business\",\"also\":\"secret\"}"
+                        },
+                        "symbol": [
+                            {
+                                "key": "secret_object",
+                                "value": {
+                                    "environment": "secret-objects",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 5,
+                                        "byte": 29
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 52,
+                                        "byte": 76
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "properties": {
+            "secret_object": {
+                "value": "{\"haha\":\"business\",\"also\":\"secret\"}",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 3,
+                            "column": 17,
+                            "byte": 41
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 52,
+                            "byte": 76
+                        }
+                    }
+                }
+            },
+            "unmarshalled_secret_object": {
+                "value": {
+                    "also": {
+                        "value": "secret",
+                        "trace": {
+                            "def": {
+                                "environment": "secret-objects",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 5,
+                                    "byte": 113
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 35,
+                                    "byte": 143
+                                }
+                            }
+                        }
+                    },
+                    "haha": {
+                        "value": "business",
+                        "trace": {
+                            "def": {
+                                "environment": "secret-objects",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 5,
+                                    "byte": 113
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 35,
+                                    "byte": 143
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "secret-objects",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 113
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 35,
+                            "byte": 143
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "secret_object": {
+                    "type": "string",
+                    "const": "{\"haha\":\"business\",\"also\":\"secret\"}"
+                },
+                "unmarshalled_secret_object": {
+                    "properties": {
+                        "also": {
+                            "type": "string",
+                            "const": "secret"
+                        },
+                        "haha": {
+                            "type": "string",
+                            "const": "business"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "also",
+                        "haha"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "secret_object",
+                "unmarshalled_secret_object"
+            ]
+        }
+    },
+    "evalJson": {
+        "secret_object": "[secret]",
+        "unmarshalled_secret_object": {
+            "also": "secret",
+            "haha": "business"
+        }
+    }
+}

--- a/eval/testdata/eval/unicode/expected.json
+++ b/eval/testdata/eval/unicode/expected.json
@@ -718,7 +718,18 @@
             ]
         }
     },
-    "evalJson": {
+    "evalJsonRedacted": {
+        "danmark": {
+            "hovedstad": "københavn"
+        },
+        "hello": "世界",
+        "linear-b": [
+            "𐀀",
+            "𐀁"
+        ],
+        "世界": "hello"
+    },
+    "evalJSONRevealed": {
         "danmark": {
             "hovedstad": "københavn"
         },


### PR DESCRIPTION
The first commit demonstrates the issue, secret objects (and arrays) were not being marked as secret when evaluating fromJSON.