### PR TITLE
eval: fix merging of merged values

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,3 +2,5 @@
 
 ### Bug Fixes
 
+- Fix merging of already-merged values.
+  [#213](https://github.com/pulumi/esc/pull/213)

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -317,6 +317,7 @@ func (e *evalContext) evaluate() (*value, syntax.Diagnostics) {
 	// root.
 	properties := make(map[string]*expr, len(e.env.Values.GetEntries()))
 	e.root = &expr{
+		path: fmt.Sprintf("<%v>", e.name),
 		repr: &objectExpr{
 			node:       ast.Object(),
 			properties: properties,
@@ -414,7 +415,7 @@ func (e *evalContext) evaluateImport(myImports map[string]*value, decl *ast.Impo
 
 	myImports[name] = val
 	if merge {
-		val = val.copy()
+		val = newCopier().copy(val)
 		val.merge(e.base)
 		e.base = val
 	}
@@ -566,7 +567,7 @@ func (e *evalContext) evaluateInterpolate(x *expr, repr *interpolateExpr) *value
 func (e *evalContext) evaluatePropertyAccess(x *expr, accessors []*propertyAccessor) *value {
 	// We make a copy of the resolved value here because evaluateExpr will merge it with its base, which mutates the
 	// value. We also stamp over the def with the provided expression in order to maintain proper error reporting.
-	v := e.evaluateExprAccess(x, accessors).copy()
+	v := newCopier().copy(e.evaluateExprAccess(x, accessors))
 	v.def = x
 	return v
 }

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -276,11 +276,19 @@ func TestEval(t *testing.T) {
 				assert.Equal(t, expected.EvalJSONRedacted, evalJSONRedacted)
 				evalJSONRevealed := esc.NewValue(actual.Properties).ToJSON(false)
 				assert.Equal(t, expected.EvalJSONRevealed, evalJSONRevealed)
+
+				bytes, err := json.MarshalIndent(evalJSONRevealed, "", "  ")
+				require.NoError(t, err)
+				t.Logf("eval: %v", string(bytes))
 			}
 
 			if check != nil {
 				checkJSON := esc.NewValue(check.Properties).ToJSON(true)
 				assert.Equal(t, expected.CheckJSON, checkJSON)
+
+				bytes, err := json.MarshalIndent(checkJSON, "", "  ")
+				require.NoError(t, err)
+				t.Logf("check: %v", string(bytes))
 			}
 
 			assert.Equal(t, expected.Check, check)

--- a/eval/testdata/eval/import-merge-2/a.yaml
+++ b/eval/testdata/eval/import-merge-2/a.yaml
@@ -1,0 +1,3 @@
+values:
+  some_object:
+    foo: bar

--- a/eval/testdata/eval/import-merge-2/b.yaml
+++ b/eval/testdata/eval/import-merge-2/b.yaml
@@ -1,0 +1,5 @@
+values:
+  alpha: beta
+  some_object:
+    fn::open::test:
+      beta: gamma

--- a/eval/testdata/eval/import-merge-2/c.yaml
+++ b/eval/testdata/eval/import-merge-2/c.yaml
@@ -1,0 +1,5 @@
+imports:
+  - b
+values:
+  some_object:
+    baz: qux

--- a/eval/testdata/eval/import-merge-2/env.yaml
+++ b/eval/testdata/eval/import-merge-2/env.yaml
@@ -1,0 +1,3 @@
+imports:
+  - a
+  - c

--- a/eval/testdata/eval/import-merge-2/expected.json
+++ b/eval/testdata/eval/import-merge-2/expected.json
@@ -1,0 +1,367 @@
+{
+    "check": {
+        "properties": {
+            "alpha": {
+                "value": "beta",
+                "trace": {
+                    "def": {
+                        "environment": "b",
+                        "begin": {
+                            "line": 2,
+                            "column": 10,
+                            "byte": 17
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 14,
+                            "byte": 21
+                        }
+                    }
+                }
+            },
+            "some_object": {
+                "value": {
+                    "baz": {
+                        "value": "qux",
+                        "trace": {
+                            "def": {
+                                "environment": "c",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 10,
+                                    "byte": 47
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 13,
+                                    "byte": 50
+                                }
+                            },
+                            "base": {
+                                "unknown": true,
+                                "trace": {
+                                    "def": {
+                                        "environment": "c",
+                                        "begin": {
+                                            "line": 5,
+                                            "column": 5,
+                                            "byte": 42
+                                        },
+                                        "end": {
+                                            "line": 5,
+                                            "column": 8,
+                                            "byte": 45
+                                        }
+                                    },
+                                    "base": {
+                                        "unknown": true,
+                                        "trace": {
+                                            "def": {
+                                                "environment": "c",
+                                                "begin": {
+                                                    "line": 5,
+                                                    "column": 10,
+                                                    "byte": 47
+                                                },
+                                                "end": {
+                                                    "line": 5,
+                                                    "column": 13,
+                                                    "byte": 50
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "c",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 42
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 13,
+                            "byte": 50
+                        }
+                    },
+                    "base": {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "b",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 5,
+                                    "byte": 41
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 18,
+                                    "byte": 74
+                                }
+                            },
+                            "base": {
+                                "value": {
+                                    "foo": {
+                                        "value": "bar",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "a",
+                                                "begin": {
+                                                    "line": 3,
+                                                    "column": 10,
+                                                    "byte": 32
+                                                },
+                                                "end": {
+                                                    "line": 3,
+                                                    "column": 13,
+                                                    "byte": 35
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 5,
+                                            "byte": 27
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 13,
+                                            "byte": 35
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "type": "object"
+        }
+    },
+    "checkJson": {
+        "alpha": "beta",
+        "some_object": {
+            "baz": "qux"
+        }
+    },
+    "eval": {
+        "properties": {
+            "alpha": {
+                "value": "beta",
+                "trace": {
+                    "def": {
+                        "environment": "b",
+                        "begin": {
+                            "line": 2,
+                            "column": 10,
+                            "byte": 17
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 14,
+                            "byte": 21
+                        }
+                    }
+                }
+            },
+            "some_object": {
+                "value": {
+                    "baz": {
+                        "value": "qux",
+                        "trace": {
+                            "def": {
+                                "environment": "c",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 10,
+                                    "byte": 47
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 13,
+                                    "byte": 50
+                                }
+                            }
+                        }
+                    },
+                    "beta": {
+                        "value": "gamma",
+                        "trace": {
+                            "def": {
+                                "environment": "b",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 5,
+                                    "byte": 41
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 18,
+                                    "byte": 74
+                                }
+                            }
+                        }
+                    },
+                    "foo": {
+                        "value": "bar",
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 10,
+                                    "byte": 32
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 13,
+                                    "byte": 35
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "c",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 42
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 13,
+                            "byte": 50
+                        }
+                    },
+                    "base": {
+                        "value": {
+                            "beta": {
+                                "value": "gamma",
+                                "trace": {
+                                    "def": {
+                                        "environment": "b",
+                                        "begin": {
+                                            "line": 4,
+                                            "column": 5,
+                                            "byte": 41
+                                        },
+                                        "end": {
+                                            "line": 5,
+                                            "column": 18,
+                                            "byte": 74
+                                        }
+                                    }
+                                }
+                            },
+                            "foo": {
+                                "value": "bar",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 10,
+                                            "byte": 32
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 13,
+                                            "byte": 35
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "b",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 5,
+                                    "byte": 41
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 18,
+                                    "byte": 74
+                                }
+                            },
+                            "base": {
+                                "value": {
+                                    "foo": {
+                                        "value": "bar",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "a",
+                                                "begin": {
+                                                    "line": 3,
+                                                    "column": 10,
+                                                    "byte": 32
+                                                },
+                                                "end": {
+                                                    "line": 3,
+                                                    "column": 13,
+                                                    "byte": 35
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 5,
+                                            "byte": 27
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 13,
+                                            "byte": 35
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "type": "object"
+        }
+    },
+    "evalJsonRedacted": {
+        "alpha": "beta",
+        "some_object": {
+            "baz": "qux",
+            "beta": "gamma",
+            "foo": "bar"
+        }
+    },
+    "evalJSONRevealed": {
+        "alpha": "beta",
+        "some_object": {
+            "baz": "qux",
+            "beta": "gamma",
+            "foo": "bar"
+        }
+    }
+}

--- a/eval/testdata/eval/import-merge/a.yaml
+++ b/eval/testdata/eval/import-merge/a.yaml
@@ -1,0 +1,3 @@
+values:
+  some_object:
+    foo: bar

--- a/eval/testdata/eval/import-merge/b.yaml
+++ b/eval/testdata/eval/import-merge/b.yaml
@@ -1,0 +1,2 @@
+values:
+  alpha: beta

--- a/eval/testdata/eval/import-merge/c.yaml
+++ b/eval/testdata/eval/import-merge/c.yaml
@@ -1,0 +1,5 @@
+imports:
+  - b
+values:
+  some_object:
+    baz: qux

--- a/eval/testdata/eval/import-merge/env.yaml
+++ b/eval/testdata/eval/import-merge/env.yaml
@@ -1,0 +1,3 @@
+imports:
+  - a
+  - c

--- a/eval/testdata/eval/import-merge/expected.json
+++ b/eval/testdata/eval/import-merge/expected.json
@@ -38,6 +38,24 @@
                                 }
                             }
                         }
+                    },
+                    "foo": {
+                        "value": "bar",
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 10,
+                                    "byte": 32
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 13,
+                                    "byte": 35
+                                }
+                            }
+                        }
                     }
                 },
                 "trace": {
@@ -53,6 +71,43 @@
                             "column": 13,
                             "byte": 50
                         }
+                    },
+                    "base": {
+                        "value": {
+                            "foo": {
+                                "value": "bar",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 10,
+                                            "byte": 32
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 13,
+                                            "byte": 35
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 27
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 13,
+                                    "byte": 35
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -64,7 +119,8 @@
     "checkJson": {
         "alpha": "beta",
         "some_object": {
-            "baz": "qux"
+            "baz": "qux",
+            "foo": "bar"
         }
     },
     "eval": {
@@ -106,6 +162,24 @@
                                 }
                             }
                         }
+                    },
+                    "foo": {
+                        "value": "bar",
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 10,
+                                    "byte": 32
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 13,
+                                    "byte": 35
+                                }
+                            }
+                        }
                     }
                 },
                 "trace": {
@@ -121,6 +195,43 @@
                             "column": 13,
                             "byte": 50
                         }
+                    },
+                    "base": {
+                        "value": {
+                            "foo": {
+                                "value": "bar",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 10,
+                                            "byte": 32
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 13,
+                                            "byte": 35
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 27
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 13,
+                                    "byte": 35
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -132,13 +243,15 @@
     "evalJsonRedacted": {
         "alpha": "beta",
         "some_object": {
-            "baz": "qux"
+            "baz": "qux",
+            "foo": "bar"
         }
     },
     "evalJSONRevealed": {
         "alpha": "beta",
         "some_object": {
-            "baz": "qux"
+            "baz": "qux",
+            "foo": "bar"
         }
     }
 }

--- a/eval/testdata/eval/import-merge/expected.json
+++ b/eval/testdata/eval/import-merge/expected.json
@@ -1,0 +1,144 @@
+{
+    "check": {
+        "properties": {
+            "alpha": {
+                "value": "beta",
+                "trace": {
+                    "def": {
+                        "environment": "b",
+                        "begin": {
+                            "line": 2,
+                            "column": 10,
+                            "byte": 17
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 14,
+                            "byte": 21
+                        }
+                    }
+                }
+            },
+            "some_object": {
+                "value": {
+                    "baz": {
+                        "value": "qux",
+                        "trace": {
+                            "def": {
+                                "environment": "c",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 10,
+                                    "byte": 47
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 13,
+                                    "byte": 50
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "c",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 42
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 13,
+                            "byte": 50
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "type": "object"
+        }
+    },
+    "checkJson": {
+        "alpha": "beta",
+        "some_object": {
+            "baz": "qux"
+        }
+    },
+    "eval": {
+        "properties": {
+            "alpha": {
+                "value": "beta",
+                "trace": {
+                    "def": {
+                        "environment": "b",
+                        "begin": {
+                            "line": 2,
+                            "column": 10,
+                            "byte": 17
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 14,
+                            "byte": 21
+                        }
+                    }
+                }
+            },
+            "some_object": {
+                "value": {
+                    "baz": {
+                        "value": "qux",
+                        "trace": {
+                            "def": {
+                                "environment": "c",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 10,
+                                    "byte": 47
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 13,
+                                    "byte": 50
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "c",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 42
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 13,
+                            "byte": 50
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "type": "object"
+        }
+    },
+    "evalJsonRedacted": {
+        "alpha": "beta",
+        "some_object": {
+            "baz": "qux"
+        }
+    },
+    "evalJSONRevealed": {
+        "alpha": "beta",
+        "some_object": {
+            "baz": "qux"
+        }
+    }
+}

--- a/eval/testdata/eval/imports/expected.json
+++ b/eval/testdata/eval/imports/expected.json
@@ -729,6 +729,24 @@
                                             "column": 17,
                                             "byte": 42
                                         }
+                                    },
+                                    "base": {
+                                        "value": "foo",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "a",
+                                                "begin": {
+                                                    "line": 3,
+                                                    "column": 14,
+                                                    "byte": 39
+                                                },
+                                                "end": {
+                                                    "line": 3,
+                                                    "column": 17,
+                                                    "byte": 42
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -1842,6 +1860,24 @@
                                             "line": 3,
                                             "column": 17,
                                             "byte": 42
+                                        }
+                                    },
+                                    "base": {
+                                        "value": "foo",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "a",
+                                                "begin": {
+                                                    "line": 3,
+                                                    "column": 14,
+                                                    "byte": 39
+                                                },
+                                                "end": {
+                                                    "line": 3,
+                                                    "column": 17,
+                                                    "byte": 42
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/eval/testdata/eval/merge-base/a.yaml
+++ b/eval/testdata/eval/merge-base/a.yaml
@@ -1,0 +1,8 @@
+values:
+  some_object:
+    foo: bar
+    baz: zab
+  other_object:
+    baz: qux
+    nested:
+      epsilon: delta

--- a/eval/testdata/eval/merge-base/env.yaml
+++ b/eval/testdata/eval/merge-base/env.yaml
@@ -1,0 +1,40 @@
+# This test validates that merge behavior works properly for property access expressions.
+#
+# In the environment below, the value of some_object should the value from this env merged with
+# the value from a, and the value of other_object should be the value of some_object merged with
+# other_object from a. Merging other_object should not affect the value of some_object.
+#
+# In concrete terms, we expect the environment to evaluate to:
+#
+# {
+#   "other_object": {
+#     "alpha": "beta",
+#     "baz": "zab",
+#     "foo": "baz",
+#     "nested": {
+#       "epsilon": "delta",
+#       "zed": "dez"
+#     }
+#   },
+#   "some_object": {
+#     "alpha": "beta",
+#     "baz": "zab",
+#     "foo": "baz",
+#     "nested": {
+#       "zed": "dez"
+#     }
+#   }
+# } 
+#
+# A buggy merge implementation might evaluate the environment such that the value of some_object is
+# identical to that of other_object.
+
+imports:
+  - a
+values:
+  some_object:
+    foo: baz
+    alpha: beta
+    nested:
+      zed: dez
+  other_object: ${some_object}

--- a/eval/testdata/eval/merge-base/expected.json
+++ b/eval/testdata/eval/merge-base/expected.json
@@ -1,0 +1,2467 @@
+{
+    "check": {
+        "exprs": {
+            "other_object": {
+                "range": {
+                    "environment": "merge-base",
+                    "begin": {
+                        "line": 40,
+                        "column": 17,
+                        "byte": 1003
+                    },
+                    "end": {
+                        "line": 40,
+                        "column": 31,
+                        "byte": 1017
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "alpha": {
+                            "type": "string",
+                            "const": "beta"
+                        },
+                        "baz": {
+                            "type": "string",
+                            "const": "zab"
+                        },
+                        "foo": {
+                            "type": "string",
+                            "const": "baz"
+                        },
+                        "nested": {
+                            "properties": {
+                                "epsilon": {
+                                    "type": "string",
+                                    "const": "delta"
+                                },
+                                "zed": {
+                                    "type": "string",
+                                    "const": "dez"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "epsilon",
+                                "zed"
+                            ]
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "alpha",
+                        "baz",
+                        "foo",
+                        "nested"
+                    ]
+                },
+                "base": {
+                    "range": {
+                        "environment": "a",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 69
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 21,
+                            "byte": 110
+                        }
+                    },
+                    "schema": {
+                        "properties": {
+                            "baz": {
+                                "type": "string",
+                                "const": "qux"
+                            },
+                            "nested": {
+                                "properties": {
+                                    "epsilon": {
+                                        "type": "string",
+                                        "const": "delta"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "epsilon"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "baz",
+                            "nested"
+                        ]
+                    },
+                    "keyRanges": {
+                        "baz": {
+                            "environment": "a",
+                            "begin": {
+                                "line": 6,
+                                "column": 5,
+                                "byte": 69
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 8,
+                                "byte": 72
+                            }
+                        },
+                        "nested": {
+                            "environment": "a",
+                            "begin": {
+                                "line": 7,
+                                "column": 5,
+                                "byte": 82
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 11,
+                                "byte": 88
+                            }
+                        }
+                    },
+                    "object": {
+                        "baz": {
+                            "range": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 10,
+                                    "byte": 74
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 13,
+                                    "byte": 77
+                                }
+                            },
+                            "schema": {
+                                "type": "string",
+                                "const": "qux"
+                            },
+                            "literal": "qux"
+                        },
+                        "nested": {
+                            "range": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 7,
+                                    "byte": 96
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 21,
+                                    "byte": 110
+                                }
+                            },
+                            "schema": {
+                                "properties": {
+                                    "epsilon": {
+                                        "type": "string",
+                                        "const": "delta"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "epsilon"
+                                ]
+                            },
+                            "keyRanges": {
+                                "epsilon": {
+                                    "environment": "a",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 7,
+                                        "byte": 96
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 14,
+                                        "byte": 103
+                                    }
+                                }
+                            },
+                            "object": {
+                                "epsilon": {
+                                    "range": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 8,
+                                            "column": 16,
+                                            "byte": 105
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 21,
+                                            "byte": 110
+                                        }
+                                    },
+                                    "schema": {
+                                        "type": "string",
+                                        "const": "delta"
+                                    },
+                                    "literal": "delta"
+                                }
+                            }
+                        }
+                    }
+                },
+                "symbol": [
+                    {
+                        "key": "some_object",
+                        "value": {
+                            "environment": "merge-base",
+                            "begin": {
+                                "line": 36,
+                                "column": 5,
+                                "byte": 935
+                            },
+                            "end": {
+                                "line": 39,
+                                "column": 15,
+                                "byte": 986
+                            }
+                        }
+                    }
+                ]
+            },
+            "some_object": {
+                "range": {
+                    "environment": "merge-base",
+                    "begin": {
+                        "line": 36,
+                        "column": 5,
+                        "byte": 935
+                    },
+                    "end": {
+                        "line": 39,
+                        "column": 15,
+                        "byte": 986
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "alpha": {
+                            "type": "string",
+                            "const": "beta"
+                        },
+                        "baz": {
+                            "type": "string",
+                            "const": "zab"
+                        },
+                        "foo": {
+                            "type": "string",
+                            "const": "baz"
+                        },
+                        "nested": {
+                            "properties": {
+                                "zed": {
+                                    "type": "string",
+                                    "const": "dez"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "zed"
+                            ]
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "alpha",
+                        "baz",
+                        "foo",
+                        "nested"
+                    ]
+                },
+                "base": {
+                    "range": {
+                        "environment": "a",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 27
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 13,
+                            "byte": 48
+                        }
+                    },
+                    "schema": {
+                        "properties": {
+                            "baz": {
+                                "type": "string",
+                                "const": "zab"
+                            },
+                            "foo": {
+                                "type": "string",
+                                "const": "bar"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "baz",
+                            "foo"
+                        ]
+                    },
+                    "keyRanges": {
+                        "baz": {
+                            "environment": "a",
+                            "begin": {
+                                "line": 4,
+                                "column": 5,
+                                "byte": 40
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 8,
+                                "byte": 43
+                            }
+                        },
+                        "foo": {
+                            "environment": "a",
+                            "begin": {
+                                "line": 3,
+                                "column": 5,
+                                "byte": 27
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 8,
+                                "byte": 30
+                            }
+                        }
+                    },
+                    "object": {
+                        "baz": {
+                            "range": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 10,
+                                    "byte": 45
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 13,
+                                    "byte": 48
+                                }
+                            },
+                            "schema": {
+                                "type": "string",
+                                "const": "zab"
+                            },
+                            "literal": "zab"
+                        },
+                        "foo": {
+                            "range": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 10,
+                                    "byte": 32
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 13,
+                                    "byte": 35
+                                }
+                            },
+                            "schema": {
+                                "type": "string",
+                                "const": "bar"
+                            },
+                            "literal": "bar"
+                        }
+                    }
+                },
+                "keyRanges": {
+                    "alpha": {
+                        "environment": "merge-base",
+                        "begin": {
+                            "line": 37,
+                            "column": 5,
+                            "byte": 948
+                        },
+                        "end": {
+                            "line": 37,
+                            "column": 10,
+                            "byte": 953
+                        }
+                    },
+                    "foo": {
+                        "environment": "merge-base",
+                        "begin": {
+                            "line": 36,
+                            "column": 5,
+                            "byte": 935
+                        },
+                        "end": {
+                            "line": 36,
+                            "column": 8,
+                            "byte": 938
+                        }
+                    },
+                    "nested": {
+                        "environment": "merge-base",
+                        "begin": {
+                            "line": 38,
+                            "column": 5,
+                            "byte": 964
+                        },
+                        "end": {
+                            "line": 38,
+                            "column": 11,
+                            "byte": 970
+                        }
+                    }
+                },
+                "object": {
+                    "alpha": {
+                        "range": {
+                            "environment": "merge-base",
+                            "begin": {
+                                "line": 37,
+                                "column": 12,
+                                "byte": 955
+                            },
+                            "end": {
+                                "line": 37,
+                                "column": 16,
+                                "byte": 959
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "beta"
+                        },
+                        "literal": "beta"
+                    },
+                    "foo": {
+                        "range": {
+                            "environment": "merge-base",
+                            "begin": {
+                                "line": 36,
+                                "column": 10,
+                                "byte": 940
+                            },
+                            "end": {
+                                "line": 36,
+                                "column": 13,
+                                "byte": 943
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "baz"
+                        },
+                        "base": {
+                            "range": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 10,
+                                    "byte": 32
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 13,
+                                    "byte": 35
+                                }
+                            },
+                            "schema": {
+                                "type": "string",
+                                "const": "bar"
+                            },
+                            "literal": "bar"
+                        },
+                        "literal": "baz"
+                    },
+                    "nested": {
+                        "range": {
+                            "environment": "merge-base",
+                            "begin": {
+                                "line": 39,
+                                "column": 7,
+                                "byte": 978
+                            },
+                            "end": {
+                                "line": 39,
+                                "column": 15,
+                                "byte": 986
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "zed": {
+                                    "type": "string",
+                                    "const": "dez"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "zed"
+                            ]
+                        },
+                        "keyRanges": {
+                            "zed": {
+                                "environment": "merge-base",
+                                "begin": {
+                                    "line": 39,
+                                    "column": 7,
+                                    "byte": 978
+                                },
+                                "end": {
+                                    "line": 39,
+                                    "column": 10,
+                                    "byte": 981
+                                }
+                            }
+                        },
+                        "object": {
+                            "zed": {
+                                "range": {
+                                    "environment": "merge-base",
+                                    "begin": {
+                                        "line": 39,
+                                        "column": 12,
+                                        "byte": 983
+                                    },
+                                    "end": {
+                                        "line": 39,
+                                        "column": 15,
+                                        "byte": 986
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "dez"
+                                },
+                                "literal": "dez"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "other_object": {
+                "value": {
+                    "alpha": {
+                        "value": "beta",
+                        "trace": {
+                            "def": {
+                                "environment": "merge-base",
+                                "begin": {
+                                    "line": 37,
+                                    "column": 12,
+                                    "byte": 955
+                                },
+                                "end": {
+                                    "line": 37,
+                                    "column": 16,
+                                    "byte": 959
+                                }
+                            }
+                        }
+                    },
+                    "baz": {
+                        "value": "zab",
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 10,
+                                    "byte": 45
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 13,
+                                    "byte": 48
+                                }
+                            },
+                            "base": {
+                                "value": "qux",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 6,
+                                            "column": 10,
+                                            "byte": 74
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 13,
+                                            "byte": 77
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "foo": {
+                        "value": "baz",
+                        "trace": {
+                            "def": {
+                                "environment": "merge-base",
+                                "begin": {
+                                    "line": 36,
+                                    "column": 10,
+                                    "byte": 940
+                                },
+                                "end": {
+                                    "line": 36,
+                                    "column": 13,
+                                    "byte": 943
+                                }
+                            },
+                            "base": {
+                                "value": "bar",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 10,
+                                            "byte": 32
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 13,
+                                            "byte": 35
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "nested": {
+                        "value": {
+                            "epsilon": {
+                                "value": "delta",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 8,
+                                            "column": 16,
+                                            "byte": 105
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 21,
+                                            "byte": 110
+                                        }
+                                    }
+                                }
+                            },
+                            "zed": {
+                                "value": "dez",
+                                "trace": {
+                                    "def": {
+                                        "environment": "merge-base",
+                                        "begin": {
+                                            "line": 39,
+                                            "column": 12,
+                                            "byte": 983
+                                        },
+                                        "end": {
+                                            "line": 39,
+                                            "column": 15,
+                                            "byte": 986
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "merge-base",
+                                "begin": {
+                                    "line": 39,
+                                    "column": 7,
+                                    "byte": 978
+                                },
+                                "end": {
+                                    "line": 39,
+                                    "column": 15,
+                                    "byte": 986
+                                }
+                            },
+                            "base": {
+                                "value": {
+                                    "epsilon": {
+                                        "value": "delta",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "a",
+                                                "begin": {
+                                                    "line": 8,
+                                                    "column": 16,
+                                                    "byte": 105
+                                                },
+                                                "end": {
+                                                    "line": 8,
+                                                    "column": 21,
+                                                    "byte": 110
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 8,
+                                            "column": 7,
+                                            "byte": 96
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 21,
+                                            "byte": 110
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "merge-base",
+                        "begin": {
+                            "line": 40,
+                            "column": 17,
+                            "byte": 1003
+                        },
+                        "end": {
+                            "line": 40,
+                            "column": 31,
+                            "byte": 1017
+                        }
+                    },
+                    "base": {
+                        "value": {
+                            "baz": {
+                                "value": "zab",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 4,
+                                            "column": 10,
+                                            "byte": 45
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 13,
+                                            "byte": 48
+                                        }
+                                    },
+                                    "base": {
+                                        "value": "qux",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "a",
+                                                "begin": {
+                                                    "line": 6,
+                                                    "column": 10,
+                                                    "byte": 74
+                                                },
+                                                "end": {
+                                                    "line": 6,
+                                                    "column": 13,
+                                                    "byte": 77
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "foo": {
+                                "value": "bar",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 10,
+                                            "byte": 32
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 13,
+                                            "byte": 35
+                                        }
+                                    }
+                                }
+                            },
+                            "nested": {
+                                "value": {
+                                    "epsilon": {
+                                        "value": "delta",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "a",
+                                                "begin": {
+                                                    "line": 8,
+                                                    "column": 16,
+                                                    "byte": 105
+                                                },
+                                                "end": {
+                                                    "line": 8,
+                                                    "column": 21,
+                                                    "byte": 110
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 8,
+                                            "column": 7,
+                                            "byte": 96
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 21,
+                                            "byte": 110
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 27
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 13,
+                                    "byte": 48
+                                }
+                            },
+                            "base": {
+                                "value": {
+                                    "baz": {
+                                        "value": "qux",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "a",
+                                                "begin": {
+                                                    "line": 6,
+                                                    "column": 10,
+                                                    "byte": 74
+                                                },
+                                                "end": {
+                                                    "line": 6,
+                                                    "column": 13,
+                                                    "byte": 77
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "nested": {
+                                        "value": {
+                                            "epsilon": {
+                                                "value": "delta",
+                                                "trace": {
+                                                    "def": {
+                                                        "environment": "a",
+                                                        "begin": {
+                                                            "line": 8,
+                                                            "column": 16,
+                                                            "byte": 105
+                                                        },
+                                                        "end": {
+                                                            "line": 8,
+                                                            "column": 21,
+                                                            "byte": 110
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "trace": {
+                                            "def": {
+                                                "environment": "a",
+                                                "begin": {
+                                                    "line": 8,
+                                                    "column": 7,
+                                                    "byte": 96
+                                                },
+                                                "end": {
+                                                    "line": 8,
+                                                    "column": 21,
+                                                    "byte": 110
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 6,
+                                            "column": 5,
+                                            "byte": 69
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 21,
+                                            "byte": 110
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "some_object": {
+                "value": {
+                    "alpha": {
+                        "value": "beta",
+                        "trace": {
+                            "def": {
+                                "environment": "merge-base",
+                                "begin": {
+                                    "line": 37,
+                                    "column": 12,
+                                    "byte": 955
+                                },
+                                "end": {
+                                    "line": 37,
+                                    "column": 16,
+                                    "byte": 959
+                                }
+                            }
+                        }
+                    },
+                    "baz": {
+                        "value": "zab",
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 10,
+                                    "byte": 45
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 13,
+                                    "byte": 48
+                                }
+                            }
+                        }
+                    },
+                    "foo": {
+                        "value": "baz",
+                        "trace": {
+                            "def": {
+                                "environment": "merge-base",
+                                "begin": {
+                                    "line": 36,
+                                    "column": 10,
+                                    "byte": 940
+                                },
+                                "end": {
+                                    "line": 36,
+                                    "column": 13,
+                                    "byte": 943
+                                }
+                            },
+                            "base": {
+                                "value": "bar",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 10,
+                                            "byte": 32
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 13,
+                                            "byte": 35
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "nested": {
+                        "value": {
+                            "zed": {
+                                "value": "dez",
+                                "trace": {
+                                    "def": {
+                                        "environment": "merge-base",
+                                        "begin": {
+                                            "line": 39,
+                                            "column": 12,
+                                            "byte": 983
+                                        },
+                                        "end": {
+                                            "line": 39,
+                                            "column": 15,
+                                            "byte": 986
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "merge-base",
+                                "begin": {
+                                    "line": 39,
+                                    "column": 7,
+                                    "byte": 978
+                                },
+                                "end": {
+                                    "line": 39,
+                                    "column": 15,
+                                    "byte": 986
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "merge-base",
+                        "begin": {
+                            "line": 36,
+                            "column": 5,
+                            "byte": 935
+                        },
+                        "end": {
+                            "line": 39,
+                            "column": 15,
+                            "byte": 986
+                        }
+                    },
+                    "base": {
+                        "value": {
+                            "baz": {
+                                "value": "zab",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 4,
+                                            "column": 10,
+                                            "byte": 45
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 13,
+                                            "byte": 48
+                                        }
+                                    }
+                                }
+                            },
+                            "foo": {
+                                "value": "bar",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 10,
+                                            "byte": 32
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 13,
+                                            "byte": 35
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 27
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 13,
+                                    "byte": 48
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "other_object": {
+                    "properties": {
+                        "alpha": {
+                            "type": "string",
+                            "const": "beta"
+                        },
+                        "baz": {
+                            "type": "string",
+                            "const": "zab"
+                        },
+                        "foo": {
+                            "type": "string",
+                            "const": "baz"
+                        },
+                        "nested": {
+                            "properties": {
+                                "epsilon": {
+                                    "type": "string",
+                                    "const": "delta"
+                                },
+                                "zed": {
+                                    "type": "string",
+                                    "const": "dez"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "epsilon",
+                                "zed"
+                            ]
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "alpha",
+                        "baz",
+                        "foo",
+                        "nested"
+                    ]
+                },
+                "some_object": {
+                    "properties": {
+                        "alpha": {
+                            "type": "string",
+                            "const": "beta"
+                        },
+                        "baz": {
+                            "type": "string",
+                            "const": "zab"
+                        },
+                        "foo": {
+                            "type": "string",
+                            "const": "baz"
+                        },
+                        "nested": {
+                            "properties": {
+                                "zed": {
+                                    "type": "string",
+                                    "const": "dez"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "zed"
+                            ]
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "alpha",
+                        "baz",
+                        "foo",
+                        "nested"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "other_object",
+                "some_object"
+            ]
+        }
+    },
+    "checkJson": {
+        "other_object": {
+            "alpha": "beta",
+            "baz": "zab",
+            "foo": "baz",
+            "nested": {
+                "epsilon": "delta",
+                "zed": "dez"
+            }
+        },
+        "some_object": {
+            "alpha": "beta",
+            "baz": "zab",
+            "foo": "baz",
+            "nested": {
+                "zed": "dez"
+            }
+        }
+    },
+    "eval": {
+        "exprs": {
+            "other_object": {
+                "range": {
+                    "environment": "merge-base",
+                    "begin": {
+                        "line": 40,
+                        "column": 17,
+                        "byte": 1003
+                    },
+                    "end": {
+                        "line": 40,
+                        "column": 31,
+                        "byte": 1017
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "alpha": {
+                            "type": "string",
+                            "const": "beta"
+                        },
+                        "baz": {
+                            "type": "string",
+                            "const": "zab"
+                        },
+                        "foo": {
+                            "type": "string",
+                            "const": "baz"
+                        },
+                        "nested": {
+                            "properties": {
+                                "epsilon": {
+                                    "type": "string",
+                                    "const": "delta"
+                                },
+                                "zed": {
+                                    "type": "string",
+                                    "const": "dez"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "epsilon",
+                                "zed"
+                            ]
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "alpha",
+                        "baz",
+                        "foo",
+                        "nested"
+                    ]
+                },
+                "base": {
+                    "range": {
+                        "environment": "a",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 69
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 21,
+                            "byte": 110
+                        }
+                    },
+                    "schema": {
+                        "properties": {
+                            "baz": {
+                                "type": "string",
+                                "const": "qux"
+                            },
+                            "nested": {
+                                "properties": {
+                                    "epsilon": {
+                                        "type": "string",
+                                        "const": "delta"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "epsilon"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "baz",
+                            "nested"
+                        ]
+                    },
+                    "keyRanges": {
+                        "baz": {
+                            "environment": "a",
+                            "begin": {
+                                "line": 6,
+                                "column": 5,
+                                "byte": 69
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 8,
+                                "byte": 72
+                            }
+                        },
+                        "nested": {
+                            "environment": "a",
+                            "begin": {
+                                "line": 7,
+                                "column": 5,
+                                "byte": 82
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 11,
+                                "byte": 88
+                            }
+                        }
+                    },
+                    "object": {
+                        "baz": {
+                            "range": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 10,
+                                    "byte": 74
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 13,
+                                    "byte": 77
+                                }
+                            },
+                            "schema": {
+                                "type": "string",
+                                "const": "qux"
+                            },
+                            "literal": "qux"
+                        },
+                        "nested": {
+                            "range": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 7,
+                                    "byte": 96
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 21,
+                                    "byte": 110
+                                }
+                            },
+                            "schema": {
+                                "properties": {
+                                    "epsilon": {
+                                        "type": "string",
+                                        "const": "delta"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "epsilon"
+                                ]
+                            },
+                            "keyRanges": {
+                                "epsilon": {
+                                    "environment": "a",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 7,
+                                        "byte": 96
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 14,
+                                        "byte": 103
+                                    }
+                                }
+                            },
+                            "object": {
+                                "epsilon": {
+                                    "range": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 8,
+                                            "column": 16,
+                                            "byte": 105
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 21,
+                                            "byte": 110
+                                        }
+                                    },
+                                    "schema": {
+                                        "type": "string",
+                                        "const": "delta"
+                                    },
+                                    "literal": "delta"
+                                }
+                            }
+                        }
+                    }
+                },
+                "symbol": [
+                    {
+                        "key": "some_object",
+                        "value": {
+                            "environment": "merge-base",
+                            "begin": {
+                                "line": 36,
+                                "column": 5,
+                                "byte": 935
+                            },
+                            "end": {
+                                "line": 39,
+                                "column": 15,
+                                "byte": 986
+                            }
+                        }
+                    }
+                ]
+            },
+            "some_object": {
+                "range": {
+                    "environment": "merge-base",
+                    "begin": {
+                        "line": 36,
+                        "column": 5,
+                        "byte": 935
+                    },
+                    "end": {
+                        "line": 39,
+                        "column": 15,
+                        "byte": 986
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "alpha": {
+                            "type": "string",
+                            "const": "beta"
+                        },
+                        "baz": {
+                            "type": "string",
+                            "const": "zab"
+                        },
+                        "foo": {
+                            "type": "string",
+                            "const": "baz"
+                        },
+                        "nested": {
+                            "properties": {
+                                "zed": {
+                                    "type": "string",
+                                    "const": "dez"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "zed"
+                            ]
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "alpha",
+                        "baz",
+                        "foo",
+                        "nested"
+                    ]
+                },
+                "base": {
+                    "range": {
+                        "environment": "a",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 27
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 13,
+                            "byte": 48
+                        }
+                    },
+                    "schema": {
+                        "properties": {
+                            "baz": {
+                                "type": "string",
+                                "const": "zab"
+                            },
+                            "foo": {
+                                "type": "string",
+                                "const": "bar"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "baz",
+                            "foo"
+                        ]
+                    },
+                    "keyRanges": {
+                        "baz": {
+                            "environment": "a",
+                            "begin": {
+                                "line": 4,
+                                "column": 5,
+                                "byte": 40
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 8,
+                                "byte": 43
+                            }
+                        },
+                        "foo": {
+                            "environment": "a",
+                            "begin": {
+                                "line": 3,
+                                "column": 5,
+                                "byte": 27
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 8,
+                                "byte": 30
+                            }
+                        }
+                    },
+                    "object": {
+                        "baz": {
+                            "range": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 10,
+                                    "byte": 45
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 13,
+                                    "byte": 48
+                                }
+                            },
+                            "schema": {
+                                "type": "string",
+                                "const": "zab"
+                            },
+                            "literal": "zab"
+                        },
+                        "foo": {
+                            "range": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 10,
+                                    "byte": 32
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 13,
+                                    "byte": 35
+                                }
+                            },
+                            "schema": {
+                                "type": "string",
+                                "const": "bar"
+                            },
+                            "literal": "bar"
+                        }
+                    }
+                },
+                "keyRanges": {
+                    "alpha": {
+                        "environment": "merge-base",
+                        "begin": {
+                            "line": 37,
+                            "column": 5,
+                            "byte": 948
+                        },
+                        "end": {
+                            "line": 37,
+                            "column": 10,
+                            "byte": 953
+                        }
+                    },
+                    "foo": {
+                        "environment": "merge-base",
+                        "begin": {
+                            "line": 36,
+                            "column": 5,
+                            "byte": 935
+                        },
+                        "end": {
+                            "line": 36,
+                            "column": 8,
+                            "byte": 938
+                        }
+                    },
+                    "nested": {
+                        "environment": "merge-base",
+                        "begin": {
+                            "line": 38,
+                            "column": 5,
+                            "byte": 964
+                        },
+                        "end": {
+                            "line": 38,
+                            "column": 11,
+                            "byte": 970
+                        }
+                    }
+                },
+                "object": {
+                    "alpha": {
+                        "range": {
+                            "environment": "merge-base",
+                            "begin": {
+                                "line": 37,
+                                "column": 12,
+                                "byte": 955
+                            },
+                            "end": {
+                                "line": 37,
+                                "column": 16,
+                                "byte": 959
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "beta"
+                        },
+                        "literal": "beta"
+                    },
+                    "foo": {
+                        "range": {
+                            "environment": "merge-base",
+                            "begin": {
+                                "line": 36,
+                                "column": 10,
+                                "byte": 940
+                            },
+                            "end": {
+                                "line": 36,
+                                "column": 13,
+                                "byte": 943
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "baz"
+                        },
+                        "base": {
+                            "range": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 10,
+                                    "byte": 32
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 13,
+                                    "byte": 35
+                                }
+                            },
+                            "schema": {
+                                "type": "string",
+                                "const": "bar"
+                            },
+                            "literal": "bar"
+                        },
+                        "literal": "baz"
+                    },
+                    "nested": {
+                        "range": {
+                            "environment": "merge-base",
+                            "begin": {
+                                "line": 39,
+                                "column": 7,
+                                "byte": 978
+                            },
+                            "end": {
+                                "line": 39,
+                                "column": 15,
+                                "byte": 986
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "zed": {
+                                    "type": "string",
+                                    "const": "dez"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "zed"
+                            ]
+                        },
+                        "keyRanges": {
+                            "zed": {
+                                "environment": "merge-base",
+                                "begin": {
+                                    "line": 39,
+                                    "column": 7,
+                                    "byte": 978
+                                },
+                                "end": {
+                                    "line": 39,
+                                    "column": 10,
+                                    "byte": 981
+                                }
+                            }
+                        },
+                        "object": {
+                            "zed": {
+                                "range": {
+                                    "environment": "merge-base",
+                                    "begin": {
+                                        "line": 39,
+                                        "column": 12,
+                                        "byte": 983
+                                    },
+                                    "end": {
+                                        "line": 39,
+                                        "column": 15,
+                                        "byte": 986
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "dez"
+                                },
+                                "literal": "dez"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "other_object": {
+                "value": {
+                    "alpha": {
+                        "value": "beta",
+                        "trace": {
+                            "def": {
+                                "environment": "merge-base",
+                                "begin": {
+                                    "line": 37,
+                                    "column": 12,
+                                    "byte": 955
+                                },
+                                "end": {
+                                    "line": 37,
+                                    "column": 16,
+                                    "byte": 959
+                                }
+                            }
+                        }
+                    },
+                    "baz": {
+                        "value": "zab",
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 10,
+                                    "byte": 45
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 13,
+                                    "byte": 48
+                                }
+                            },
+                            "base": {
+                                "value": "qux",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 6,
+                                            "column": 10,
+                                            "byte": 74
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 13,
+                                            "byte": 77
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "foo": {
+                        "value": "baz",
+                        "trace": {
+                            "def": {
+                                "environment": "merge-base",
+                                "begin": {
+                                    "line": 36,
+                                    "column": 10,
+                                    "byte": 940
+                                },
+                                "end": {
+                                    "line": 36,
+                                    "column": 13,
+                                    "byte": 943
+                                }
+                            },
+                            "base": {
+                                "value": "bar",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 10,
+                                            "byte": 32
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 13,
+                                            "byte": 35
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "nested": {
+                        "value": {
+                            "epsilon": {
+                                "value": "delta",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 8,
+                                            "column": 16,
+                                            "byte": 105
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 21,
+                                            "byte": 110
+                                        }
+                                    }
+                                }
+                            },
+                            "zed": {
+                                "value": "dez",
+                                "trace": {
+                                    "def": {
+                                        "environment": "merge-base",
+                                        "begin": {
+                                            "line": 39,
+                                            "column": 12,
+                                            "byte": 983
+                                        },
+                                        "end": {
+                                            "line": 39,
+                                            "column": 15,
+                                            "byte": 986
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "merge-base",
+                                "begin": {
+                                    "line": 39,
+                                    "column": 7,
+                                    "byte": 978
+                                },
+                                "end": {
+                                    "line": 39,
+                                    "column": 15,
+                                    "byte": 986
+                                }
+                            },
+                            "base": {
+                                "value": {
+                                    "epsilon": {
+                                        "value": "delta",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "a",
+                                                "begin": {
+                                                    "line": 8,
+                                                    "column": 16,
+                                                    "byte": 105
+                                                },
+                                                "end": {
+                                                    "line": 8,
+                                                    "column": 21,
+                                                    "byte": 110
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 8,
+                                            "column": 7,
+                                            "byte": 96
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 21,
+                                            "byte": 110
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "merge-base",
+                        "begin": {
+                            "line": 40,
+                            "column": 17,
+                            "byte": 1003
+                        },
+                        "end": {
+                            "line": 40,
+                            "column": 31,
+                            "byte": 1017
+                        }
+                    },
+                    "base": {
+                        "value": {
+                            "baz": {
+                                "value": "zab",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 4,
+                                            "column": 10,
+                                            "byte": 45
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 13,
+                                            "byte": 48
+                                        }
+                                    },
+                                    "base": {
+                                        "value": "qux",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "a",
+                                                "begin": {
+                                                    "line": 6,
+                                                    "column": 10,
+                                                    "byte": 74
+                                                },
+                                                "end": {
+                                                    "line": 6,
+                                                    "column": 13,
+                                                    "byte": 77
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "foo": {
+                                "value": "bar",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 10,
+                                            "byte": 32
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 13,
+                                            "byte": 35
+                                        }
+                                    }
+                                }
+                            },
+                            "nested": {
+                                "value": {
+                                    "epsilon": {
+                                        "value": "delta",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "a",
+                                                "begin": {
+                                                    "line": 8,
+                                                    "column": 16,
+                                                    "byte": 105
+                                                },
+                                                "end": {
+                                                    "line": 8,
+                                                    "column": 21,
+                                                    "byte": 110
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 8,
+                                            "column": 7,
+                                            "byte": 96
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 21,
+                                            "byte": 110
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 27
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 13,
+                                    "byte": 48
+                                }
+                            },
+                            "base": {
+                                "value": {
+                                    "baz": {
+                                        "value": "qux",
+                                        "trace": {
+                                            "def": {
+                                                "environment": "a",
+                                                "begin": {
+                                                    "line": 6,
+                                                    "column": 10,
+                                                    "byte": 74
+                                                },
+                                                "end": {
+                                                    "line": 6,
+                                                    "column": 13,
+                                                    "byte": 77
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "nested": {
+                                        "value": {
+                                            "epsilon": {
+                                                "value": "delta",
+                                                "trace": {
+                                                    "def": {
+                                                        "environment": "a",
+                                                        "begin": {
+                                                            "line": 8,
+                                                            "column": 16,
+                                                            "byte": 105
+                                                        },
+                                                        "end": {
+                                                            "line": 8,
+                                                            "column": 21,
+                                                            "byte": 110
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "trace": {
+                                            "def": {
+                                                "environment": "a",
+                                                "begin": {
+                                                    "line": 8,
+                                                    "column": 7,
+                                                    "byte": 96
+                                                },
+                                                "end": {
+                                                    "line": 8,
+                                                    "column": 21,
+                                                    "byte": 110
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 6,
+                                            "column": 5,
+                                            "byte": 69
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 21,
+                                            "byte": 110
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "some_object": {
+                "value": {
+                    "alpha": {
+                        "value": "beta",
+                        "trace": {
+                            "def": {
+                                "environment": "merge-base",
+                                "begin": {
+                                    "line": 37,
+                                    "column": 12,
+                                    "byte": 955
+                                },
+                                "end": {
+                                    "line": 37,
+                                    "column": 16,
+                                    "byte": 959
+                                }
+                            }
+                        }
+                    },
+                    "baz": {
+                        "value": "zab",
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 10,
+                                    "byte": 45
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 13,
+                                    "byte": 48
+                                }
+                            }
+                        }
+                    },
+                    "foo": {
+                        "value": "baz",
+                        "trace": {
+                            "def": {
+                                "environment": "merge-base",
+                                "begin": {
+                                    "line": 36,
+                                    "column": 10,
+                                    "byte": 940
+                                },
+                                "end": {
+                                    "line": 36,
+                                    "column": 13,
+                                    "byte": 943
+                                }
+                            },
+                            "base": {
+                                "value": "bar",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 10,
+                                            "byte": 32
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 13,
+                                            "byte": 35
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "nested": {
+                        "value": {
+                            "zed": {
+                                "value": "dez",
+                                "trace": {
+                                    "def": {
+                                        "environment": "merge-base",
+                                        "begin": {
+                                            "line": 39,
+                                            "column": 12,
+                                            "byte": 983
+                                        },
+                                        "end": {
+                                            "line": 39,
+                                            "column": 15,
+                                            "byte": 986
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "merge-base",
+                                "begin": {
+                                    "line": 39,
+                                    "column": 7,
+                                    "byte": 978
+                                },
+                                "end": {
+                                    "line": 39,
+                                    "column": 15,
+                                    "byte": 986
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "merge-base",
+                        "begin": {
+                            "line": 36,
+                            "column": 5,
+                            "byte": 935
+                        },
+                        "end": {
+                            "line": 39,
+                            "column": 15,
+                            "byte": 986
+                        }
+                    },
+                    "base": {
+                        "value": {
+                            "baz": {
+                                "value": "zab",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 4,
+                                            "column": 10,
+                                            "byte": 45
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 13,
+                                            "byte": 48
+                                        }
+                                    }
+                                }
+                            },
+                            "foo": {
+                                "value": "bar",
+                                "trace": {
+                                    "def": {
+                                        "environment": "a",
+                                        "begin": {
+                                            "line": 3,
+                                            "column": 10,
+                                            "byte": 32
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 13,
+                                            "byte": 35
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "a",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 27
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 13,
+                                    "byte": 48
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "other_object": {
+                    "properties": {
+                        "alpha": {
+                            "type": "string",
+                            "const": "beta"
+                        },
+                        "baz": {
+                            "type": "string",
+                            "const": "zab"
+                        },
+                        "foo": {
+                            "type": "string",
+                            "const": "baz"
+                        },
+                        "nested": {
+                            "properties": {
+                                "epsilon": {
+                                    "type": "string",
+                                    "const": "delta"
+                                },
+                                "zed": {
+                                    "type": "string",
+                                    "const": "dez"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "epsilon",
+                                "zed"
+                            ]
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "alpha",
+                        "baz",
+                        "foo",
+                        "nested"
+                    ]
+                },
+                "some_object": {
+                    "properties": {
+                        "alpha": {
+                            "type": "string",
+                            "const": "beta"
+                        },
+                        "baz": {
+                            "type": "string",
+                            "const": "zab"
+                        },
+                        "foo": {
+                            "type": "string",
+                            "const": "baz"
+                        },
+                        "nested": {
+                            "properties": {
+                                "zed": {
+                                    "type": "string",
+                                    "const": "dez"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "zed"
+                            ]
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "alpha",
+                        "baz",
+                        "foo",
+                        "nested"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "other_object",
+                "some_object"
+            ]
+        }
+    },
+    "evalJsonRedacted": {
+        "other_object": {
+            "alpha": "beta",
+            "baz": "zab",
+            "foo": "baz",
+            "nested": {
+                "epsilon": "delta",
+                "zed": "dez"
+            }
+        },
+        "some_object": {
+            "alpha": "beta",
+            "baz": "zab",
+            "foo": "baz",
+            "nested": {
+                "zed": "dez"
+            }
+        }
+    },
+    "evalJSONRevealed": {
+        "other_object": {
+            "alpha": "beta",
+            "baz": "zab",
+            "foo": "baz",
+            "nested": {
+                "epsilon": "delta",
+                "zed": "dez"
+            }
+        },
+        "some_object": {
+            "alpha": "beta",
+            "baz": "zab",
+            "foo": "baz",
+            "nested": {
+                "zed": "dez"
+            }
+        }
+    }
+}

--- a/eval/testdata/eval/merge-unknown/expected.json
+++ b/eval/testdata/eval/merge-unknown/expected.json
@@ -400,24 +400,6 @@
                                                     "column": 10,
                                                     "byte": 62
                                                 }
-                                            },
-                                            "base": {
-                                                "unknown": true,
-                                                "trace": {
-                                                    "def": {
-                                                        "environment": "merge-unknown",
-                                                        "begin": {
-                                                            "line": 7,
-                                                            "column": 12,
-                                                            "byte": 64
-                                                        },
-                                                        "end": {
-                                                            "line": 7,
-                                                            "column": 15,
-                                                            "byte": 67
-                                                        }
-                                                    }
-                                                }
                                             }
                                         }
                                     }
@@ -452,24 +434,6 @@
                                             "line": 6,
                                             "column": 8,
                                             "byte": 51
-                                        }
-                                    },
-                                    "base": {
-                                        "unknown": true,
-                                        "trace": {
-                                            "def": {
-                                                "environment": "merge-unknown",
-                                                "begin": {
-                                                    "line": 7,
-                                                    "column": 7,
-                                                    "byte": 59
-                                                },
-                                                "end": {
-                                                    "line": 7,
-                                                    "column": 15,
-                                                    "byte": 67
-                                                }
-                                            }
                                         }
                                     }
                                 }
@@ -506,24 +470,6 @@
                                             "line": 5,
                                             "column": 8,
                                             "byte": 38
-                                        }
-                                    },
-                                    "base": {
-                                        "unknown": true,
-                                        "trace": {
-                                            "def": {
-                                                "environment": "merge-unknown",
-                                                "begin": {
-                                                    "line": 5,
-                                                    "column": 10,
-                                                    "byte": 40
-                                                },
-                                                "end": {
-                                                    "line": 5,
-                                                    "column": 13,
-                                                    "byte": 43
-                                                }
-                                            }
                                         }
                                     }
                                 }

--- a/expr.go
+++ b/expr.go
@@ -15,6 +15,8 @@
 package esc
 
 import (
+	"fmt"
+
 	"github.com/pulumi/esc/schema"
 )
 
@@ -112,6 +114,10 @@ type Range struct {
 	End Pos `json:"end"`
 }
 
+func (r Range) String() string {
+	return fmt.Sprintf("%v:[%v,%v]", r.Environment, r.Begin, r.End)
+}
+
 // Contains returns true if the range contains the given position.
 func (r Range) Contains(pos Pos) bool {
 	if pos.Byte >= r.Begin.Byte && pos.Byte < r.End.Byte {
@@ -138,4 +144,8 @@ type Pos struct {
 
 	// Byte is the byte offset into the file where the indicated position begins.
 	Byte int `json:"byte"`
+}
+
+func (p Pos) String() string {
+	return fmt.Sprintf("%v:%v", p.Line, p.Column)
 }


### PR DESCRIPTION
These changes fix the merging of values that have already been merged.

During evaluation, merged values are represented by _chains_. Each value
`v` maintains a reference to its _base_ value--i.e. the value with which
it has been merged--if any. For example, consider the following values,
where `repr` is the value's data and `base` is the value's base:

```
A: (repr: { foo: B }, base: None)
B: (repr: "bar", base: None)

C: (repr: { foo: D, zed: E }, base: None)
D: (repr: "baz", base: None)
E: (repr: "qux", base: None)
```

When merging `C` onto `A`, `C`'s base will be set to `A` and`D`'s base
will be set to `B`:

```
A: (repr: { foo: B }, base: None)
B: (repr: "bar", base: None)

C: (repr: { foo: D, zed: E }, base: A)
D: (repr: "baz", base: B)
E: (repr: "qux", base: None)
```

Now introduce the following values:

```
F: (repr: { foo: G, zed: H }, base: None)
G: (repr: "beta", base: None)
H: (repr: "gamma", base: None)
```

If `C` is merged onto `F`, `A`'s base should be set to `F`, `B`'s base
should be set to `G`, and `E`'s base should be set to `H`:

```
F: (repr: { foo: G, zed: H }, base: None)
G: (repr: "beta", base: None)
H: (repr: "gamma", base: None)

A: (repr: { foo: B }, base: F)
B: (repr: "bar", base: G)

C: (repr: { foo: D, zed: E }, base: A)
D: (repr: "baz", base: B)
E: (repr: "qux", base: H)
```

In order to achieve this, the merge operation looks like this:

```
def merge(top, base):
  # If there is no new base or if the new base is the same as v, we're
  # done.
  if base == None || top == base:
    return

  if top.base is not None:
    # This value already has a base. Recur.
    merge(top.base, base)
  else:
    # This value does not have a base. Set it now.
    top.base = base

  # Now that the base has been updated, this value's members may need to
  # be updated to point to their new base.
  if isinstance(top.repr, dict):
    for k, p in ctop.repr.items():
      merge(p, top.base.property(k)
```

Prior to these changes, the merge operation had two bugs.

First--and most importantly--it only updated a top value's members if
the top value did not already have a base. Fixing this issue was
straightforward, as it only required adjusting the code to
unconditionally update the top value's members. This is the fix to #212.
In reference to the figures above, prior to these changes, merging `C`
onto `F` would have resulted in:

```
F: (repr: { foo: G, zed: H }, base: None)
G: (repr: "beta", base: None)
H: (repr: "gamma", base: None)

A: (repr: { foo: B }, base: F)
B: (repr: "bar", base: G)

C: (repr: { foo: D, zed: E }, base: A)
D: (repr: "baz", base: B)
E: (repr: "qux", base: None) # <- base should be H
```

The second issue was more subtle. If a value already has a base, merging
that value onto another will mutate the base. This means that base
values cannot be shared between multiple top values, and must instead be
copied. However, the copy routine violated the _critically important
property_ that the base `Q` for a property `P` in a top value must be the
same object as `Q` in the base of the object that contains `P`. For
example, given:

```
A: (repr: { prop: Q }, base: None)
                  ^ call this reference R1

Q: (repr: "foo", base: None)

B: (repr: { prop: P }, base: A)
P: (repr: "bar", base: Q)
                       ^ call this reference R2
```

`R1` and `R2` must refer to the same `Q`. If they do not, then merging
`A` and `B` will result in redundant merges. This isn't a correctness
issue as far as the resulting value, but it does cause incorrect traces.

In order to fix this issue, these changes replace the `(*value).copy`
method with `(copier).copy`, which tracks copied values and ensures that
all references to a value `V` are redirected to the same copy of `V`
rather than copying `V` multiple times.

Fixes #212.
