### PR TITLE
ast: error recovery

### DIFF
--- a/ast/environment.go
+++ b/ast/environment.go
@@ -289,9 +289,6 @@ func parseField(name string, dest reflect.Value, node syntax.Node) syntax.Diagno
 	case dest.Type().AssignableTo(exprType):
 		x, xdiags := ParseExpr(node)
 		diags.Extend(xdiags...)
-		if diags.HasErrors() {
-			return diags
-		}
 
 		xv := reflect.ValueOf(x)
 		if !xv.Type().AssignableTo(dest.Type()) {
@@ -303,9 +300,7 @@ func parseField(name string, dest reflect.Value, node syntax.Node) syntax.Diagno
 		panic(fmt.Errorf("unexpected field of type %T", dest.Interface()))
 	}
 
-	if !diags.HasErrors() {
-		dest.Set(v)
-	}
+	dest.Set(v)
 	return diags
 }
 
@@ -351,7 +346,6 @@ func parseRecord(objName string, dest recordDecl, node syntax.Node, noMatchWarni
 			nodeError.Severity = hcl.DiagWarning
 			diags = append(diags, nodeError)
 		}
-
 	}
 
 	return diags

--- a/ast/environment_test.go
+++ b/ast/environment_test.go
@@ -149,17 +149,6 @@ func loadYAMLBytes(filename string, source []byte) (*EnvironmentDecl, syntax.Dia
 	return t, diags, nil
 }
 
