### PR TITLE
Add support for yaml output format

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,3 +4,4 @@
 
 * Fix a nil pointer dereference in Syntax.NodeError. [#180](https://github.com/pulumi/esc/pull/180)
 * Mark nested structures as secret if the JSON string is secret. [#191](https://github.com/pulumi/esc/pull/191)
+* Add support for yaml format as output from esc open [#195](https://github.com/pulumi/esc/issues/195)

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pulumi/esc/cmd/esc/cli/client"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
@@ -51,7 +52,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 			}
 
 			switch format {
-			case "detailed", "json", "string":
+			case "detailed", "json", "yaml", "string":
 				// OK
 			case "dotenv", "shell":
 				if len(path) != 0 {
@@ -78,7 +79,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 		"the lifetime of the opened environment in the form HhMm (e.g. 2h, 1h30m, 15m)")
 	cmd.Flags().StringVarP(
 		&format, "format", "f", "json",
-		"the output format to use. May be 'dotenv', 'json', 'detailed', or 'shell'")
+		"the output format to use. May be 'dotenv', 'json', 'yaml', 'detailed', or 'shell'")
 
 	return cmd
 }
@@ -109,6 +110,11 @@ func (env *envCommand) renderValue(
 		body := val.ToJSON(!showSecrets)
 		enc := json.NewEncoder(out)
 		enc.SetIndent("", "  ")
+		return enc.Encode(body)
+	case "yaml":
+		body := val.ToJSON(!showSecrets)
+		enc := yaml.NewEncoder(out)
+		enc.SetIndent(3)
 		return enc.Encode(body)
 	case "detailed":
 		enc := json.NewEncoder(out)

--- a/cmd/esc/cli/testdata/open-yaml.yaml
+++ b/cmd/esc/cli/testdata/open-yaml.yaml
@@ -1,0 +1,17 @@
+run: esc open test --format yaml
+environments:
+  test-user/test:
+    imports:
+      - test-2
+    values:
+      foo: bar
+  test-user/test-2:
+    values:
+      foo: baz
+      hello: world
+stdout: |
+  > esc open test --format yaml
+  foo: bar
+  hello: world
+stderr: |
+  > esc open test --format yaml


### PR DESCRIPTION
Adds support for yaml format in `esc open`. 

Added test to verify.

Fixes [#195](https://github.com/pulumi/esc/issues/195).