### PR TITLE
chore: CHANGELOG for v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 CHANGELOG
 =========
 
+## 0.6.2
+
+### Bug Fixes
+
+- Add support for yaml format as output from `esc open`.
+  [#204](https://github.com/pulumi/esc/pull/204)
+
+## 0.6.1
+
+### Bug Fixes
+
+- Fix a nil pointer dereference in Syntax.NodeError.
+  [#180](https://github.com/pulumi/esc/pull/180)
+
+- Mark nested structures as secret if the JSON string is secret.
+  [#191](https://github.com/pulumi/esc/pull/191)
+
 ## 0.6.0
 
 ### Improvements

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,6 +2,3 @@
 
 ### Bug Fixes
 
-* Fix a nil pointer dereference in Syntax.NodeError. [#180](https://github.com/pulumi/esc/pull/180)
-* Mark nested structures as secret if the JSON string is secret. [#191](https://github.com/pulumi/esc/pull/191)
-* Add support for yaml format as output from esc open [#195](https://github.com/pulumi/esc/issues/195)


### PR DESCRIPTION
Also fill-in CHANGELOG for v0.6.1.

We need another release of `esc` so we can depend on it from `pulumi/pulumi`.