-func normalize[T any](t *testing.T, v T) T {
-	var decoded T
-	marshaled, err := json.Marshal(v)
-	require.NoError(t, err)
-	dec := json.NewDecoder(bytes.NewReader(marshaled))
-	dec.UseNumber()
-	err = dec.Decode(&decoded)
-	require.NoError(t, err)
-	return decoded
-}
-
 func TestParse(t *testing.T) {
 	type expectedData struct {
 		Decl  any                `json:"decl,omitempty"`

--- a/ast/environment_test.go
+++ b/ast/environment_test.go
@@ -15,6 +15,11 @@
 package ast
 
 import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -22,7 +27,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	"github.com/pulumi/esc/syntax"
 	"github.com/pulumi/esc/syntax/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
 func TestExample(t *testing.T) {
@@ -93,4 +100,123 @@ func TestEmptyDocument(t *testing.T) {
 	assert.Len(t, diags, 0)
 
 	assert.Nil(t, environment.Description)
+}
+
+func accept() bool {
+	return cmdutil.IsTruthy(os.Getenv("PULUMI_ACCEPT"))
+}
+
+func sortEnvironmentDiagnostics(diags syntax.Diagnostics) {
+	sort.Slice(diags, func(i, j int) bool {
+		di, dj := diags[i], diags[j]
+		if di.Subject == nil {
+			if dj.Subject == nil {
+				return di.Summary < dj.Summary
+			}
+			return true
+		}
+		if dj.Subject == nil {
+			return false
+		}
+		if di.Subject.Filename != dj.Subject.Filename {
+			return di.Subject.Filename < dj.Subject.Filename
+		}
+		if di.Subject.Start.Line != dj.Subject.Start.Line {
+			return di.Subject.Start.Line < dj.Subject.Start.Line
+		}
+		return di.Subject.Start.Column < dj.Subject.Start.Column
+	})
+}
+
+type tagDecoder int
+
+func (d tagDecoder) DecodeTag(filename string, n *yaml.Node) (syntax.Node, syntax.Diagnostics, bool) {
+	return nil, nil, false
+}
+
+// loadYAMLBytes decodes a YAML template from a byte array.
+func loadYAMLBytes(filename string, source []byte) (*EnvironmentDecl, syntax.Diagnostics, error) {
+	var diags syntax.Diagnostics
+
+	syn, sdiags := encoding.DecodeYAMLBytes(filename, source, tagDecoder(0))
+	diags.Extend(sdiags...)
+	if sdiags.HasErrors() {
+		return nil, diags, nil
+	}
+
+	t, tdiags := ParseEnvironment(source, syn)
+	diags.Extend(tdiags...)
+	return t, diags, nil
+}
+
+func normalize[T any](t *testing.T, v T) T {
+	var decoded T
+	marshaled, err := json.Marshal(v)
+	require.NoError(t, err)
+	dec := json.NewDecoder(bytes.NewReader(marshaled))
+	dec.UseNumber()
+	err = dec.Decode(&decoded)
+	require.NoError(t, err)
+	return decoded
+}
+
+func TestParse(t *testing.T) {
+	type expectedData struct {
+		Decl  any                `json:"decl,omitempty"`
+		Diags syntax.Diagnostics `json:"diags,omitempty"`
+	}
+
+	path := filepath.Join("testdata", "parse")
+	entries, err := os.ReadDir(path)
+	require.NoError(t, err)
+	for _, e := range entries {
+		t.Run(e.Name(), func(t *testing.T) {
+			basePath := filepath.Join(path, e.Name())
+			envPath, expectedPath := filepath.Join(basePath, "env.yaml"), filepath.Join(basePath, "expected.json")
+
+			envBytes, err := os.ReadFile(envPath)
+			require.NoError(t, err)
+
+			decl, diags, err := loadYAMLBytes(e.Name(), envBytes)
+			require.NoError(t, err)
+			sortEnvironmentDiagnostics(diags)
+
+			if accept() {
+				bytes, err := json.MarshalIndent(expectedData{
+					Decl:  decl,
+					Diags: diags,
+				}, "", "    ")
+				bytes = append(bytes, '\n')
+				require.NoError(t, err)
+
+				err = os.WriteFile(expectedPath, bytes, 0600)
+				require.NoError(t, err)
+
+				return
+			}
+
+			var expected expectedData
+			expectedBytes, err := os.ReadFile(expectedPath)
+			require.NoError(t, err)
+			dec := json.NewDecoder(bytes.NewReader(expectedBytes))
+			dec.UseNumber()
+			err = dec.Decode(&expected)
+			require.NoError(t, err)
+
+			assert.Equal(t, expected.Diags, diags)
+
+			declJSON, err := json.MarshalIndent(decl, "", "    ")
+			require.NoError(t, err)
+			var roundTripDecl any
+			err = json.Unmarshal(declJSON, &roundTripDecl)
+			require.NoError(t, err)
+			declJSON, err = json.MarshalIndent(roundTripDecl, "", "    ")
+			require.NoError(t, err)
+
+			expectedJSON, err := json.MarshalIndent(expected.Decl, "", "    ")
+			require.NoError(t, err)
+
+			assert.Equal(t, string(expectedJSON), string(declJSON))
+		})
+	}
 }

--- a/ast/interpolation.go
+++ b/ast/interpolation.go
@@ -28,16 +28,15 @@ type Interpolation struct {
 func parseInterpolate(node syntax.Node, value string) ([]Interpolation, syntax.Diagnostics) {
 	var parts []Interpolation
 	var str strings.Builder
+	var diags syntax.Diagnostics
 	for len(value) > 0 {
 		switch {
 		case strings.HasPrefix(value, "$$"):
 			str.WriteByte('$')
 			value = value[2:]
 		case strings.HasPrefix(value, "${"):
-			rest, access, diags := parsePropertyAccess(node, value[2:])
-			if len(diags) != 0 {
-				return nil, diags
-			}
+			rest, access, accessDiags := parsePropertyAccess(node, value[2:])
+			diags.Extend(accessDiags...)
 			parts = append(parts, Interpolation{
 				Text:  str.String(),
 				Value: access,
@@ -53,5 +52,5 @@ func parseInterpolate(node syntax.Node, value string) ([]Interpolation, syntax.D
 	if str.Len() != 0 {
 		parts = append(parts, Interpolation{Text: str.String()})
 	}
-	return parts, nil
+	return parts, diags
 }

--- a/ast/property_test.go
+++ b/ast/property_test.go
@@ -15,8 +15,9 @@
 package ast
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPropertyAccess_String(t *testing.T) {

--- a/ast/testdata/parse/invalid-interpolations/env.yaml
+++ b/ast/testdata/parse/invalid-interpolations/env.yaml
@@ -1,0 +1,7 @@
+values:
+  interpolations:
+    - unterminated ${interpolation
+    - missing ${property.} name
+    - missing ${property[} subscript
+    - missing ${closing["quote
+    - invalid ${integer[subscript]}

--- a/ast/testdata/parse/invalid-interpolations/expected.json
+++ b/ast/testdata/parse/invalid-interpolations/expected.json
@@ -1,0 +1,220 @@
+{
+    "decl": {
+        "Description": null,
+        "Imports": null,
+        "Values": {
+            "Entries": [
+                {
+                    "Key": {
+                        "Value": "interpolations"
+                    },
+                    "Value": {
+                        "Elements": [
+                            {
+                                "Parts": [
+                                    {
+                                        "Text": "unterminated ",
+                                        "Value": {
+                                            "Accessors": [
+                                                {
+                                                    "Name": "interpolation"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "Parts": [
+                                    {
+                                        "Text": "missing ",
+                                        "Value": {
+                                            "Accessors": [
+                                                {
+                                                    "Name": "property"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Text": " name",
+                                        "Value": null
+                                    }
+                                ]
+                            },
+                            {
+                                "Parts": [
+                                    {
+                                        "Text": "missing ",
+                                        "Value": {
+                                            "Accessors": [
+                                                {
+                                                    "Name": "property"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "Text": " subscript",
+                                        "Value": null
+                                    }
+                                ]
+                            },
+                            {
+                                "Parts": [
+                                    {
+                                        "Text": "missing ",
+                                        "Value": {
+                                            "Accessors": [
+                                                {
+                                                    "Name": "closing"
+                                                },
+                                                {
+                                                    "Index": "quote"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "Parts": [
+                                    {
+                                        "Text": "invalid ",
+                                        "Value": {
+                                            "Accessors": [
+                                                {
+                                                    "Name": "integer"
+                                                },
+                                                {
+                                                    "Index": 0
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "diags": [
+        {
+            "Severity": 1,
+            "Summary": "unterminated interpolation",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-interpolations",
+                "Start": {
+                    "Line": 3,
+                    "Column": 7,
+                    "Byte": 32
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 35,
+                    "Byte": 60
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.interpolations[0]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "missing closing bracket in list index",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-interpolations",
+                "Start": {
+                    "Line": 5,
+                    "Column": 7,
+                    "Byte": 99
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 37,
+                    "Byte": 129
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.interpolations[2]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "missing closing quote in property name",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-interpolations",
+                "Start": {
+                    "Line": 6,
+                    "Column": 7,
+                    "Byte": 136
+                },
+                "End": {
+                    "Line": 6,
+                    "Column": 31,
+                    "Byte": 160
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.interpolations[3]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unterminated interpolation",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-interpolations",
+                "Start": {
+                    "Line": 6,
+                    "Column": 7,
+                    "Byte": 136
+                },
+                "End": {
+                    "Line": 6,
+                    "Column": 31,
+                    "Byte": 160
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.interpolations[3]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "invalid list index",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-interpolations",
+                "Start": {
+                    "Line": 7,
+                    "Column": 7,
+                    "Byte": 167
+                },
+                "End": {
+                    "Line": 7,
+                    "Column": 36,
+                    "Byte": 196
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.interpolations[4]"
+        }
+    ]
+}

--- a/ast/testdata/parse/invalid-join/env.yaml
+++ b/ast/testdata/parse/invalid-join/env.yaml
@@ -1,0 +1,4 @@
+values:
+  join:
+    fn::join: oops
+  other: value

--- a/ast/testdata/parse/invalid-join/expected.json
+++ b/ast/testdata/parse/invalid-join/expected.json
@@ -1,0 +1,52 @@
+{
+    "decl": {
+        "Description": null,
+        "Imports": null,
+        "Values": {
+            "Entries": [
+                {
+                    "Key": {
+                        "Value": "join"
+                    },
+                    "Value": {
+                        "Delimiter": null,
+                        "Values": null
+                    }
+                },
+                {
+                    "Key": {
+                        "Value": "other"
+                    },
+                    "Value": {
+                        "Value": "value"
+                    }
+                }
+            ]
+        }
+    },
+    "diags": [
+        {
+            "Severity": 1,
+            "Summary": "the argument to fn::join must be a two-valued list",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-join",
+                "Start": {
+                    "Line": 3,
+                    "Column": 15,
+                    "Byte": 30
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 19,
+                    "Byte": 34
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.join[\"fn::join\"]"
+        }
+    ]
+}

--- a/ast/testdata/parse/invalid-open/env.yaml
+++ b/ast/testdata/parse/invalid-open/env.yaml
@@ -1,0 +1,11 @@
+values:
+  missing-provider:
+    fn::open:
+      inputs: inputs
+  missing-inputs:
+    fn::open:
+      provider: test
+  invalid-provider:
+    fn::open:
+      provider: [ oops ]
+      inputs: inputs

--- a/ast/testdata/parse/invalid-open/expected.json
+++ b/ast/testdata/parse/invalid-open/expected.json
@@ -1,0 +1,114 @@
+{
+    "decl": {
+        "Description": null,
+        "Imports": null,
+        "Values": {
+            "Entries": [
+                {
+                    "Key": {
+                        "Value": "missing-provider"
+                    },
+                    "Value": {
+                        "Provider": null,
+                        "Inputs": {
+                            "Value": "inputs"
+                        }
+                    }
+                },
+                {
+                    "Key": {
+                        "Value": "missing-inputs"
+                    },
+                    "Value": {
+                        "Provider": {
+                            "Value": "test"
+                        },
+                        "Inputs": null
+                    }
+                },
+                {
+                    "Key": {
+                        "Value": "invalid-provider"
+                    },
+                    "Value": {
+                        "Provider": null,
+                        "Inputs": {
+                            "Value": "inputs"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "diags": [
+        {
+            "Severity": 1,
+            "Summary": "missing provider name ('provider')",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-open",
+                "Start": {
+                    "Line": 4,
+                    "Column": 7,
+                    "Byte": 48
+                },
+                "End": {
+                    "Line": 4,
+                    "Column": 21,
+                    "Byte": 62
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values[\"missing-provider\"][\"fn::open\"]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "missing provider inputs ('inputs')",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-open",
+                "Start": {
+                    "Line": 7,
+                    "Column": 7,
+                    "Byte": 101
+                },
+                "End": {
+                    "Line": 7,
+                    "Column": 21,
+                    "Byte": 115
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values[\"missing-inputs\"][\"fn::open\"]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "provider name must be a string literal",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-open",
+                "Start": {
+                    "Line": 10,
+                    "Column": 17,
+                    "Byte": 166
+                },
+                "End": {
+                    "Line": 10,
+                    "Column": 23,
+                    "Byte": 172
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values[\"invalid-provider\"][\"fn::open\"].provider"
+        }
+    ]
+}

--- a/ast/testdata/parse/invalid-plaintext/env.yaml
+++ b/ast/testdata/parse/invalid-plaintext/env.yaml
@@ -1,0 +1,6 @@
+values:
+  foo:
+    fn::secret: [ some, list ]
+  bar:
+    a: valid
+    object: here

--- a/ast/testdata/parse/invalid-plaintext/expected.json
+++ b/ast/testdata/parse/invalid-plaintext/expected.json
@@ -1,0 +1,69 @@
+{
+    "decl": {
+        "Description": null,
+        "Imports": null,
+        "Values": {
+            "Entries": [
+                {
+                    "Key": {
+                        "Value": "foo"
+                    },
+                    "Value": {
+                        "Plaintext": null,
+                        "Ciphertext": null
+                    }
+                },
+                {
+                    "Key": {
+                        "Value": "bar"
+                    },
+                    "Value": {
+                        "Entries": [
+                            {
+                                "Key": {
+                                    "Value": "a"
+                                },
+                                "Value": {
+                                    "Value": "valid"
+                                }
+                            },
+                            {
+                                "Key": {
+                                    "Value": "object"
+                                },
+                                "Value": {
+                                    "Value": "here"
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "diags": [
+        {
+            "Severity": 1,
+            "Summary": "secret values must be string literals",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-plaintext",
+                "Start": {
+                    "Line": 3,
+                    "Column": 17,
+                    "Byte": 31
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 29,
+                    "Byte": 43
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.foo[\"fn::secret\"]"
+        }
+    ]
+}

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -66,10 +66,6 @@ func LoadYAMLBytes(filename string, source []byte) (*ast.EnvironmentDecl, syntax
 
 	t, tdiags := ast.ParseEnvironment(source, syn)
 	diags.Extend(tdiags...)
-	if tdiags.HasErrors() {
-		return nil, diags, nil
-	}
-
 	return t, diags, nil
 }
 
@@ -402,6 +398,9 @@ func (e *evalContext) evaluateImport(myImports map[string]*value, decl *ast.Impo
 		e.diags.Extend(diags...)
 		if err != nil {
 			e.errorf(decl.Environment, "%s", err.Error())
+			return
+		}
+		if diags.HasErrors() {
 			return
 		}
 

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -207,35 +207,35 @@ func TestEval(t *testing.T) {
 				require.NoError(t, err)
 				sortEnvironmentDiagnostics(loadDiags)
 
-				check, checkDiags := CheckEnvironment(context.Background(), e.Name(), env, testProviders{}, &testEnvironments{basePath})
-				sortEnvironmentDiagnostics(checkDiags)
+				expected := expectedData{LoadDiags: loadDiags}
+				if !loadDiags.HasErrors() {
+					check, checkDiags := CheckEnvironment(context.Background(), e.Name(), env, testProviders{}, &testEnvironments{basePath})
+					sortEnvironmentDiagnostics(checkDiags)
 
-				actual, evalDiags := EvalEnvironment(context.Background(), e.Name(), env, rot128{}, testProviders{}, &testEnvironments{basePath})
-				sortEnvironmentDiagnostics(evalDiags)
+					eval, evalDiags := EvalEnvironment(context.Background(), e.Name(), env, rot128{}, testProviders{}, &testEnvironments{basePath})
+					sortEnvironmentDiagnostics(evalDiags)
 
-				var checkJSON any
-				var evalJSONRedacted any
-				var evalJSONRevealed any
-				if check != nil {
-					check = normalize(t, check)
-					checkJSON = esc.NewValue(check.Properties).ToJSON(true)
+					var checkJSON any
+					var evalJSONRedacted any
+					var evalJSONRevealed any
+					if check != nil {
+						check = normalize(t, check)
+						checkJSON = esc.NewValue(check.Properties).ToJSON(true)
+					}
+					if eval != nil {
+						eval = normalize(t, eval)
+						evalJSONRedacted = esc.NewValue(eval.Properties).ToJSON(true)
+						evalJSONRevealed = esc.NewValue(eval.Properties).ToJSON(false)
+					}
+
+					expected.Check, expected.CheckDiags = check, checkDiags
+					expected.Eval, expected.EvalDiags = eval, evalDiags
+					expected.EvalJSONRedacted = evalJSONRedacted
+					expected.EvalJSONRevealed = evalJSONRevealed
+					expected.CheckJSON = checkJSON
 				}
-				if actual != nil {
-					actual = normalize(t, actual)
-					evalJSONRedacted = esc.NewValue(actual.Properties).ToJSON(true)
-					evalJSONRevealed = esc.NewValue(actual.Properties).ToJSON(false)
-				}
 
-				bytes, err := json.MarshalIndent(expectedData{
-					LoadDiags:        loadDiags,
-					CheckDiags:       checkDiags,
-					EvalDiags:        evalDiags,
-					Check:            check,
-					Eval:             actual,
-					EvalJSONRedacted: evalJSONRedacted,
-					EvalJSONRevealed: evalJSONRevealed,
-					CheckJSON:        checkJSON,
-				}, "", "    ")
+				bytes, err := json.MarshalIndent(expected, "", "    ")
 				bytes = append(bytes, '\n')
 				require.NoError(t, err)
 
@@ -257,6 +257,10 @@ func TestEval(t *testing.T) {
 			require.NoError(t, err)
 			sortEnvironmentDiagnostics(diags)
 			require.Equal(t, expected.LoadDiags, diags)
+
+			if diags.HasErrors() {
+				return
+			}
 
 			check, diags := CheckEnvironment(context.Background(), e.Name(), env, testProviders{}, &testEnvironments{basePath})
 			sortEnvironmentDiagnostics(diags)

--- a/eval/testdata/eval/invalid-access-load/expected.json
+++ b/eval/testdata/eval/invalid-access-load/expected.json
@@ -53,6 +53,29 @@
             "Subject": {
                 "Filename": "invalid-access-load",
                 "Start": {
+                    "Line": 4,
+                    "Column": 7,
+                    "Byte": 56
+                },
+                "End": {
+                    "Line": 4,
+                    "Column": 20,
+                    "Byte": 69
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[1]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unterminated interpolation",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
                     "Line": 5,
                     "Column": 7,
                     "Byte": 76
@@ -72,6 +95,29 @@
         {
             "Severity": 1,
             "Summary": "missing closing bracket in list index",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 6,
+                    "Column": 7,
+                    "Byte": 96
+                },
+                "End": {
+                    "Line": 6,
+                    "Column": 17,
+                    "Byte": 106
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[3]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unterminated interpolation",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-access-load",


### PR DESCRIPTION
Allow the parser to recover from errors and return its best possible AST. This is the first step towards allowing evaluation of environments that contain parse errors, which is vital for live analysis.