### PR TITLE
eval: evaluate after parse errors

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
+- Allow evaluation of environments with parse errors.
+  [#222](https://github.com/pulumi/esc/pull/222)
+
 ### Bug Fixes

--- a/ast/expr.go
+++ b/ast/expr.go
@@ -140,7 +140,7 @@ func StringSyntaxValue(node *syntax.StringNode, value string) *StringExpr {
 
 // String creates a new string literal expression with the given value.
 func String(value string) *StringExpr {
-	return &StringExpr{Value: value}
+	return &StringExpr{exprNode: expr(syntax.String(value)), Value: value}
 }
 
 // An InterpolateExpr represents an interpolated string.
@@ -722,6 +722,7 @@ func parseSecret(node *syntax.ObjectNode, name *StringExpr, value Expr) (Expr, s
 	var diags syntax.Diagnostics
 	str, ok := value.(*StringExpr)
 	if !ok {
+		str = String("")
 		diags = syntax.Diagnostics{ExprError(value, "secret values must be string literals")}
 	}
 	return PlaintextSyntax(node, name, str), diags

--- a/ast/testdata/parse/invalid-plaintext/expected.json
+++ b/ast/testdata/parse/invalid-plaintext/expected.json
@@ -9,7 +9,9 @@
                         "Value": "foo"
                     },
                     "Value": {
-                        "Plaintext": null,
+                        "Plaintext": {
+                            "Value": ""
+                        },
                         "Ciphertext": null
                     }
                 },

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -207,35 +207,35 @@ func TestEval(t *testing.T) {
 				require.NoError(t, err)
 				sortEnvironmentDiagnostics(loadDiags)
 
-				expected := expectedData{LoadDiags: loadDiags}
-				if !loadDiags.HasErrors() {
-					check, checkDiags := CheckEnvironment(context.Background(), e.Name(), env, testProviders{}, &testEnvironments{basePath})
-					sortEnvironmentDiagnostics(checkDiags)
+				check, checkDiags := CheckEnvironment(context.Background(), e.Name(), env, testProviders{}, &testEnvironments{basePath})
+				sortEnvironmentDiagnostics(checkDiags)
 
-					eval, evalDiags := EvalEnvironment(context.Background(), e.Name(), env, rot128{}, testProviders{}, &testEnvironments{basePath})
-					sortEnvironmentDiagnostics(evalDiags)
+				actual, evalDiags := EvalEnvironment(context.Background(), e.Name(), env, rot128{}, testProviders{}, &testEnvironments{basePath})
+				sortEnvironmentDiagnostics(evalDiags)
 
-					var checkJSON any
-					var evalJSONRedacted any
-					var evalJSONRevealed any
-					if check != nil {
-						check = normalize(t, check)
-						checkJSON = esc.NewValue(check.Properties).ToJSON(true)
-					}
-					if eval != nil {
-						eval = normalize(t, eval)
-						evalJSONRedacted = esc.NewValue(eval.Properties).ToJSON(true)
-						evalJSONRevealed = esc.NewValue(eval.Properties).ToJSON(false)
-					}
-
-					expected.Check, expected.CheckDiags = check, checkDiags
-					expected.Eval, expected.EvalDiags = eval, evalDiags
-					expected.EvalJSONRedacted = evalJSONRedacted
-					expected.EvalJSONRevealed = evalJSONRevealed
-					expected.CheckJSON = checkJSON
+				var checkJSON any
+				var evalJSONRedacted any
+				var evalJSONRevealed any
+				if check != nil {
+					check = normalize(t, check)
+					checkJSON = esc.NewValue(check.Properties).ToJSON(true)
+				}
+				if actual != nil {
+					actual = normalize(t, actual)
+					evalJSONRedacted = esc.NewValue(actual.Properties).ToJSON(true)
+					evalJSONRevealed = esc.NewValue(actual.Properties).ToJSON(false)
 				}
 
-				bytes, err := json.MarshalIndent(expected, "", "    ")
+				bytes, err := json.MarshalIndent(expectedData{
+					LoadDiags:        loadDiags,
+					CheckDiags:       checkDiags,
+					EvalDiags:        evalDiags,
+					Check:            check,
+					Eval:             actual,
+					EvalJSONRedacted: evalJSONRedacted,
+					EvalJSONRevealed: evalJSONRevealed,
+					CheckJSON:        checkJSON,
+				}, "", "    ")
 				bytes = append(bytes, '\n')
 				require.NoError(t, err)
 
@@ -257,10 +257,6 @@ func TestEval(t *testing.T) {
 			require.NoError(t, err)
 			sortEnvironmentDiagnostics(diags)
 			require.Equal(t, expected.LoadDiags, diags)
-
-			if diags.HasErrors() {
-				return
-			}
 
 			check, diags := CheckEnvironment(context.Background(), e.Name(), env, testProviders{}, &testEnvironments{basePath})
 			sortEnvironmentDiagnostics(diags)

--- a/eval/testdata/eval/invalid-access-load/expected.json
+++ b/eval/testdata/eval/invalid-access-load/expected.json
@@ -276,5 +276,1857 @@
             "Extra": null,
             "Path": "values.propertyAccessTest[9]"
         }
-    ]
+    ],
+    "checkDiags": [
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"open\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 3,
+                    "Column": 7,
+                    "Byte": 36
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 20,
+                    "Byte": 49
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[0]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"open\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 4,
+                    "Column": 7,
+                    "Byte": 56
+                },
+                "End": {
+                    "Line": 4,
+                    "Column": 20,
+                    "Byte": 69
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[1]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"open\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 5,
+                    "Column": 7,
+                    "Byte": 76
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 20,
+                    "Byte": 89
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[2]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"array\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 6,
+                    "Column": 7,
+                    "Byte": 96
+                },
+                "End": {
+                    "Line": 6,
+                    "Column": 17,
+                    "Byte": 106
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[3]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"array\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 7,
+                    "Column": 7,
+                    "Byte": 113
+                },
+                "End": {
+                    "Line": 7,
+                    "Column": 27,
+                    "Byte": 133
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[4]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "cannot access an object property using an integer index",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 9,
+                    "Column": 7,
+                    "Byte": 150
+                },
+                "End": {
+                    "Line": 9,
+                    "Column": 13,
+                    "Byte": 156
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[6]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"2\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 10,
+                    "Column": 7,
+                    "Byte": 163
+                },
+                "End": {
+                    "Line": 10,
+                    "Column": 19,
+                    "Byte": 175
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[7]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"34\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 11,
+                    "Column": 7,
+                    "Byte": 182
+                },
+                "End": {
+                    "Line": 11,
+                    "Column": 16,
+                    "Byte": 191
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[8]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"bad\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 12,
+                    "Column": 7,
+                    "Byte": 198
+                },
+                "End": {
+                    "Line": 12,
+                    "Column": 14,
+                    "Byte": 205
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[9]"
+        }
+    ],
+    "check": {
+        "exprs": {
+            "propertyAccessTest": {
+                "range": {
+                    "environment": "invalid-access-load",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 34
+                    },
+                    "end": {
+                        "line": 12,
+                        "column": 14,
+                        "byte": 205
+                    }
+                },
+                "schema": {
+                    "prefixItems": [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    "items": false,
+                    "type": "array"
+                },
+                "list": [
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 3,
+                                "column": 7,
+                                "byte": 36
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 20,
+                                "byte": 49
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "open",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 7,
+                                        "byte": 36
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 20,
+                                        "byte": 49
+                                    }
+                                }
+                            },
+                            {
+                                "key": "foo",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 7,
+                                        "byte": 36
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 20,
+                                        "byte": 49
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 4,
+                                "column": 7,
+                                "byte": 56
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 20,
+                                "byte": 69
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "open",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 7,
+                                        "byte": 56
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 20,
+                                        "byte": 69
+                                    }
+                                }
+                            },
+                            {
+                                "key": "foo]}",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 7,
+                                        "byte": 56
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 20,
+                                        "byte": 69
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 5,
+                                "column": 7,
+                                "byte": 76
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 20,
+                                "byte": 89
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "open",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 7,
+                                        "byte": 76
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 20,
+                                        "byte": 89
+                                    }
+                                }
+                            },
+                            {
+                                "key": "foo",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 7,
+                                        "byte": 76
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 20,
+                                        "byte": 89
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 6,
+                                "column": 7,
+                                "byte": 96
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 17,
+                                "byte": 106
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "array",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 7,
+                                        "byte": 96
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 17,
+                                        "byte": 106
+                                    }
+                                }
+                            },
+                            {
+                                "index": 1,
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 7,
+                                        "byte": 96
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 17,
+                                        "byte": 106
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 7,
+                                "column": 7,
+                                "byte": 113
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 27,
+                                "byte": 133
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "array",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 7,
+                                        "byte": 113
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 27,
+                                        "byte": 133
+                                    }
+                                }
+                            },
+                            {
+                                "index": 0,
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 7,
+                                        "byte": 113
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 27,
+                                        "byte": 133
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 8,
+                                "column": 7,
+                                "byte": 140
+                            },
+                            "end": {
+                                "line": 8,
+                                "column": 10,
+                                "byte": 143
+                            }
+                        },
+                        "schema": true
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 9,
+                                "column": 7,
+                                "byte": 150
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 13,
+                                "byte": 156
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "index": 2,
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 9,
+                                        "column": 7,
+                                        "byte": 150
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 13,
+                                        "byte": 156
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 10,
+                                "column": 7,
+                                "byte": 163
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 19,
+                                "byte": 175
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "2",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 7,
+                                        "byte": 163
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 19,
+                                        "byte": 175
+                                    }
+                                }
+                            },
+                            {
+                                "key": "bad",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 7,
+                                        "byte": 163
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 19,
+                                        "byte": 175
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 11,
+                                "column": 7,
+                                "byte": 182
+                            },
+                            "end": {
+                                "line": 11,
+                                "column": 16,
+                                "byte": 191
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "34",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 7,
+                                        "byte": 182
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 16,
+                                        "byte": 191
+                                    }
+                                }
+                            },
+                            {
+                                "key": "bad",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 7,
+                                        "byte": 182
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 16,
+                                        "byte": 191
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 12,
+                                "column": 7,
+                                "byte": 198
+                            },
+                            "end": {
+                                "line": 12,
+                                "column": 14,
+                                "byte": 205
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "bad",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 7,
+                                        "byte": 198
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 14,
+                                        "byte": 205
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "properties": {
+            "propertyAccessTest": {
+                "value": [
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 7,
+                                    "byte": 36
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 20,
+                                    "byte": 49
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 7,
+                                    "byte": 56
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 20,
+                                    "byte": 69
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 7,
+                                    "byte": 76
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 20,
+                                    "byte": 89
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 7,
+                                    "byte": 96
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 17,
+                                    "byte": 106
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 7,
+                                    "byte": 113
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 27,
+                                    "byte": 133
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 7,
+                                    "byte": 140
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 10,
+                                    "byte": 143
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 7,
+                                    "byte": 150
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 13,
+                                    "byte": 156
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 7,
+                                    "byte": 163
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 19,
+                                    "byte": 175
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 11,
+                                    "column": 7,
+                                    "byte": 182
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 16,
+                                    "byte": 191
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 12,
+                                    "column": 7,
+                                    "byte": 198
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 14,
+                                    "byte": 205
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "invalid-access-load",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 34
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 14,
+                            "byte": 205
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "propertyAccessTest": {
+                    "prefixItems": [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    "items": false,
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "required": [
+                "propertyAccessTest"
+            ]
+        }
+    },
+    "checkJson": {
+        "propertyAccessTest": [
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]"
+        ]
+    },
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"open\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 3,
+                    "Column": 7,
+                    "Byte": 36
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 20,
+                    "Byte": 49
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[0]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"open\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 4,
+                    "Column": 7,
+                    "Byte": 56
+                },
+                "End": {
+                    "Line": 4,
+                    "Column": 20,
+                    "Byte": 69
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[1]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"open\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 5,
+                    "Column": 7,
+                    "Byte": 76
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 20,
+                    "Byte": 89
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[2]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"array\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 6,
+                    "Column": 7,
+                    "Byte": 96
+                },
+                "End": {
+                    "Line": 6,
+                    "Column": 17,
+                    "Byte": 106
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[3]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"array\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 7,
+                    "Column": 7,
+                    "Byte": 113
+                },
+                "End": {
+                    "Line": 7,
+                    "Column": 27,
+                    "Byte": 133
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[4]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "cannot access an object property using an integer index",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 9,
+                    "Column": 7,
+                    "Byte": 150
+                },
+                "End": {
+                    "Line": 9,
+                    "Column": 13,
+                    "Byte": 156
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[6]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"2\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 10,
+                    "Column": 7,
+                    "Byte": 163
+                },
+                "End": {
+                    "Line": 10,
+                    "Column": 19,
+                    "Byte": 175
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[7]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"34\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 11,
+                    "Column": 7,
+                    "Byte": 182
+                },
+                "End": {
+                    "Line": 11,
+                    "Column": 16,
+                    "Byte": 191
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[8]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"bad\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 12,
+                    "Column": 7,
+                    "Byte": 198
+                },
+                "End": {
+                    "Line": 12,
+                    "Column": 14,
+                    "Byte": 205
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[9]"
+        }
+    ],
+    "eval": {
+        "exprs": {
+            "propertyAccessTest": {
+                "range": {
+                    "environment": "invalid-access-load",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 34
+                    },
+                    "end": {
+                        "line": 12,
+                        "column": 14,
+                        "byte": 205
+                    }
+                },
+                "schema": {
+                    "prefixItems": [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    "items": false,
+                    "type": "array"
+                },
+                "list": [
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 3,
+                                "column": 7,
+                                "byte": 36
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 20,
+                                "byte": 49
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "open",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 7,
+                                        "byte": 36
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 20,
+                                        "byte": 49
+                                    }
+                                }
+                            },
+                            {
+                                "key": "foo",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 7,
+                                        "byte": 36
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 20,
+                                        "byte": 49
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 4,
+                                "column": 7,
+                                "byte": 56
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 20,
+                                "byte": 69
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "open",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 7,
+                                        "byte": 56
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 20,
+                                        "byte": 69
+                                    }
+                                }
+                            },
+                            {
+                                "key": "foo]}",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 7,
+                                        "byte": 56
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 20,
+                                        "byte": 69
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 5,
+                                "column": 7,
+                                "byte": 76
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 20,
+                                "byte": 89
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "open",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 7,
+                                        "byte": 76
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 20,
+                                        "byte": 89
+                                    }
+                                }
+                            },
+                            {
+                                "key": "foo",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 7,
+                                        "byte": 76
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 20,
+                                        "byte": 89
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 6,
+                                "column": 7,
+                                "byte": 96
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 17,
+                                "byte": 106
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "array",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 7,
+                                        "byte": 96
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 17,
+                                        "byte": 106
+                                    }
+                                }
+                            },
+                            {
+                                "index": 1,
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 7,
+                                        "byte": 96
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 17,
+                                        "byte": 106
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 7,
+                                "column": 7,
+                                "byte": 113
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 27,
+                                "byte": 133
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "array",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 7,
+                                        "byte": 113
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 27,
+                                        "byte": 133
+                                    }
+                                }
+                            },
+                            {
+                                "index": 0,
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 7,
+                                        "byte": 113
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 27,
+                                        "byte": 133
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 8,
+                                "column": 7,
+                                "byte": 140
+                            },
+                            "end": {
+                                "line": 8,
+                                "column": 10,
+                                "byte": 143
+                            }
+                        },
+                        "schema": true
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 9,
+                                "column": 7,
+                                "byte": 150
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 13,
+                                "byte": 156
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "index": 2,
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 9,
+                                        "column": 7,
+                                        "byte": 150
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 13,
+                                        "byte": 156
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 10,
+                                "column": 7,
+                                "byte": 163
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 19,
+                                "byte": 175
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "2",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 7,
+                                        "byte": 163
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 19,
+                                        "byte": 175
+                                    }
+                                }
+                            },
+                            {
+                                "key": "bad",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 7,
+                                        "byte": 163
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 19,
+                                        "byte": 175
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 11,
+                                "column": 7,
+                                "byte": 182
+                            },
+                            "end": {
+                                "line": 11,
+                                "column": 16,
+                                "byte": 191
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "34",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 7,
+                                        "byte": 182
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 16,
+                                        "byte": 191
+                                    }
+                                }
+                            },
+                            {
+                                "key": "bad",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 7,
+                                        "byte": 182
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 16,
+                                        "byte": 191
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 12,
+                                "column": 7,
+                                "byte": 198
+                            },
+                            "end": {
+                                "line": 12,
+                                "column": 14,
+                                "byte": 205
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "bad",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 7,
+                                        "byte": 198
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 14,
+                                        "byte": 205
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "properties": {
+            "propertyAccessTest": {
+                "value": [
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 7,
+                                    "byte": 36
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 20,
+                                    "byte": 49
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 7,
+                                    "byte": 56
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 20,
+                                    "byte": 69
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 7,
+                                    "byte": 76
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 20,
+                                    "byte": 89
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 7,
+                                    "byte": 96
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 17,
+                                    "byte": 106
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 7,
+                                    "byte": 113
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 27,
+                                    "byte": 133
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 7,
+                                    "byte": 140
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 10,
+                                    "byte": 143
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 7,
+                                    "byte": 150
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 13,
+                                    "byte": 156
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 7,
+                                    "byte": 163
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 19,
+                                    "byte": 175
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 11,
+                                    "column": 7,
+                                    "byte": 182
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 16,
+                                    "byte": 191
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 12,
+                                    "column": 7,
+                                    "byte": 198
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 14,
+                                    "byte": 205
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "invalid-access-load",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 34
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 14,
+                            "byte": 205
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "propertyAccessTest": {
+                    "prefixItems": [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    "items": false,
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "required": [
+                "propertyAccessTest"
+            ]
+        }
+    },
+    "evalJsonRedacted": {
+        "propertyAccessTest": [
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]"
+        ]
+    },
+    "evalJSONRevealed": {
+        "propertyAccessTest": [
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]"
+        ]
+    }
 }

--- a/eval/testdata/eval/invalid-join/env.yaml
+++ b/eval/testdata/eval/invalid-join/env.yaml
@@ -1,0 +1,4 @@
+values:
+  join:
+    fn::join: oops
+  other: value

--- a/eval/testdata/eval/invalid-join/expected.json
+++ b/eval/testdata/eval/invalid-join/expected.json
@@ -1,0 +1,391 @@
+{
+    "loadDiags": [
+        {
+            "Severity": 1,
+            "Summary": "the argument to fn::join must be a two-valued list",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-join",
+                "Start": {
+                    "Line": 3,
+                    "Column": 15,
+                    "Byte": 30
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 19,
+                    "Byte": 34
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.join[\"fn::join\"]"
+        }
+    ],
+    "check": {
+        "exprs": {
+            "join": {
+                "range": {
+                    "environment": "invalid-join",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 20
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 19,
+                        "byte": 34
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "fn::join",
+                    "nameRange": {
+                        "environment": "invalid-join",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 13,
+                            "byte": 28
+                        }
+                    },
+                    "argSchema": {
+                        "prefixItems": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        ],
+                        "items": false,
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "invalid-join",
+                            "begin": {
+                                "line": 3,
+                                "column": 15,
+                                "byte": 30
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 19,
+                                "byte": 34
+                            }
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "invalid-join",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            },
+                            {
+                                "range": {
+                                    "environment": "invalid-join",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            }
+                        ]
+                    }
+                }
+            },
+            "other": {
+                "range": {
+                    "environment": "invalid-join",
+                    "begin": {
+                        "line": 4,
+                        "column": 10,
+                        "byte": 44
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 15,
+                        "byte": 49
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "value"
+                },
+                "literal": "value"
+            }
+        },
+        "properties": {
+            "join": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-join",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 19,
+                            "byte": 34
+                        }
+                    }
+                }
+            },
+            "other": {
+                "value": "value",
+                "trace": {
+                    "def": {
+                        "environment": "invalid-join",
+                        "begin": {
+                            "line": 4,
+                            "column": 10,
+                            "byte": 44
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 15,
+                            "byte": 49
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "join": {
+                    "type": "string"
+                },
+                "other": {
+                    "type": "string",
+                    "const": "value"
+                }
+            },
+            "type": "object",
+            "required": [
+                "join",
+                "other"
+            ]
+        }
+    },
+    "checkJson": {
+        "join": "[unknown]",
+        "other": "value"
+    },
+    "eval": {
+        "exprs": {
+            "join": {
+                "range": {
+                    "environment": "invalid-join",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 20
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 19,
+                        "byte": 34
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "fn::join",
+                    "nameRange": {
+                        "environment": "invalid-join",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 13,
+                            "byte": 28
+                        }
+                    },
+                    "argSchema": {
+                        "prefixItems": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        ],
+                        "items": false,
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "invalid-join",
+                            "begin": {
+                                "line": 3,
+                                "column": 15,
+                                "byte": 30
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 19,
+                                "byte": 34
+                            }
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "invalid-join",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            },
+                            {
+                                "range": {
+                                    "environment": "invalid-join",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            }
+                        ]
+                    }
+                }
+            },
+            "other": {
+                "range": {
+                    "environment": "invalid-join",
+                    "begin": {
+                        "line": 4,
+                        "column": 10,
+                        "byte": 44
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 15,
+                        "byte": 49
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "value"
+                },
+                "literal": "value"
+            }
+        },
+        "properties": {
+            "join": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-join",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 19,
+                            "byte": 34
+                        }
+                    }
+                }
+            },
+            "other": {
+                "value": "value",
+                "trace": {
+                    "def": {
+                        "environment": "invalid-join",
+                        "begin": {
+                            "line": 4,
+                            "column": 10,
+                            "byte": 44
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 15,
+                            "byte": 49
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "join": {
+                    "type": "string"
+                },
+                "other": {
+                    "type": "string",
+                    "const": "value"
+                }
+            },
+            "type": "object",
+            "required": [
+                "join",
+                "other"
+            ]
+        }
+    },
+    "evalJsonRedacted": {
+        "join": "[unknown]",
+        "other": "value"
+    },
+    "evalJSONRevealed": {
+        "join": "[unknown]",
+        "other": "value"
+    }
+}

--- a/eval/testdata/eval/invalid-open/env.yaml
+++ b/eval/testdata/eval/invalid-open/env.yaml
@@ -1,0 +1,11 @@
+values:
+  missing-provider:
+    fn::open:
+      inputs: inputs
+  missing-inputs:
+    fn::open:
+      provider: test
+  invalid-provider:
+    fn::open:
+      provider: [ oops ]
+      inputs: inputs

--- a/eval/testdata/eval/invalid-open/expected.json
+++ b/eval/testdata/eval/invalid-open/expected.json
@@ -1,0 +1,816 @@
+{
+    "loadDiags": [
+        {
+            "Severity": 1,
+            "Summary": "missing provider name ('provider')",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-open",
+                "Start": {
+                    "Line": 4,
+                    "Column": 7,
+                    "Byte": 48
+                },
+                "End": {
+                    "Line": 4,
+                    "Column": 21,
+                    "Byte": 62
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values[\"missing-provider\"][\"fn::open\"]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "missing provider inputs ('inputs')",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-open",
+                "Start": {
+                    "Line": 7,
+                    "Column": 7,
+                    "Byte": 101
+                },
+                "End": {
+                    "Line": 7,
+                    "Column": 21,
+                    "Byte": 115
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values[\"missing-inputs\"][\"fn::open\"]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "provider name must be a string literal",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-open",
+                "Start": {
+                    "Line": 10,
+                    "Column": 17,
+                    "Byte": 166
+                },
+                "End": {
+                    "Line": 10,
+                    "Column": 23,
+                    "Byte": 172
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values[\"invalid-provider\"][\"fn::open\"].provider"
+        }
+    ],
+    "check": {
+        "exprs": {
+            "invalid-provider": {
+                "range": {
+                    "environment": "invalid-open",
+                    "begin": {
+                        "line": 9,
+                        "column": 5,
+                        "byte": 140
+                    },
+                    "end": {
+                        "line": 11,
+                        "column": 21,
+                        "byte": 195
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::open",
+                    "nameRange": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 9,
+                            "column": 5,
+                            "byte": 140
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 13,
+                            "byte": 148
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 15,
+                                        "byte": 189
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 21,
+                                        "byte": 195
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "inputs"
+                                },
+                                "literal": "inputs"
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            }
+                        }
+                    }
+                }
+            },
+            "missing-inputs": {
+                "range": {
+                    "environment": "invalid-open",
+                    "begin": {
+                        "line": 6,
+                        "column": 5,
+                        "byte": 85
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 21,
+                        "byte": 115
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::open",
+                    "nameRange": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 85
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 13,
+                            "byte": 93
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 17,
+                                        "byte": 111
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 21,
+                                        "byte": 115
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "test"
+                                },
+                                "literal": "test"
+                            }
+                        }
+                    }
+                }
+            },
+            "missing-provider": {
+                "range": {
+                    "environment": "invalid-open",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 32
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 21,
+                        "byte": 62
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::open",
+                    "nameRange": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 32
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 13,
+                            "byte": 40
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 15,
+                                        "byte": 56
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 21,
+                                        "byte": 62
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "inputs"
+                                },
+                                "literal": "inputs"
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "invalid-provider": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 9,
+                            "column": 5,
+                            "byte": 140
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 21,
+                            "byte": 195
+                        }
+                    }
+                }
+            },
+            "missing-inputs": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 85
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 21,
+                            "byte": 115
+                        }
+                    }
+                }
+            },
+            "missing-provider": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 32
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 21,
+                            "byte": 62
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "invalid-provider": true,
+                "missing-inputs": true,
+                "missing-provider": true
+            },
+            "type": "object",
+            "required": [
+                "invalid-provider",
+                "missing-inputs",
+                "missing-provider"
+            ]
+        }
+    },
+    "checkJson": {
+        "invalid-provider": "[unknown]",
+        "missing-inputs": "[unknown]",
+        "missing-provider": "[unknown]"
+    },
+    "eval": {
+        "exprs": {
+            "invalid-provider": {
+                "range": {
+                    "environment": "invalid-open",
+                    "begin": {
+                        "line": 9,
+                        "column": 5,
+                        "byte": 140
+                    },
+                    "end": {
+                        "line": 11,
+                        "column": 21,
+                        "byte": 195
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::open",
+                    "nameRange": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 9,
+                            "column": 5,
+                            "byte": 140
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 13,
+                            "byte": 148
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 15,
+                                        "byte": 189
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 21,
+                                        "byte": 195
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "inputs"
+                                },
+                                "literal": "inputs"
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            }
+                        }
+                    }
+                }
+            },
+            "missing-inputs": {
+                "range": {
+                    "environment": "invalid-open",
+                    "begin": {
+                        "line": 6,
+                        "column": 5,
+                        "byte": 85
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 21,
+                        "byte": 115
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::open",
+                    "nameRange": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 85
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 13,
+                            "byte": 93
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 17,
+                                        "byte": 111
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 21,
+                                        "byte": 115
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "test"
+                                },
+                                "literal": "test"
+                            }
+                        }
+                    }
+                }
+            },
+            "missing-provider": {
+                "range": {
+                    "environment": "invalid-open",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 32
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 21,
+                        "byte": 62
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::open",
+                    "nameRange": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 32
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 13,
+                            "byte": 40
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 15,
+                                        "byte": 56
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 21,
+                                        "byte": 62
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "inputs"
+                                },
+                                "literal": "inputs"
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "invalid-provider": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 9,
+                            "column": 5,
+                            "byte": 140
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 21,
+                            "byte": 195
+                        }
+                    }
+                }
+            },
+            "missing-inputs": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 85
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 21,
+                            "byte": 115
+                        }
+                    }
+                }
+            },
+            "missing-provider": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 32
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 21,
+                            "byte": 62
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "invalid-provider": true,
+                "missing-inputs": true,
+                "missing-provider": true
+            },
+            "type": "object",
+            "required": [
+                "invalid-provider",
+                "missing-inputs",
+                "missing-provider"
+            ]
+        }
+    },
+    "evalJsonRedacted": {
+        "invalid-provider": "[unknown]",
+        "missing-inputs": "[unknown]",
+        "missing-provider": "[unknown]"
+    },
+    "evalJSONRevealed": {
+        "invalid-provider": "[unknown]",
+        "missing-inputs": "[unknown]",
+        "missing-provider": "[unknown]"
+    }
+}

--- a/eval/testdata/eval/invalid-plaintext/env.yaml
+++ b/eval/testdata/eval/invalid-plaintext/env.yaml
@@ -1,0 +1,6 @@
+values:
+  foo:
+    fn::secret: [ some, list ]
+  bar:
+    a: valid
+    object: here

--- a/eval/testdata/eval/invalid-plaintext/expected.json
+++ b/eval/testdata/eval/invalid-plaintext/expected.json
@@ -1,0 +1,584 @@
+{
+    "loadDiags": [
+        {
+            "Severity": 1,
+            "Summary": "secret values must be string literals",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-plaintext",
+                "Start": {
+                    "Line": 3,
+                    "Column": 17,
+                    "Byte": 31
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 29,
+                    "Byte": 43
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.foo[\"fn::secret\"]"
+        }
+    ],
+    "check": {
+        "exprs": {
+            "bar": {
+                "range": {
+                    "environment": "invalid-plaintext",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 57
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 17,
+                        "byte": 82
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "valid"
+                        },
+                        "object": {
+                            "type": "string",
+                            "const": "here"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "object"
+                    ]
+                },
+                "keyRanges": {
+                    "a": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 57
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 6,
+                            "byte": 58
+                        }
+                    },
+                    "object": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 70
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 11,
+                            "byte": 76
+                        }
+                    }
+                },
+                "object": {
+                    "a": {
+                        "range": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 5,
+                                "column": 8,
+                                "byte": 60
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 13,
+                                "byte": 65
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "valid"
+                        },
+                        "literal": "valid"
+                    },
+                    "object": {
+                        "range": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 6,
+                                "column": 13,
+                                "byte": 78
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 17,
+                                "byte": 82
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "here"
+                        },
+                        "literal": "here"
+                    }
+                }
+            },
+            "foo": {
+                "range": {
+                    "environment": "invalid-plaintext",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 19
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 29,
+                        "byte": 43
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": ""
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 19
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 29
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": ""
+                        },
+                        "literal": ""
+                    }
+                }
+            }
+        },
+        "properties": {
+            "bar": {
+                "value": {
+                    "a": {
+                        "value": "valid",
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-plaintext",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 8,
+                                    "byte": 60
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 13,
+                                    "byte": 65
+                                }
+                            }
+                        }
+                    },
+                    "object": {
+                        "value": "here",
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-plaintext",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 13,
+                                    "byte": 78
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 17,
+                                    "byte": 82
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 57
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 17,
+                            "byte": 82
+                        }
+                    }
+                }
+            },
+            "foo": {
+                "value": "",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 0,
+                            "column": 0,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 0,
+                            "column": 0,
+                            "byte": 0
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "bar": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "valid"
+                        },
+                        "object": {
+                            "type": "string",
+                            "const": "here"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "object"
+                    ]
+                },
+                "foo": {
+                    "type": "string",
+                    "const": ""
+                }
+            },
+            "type": "object",
+            "required": [
+                "bar",
+                "foo"
+            ]
+        }
+    },
+    "checkJson": {
+        "bar": {
+            "a": "valid",
+            "object": "here"
+        },
+        "foo": "[secret]"
+    },
+    "eval": {
+        "exprs": {
+            "bar": {
+                "range": {
+                    "environment": "invalid-plaintext",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 57
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 17,
+                        "byte": 82
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "valid"
+                        },
+                        "object": {
+                            "type": "string",
+                            "const": "here"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "object"
+                    ]
+                },
+                "keyRanges": {
+                    "a": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 57
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 6,
+                            "byte": 58
+                        }
+                    },
+                    "object": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 70
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 11,
+                            "byte": 76
+                        }
+                    }
+                },
+                "object": {
+                    "a": {
+                        "range": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 5,
+                                "column": 8,
+                                "byte": 60
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 13,
+                                "byte": 65
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "valid"
+                        },
+                        "literal": "valid"
+                    },
+                    "object": {
+                        "range": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 6,
+                                "column": 13,
+                                "byte": 78
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 17,
+                                "byte": 82
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "here"
+                        },
+                        "literal": "here"
+                    }
+                }
+            },
+            "foo": {
+                "range": {
+                    "environment": "invalid-plaintext",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 19
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 29,
+                        "byte": 43
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": ""
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 19
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 29
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": ""
+                        },
+                        "literal": ""
+                    }
+                }
+            }
+        },
+        "properties": {
+            "bar": {
+                "value": {
+                    "a": {
+                        "value": "valid",
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-plaintext",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 8,
+                                    "byte": 60
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 13,
+                                    "byte": 65
+                                }
+                            }
+                        }
+                    },
+                    "object": {
+                        "value": "here",
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-plaintext",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 13,
+                                    "byte": 78
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 17,
+                                    "byte": 82
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 57
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 17,
+                            "byte": 82
+                        }
+                    }
+                }
+            },
+            "foo": {
+                "value": "",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 0,
+                            "column": 0,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 0,
+                            "column": 0,
+                            "byte": 0
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "bar": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "valid"
+                        },
+                        "object": {
+                            "type": "string",
+                            "const": "here"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "object"
+                    ]
+                },
+                "foo": {
+                    "type": "string",
+                    "const": ""
+                }
+            },
+            "type": "object",
+            "required": [
+                "bar",
+                "foo"
+            ]
+        }
+    },
+    "evalJsonRedacted": {
+        "bar": {
+            "a": "valid",
+            "object": "here"
+        },
+        "foo": "[secret]"
+    },
+    "evalJSONRevealed": {
+        "bar": {
+            "a": "valid",
+            "object": "here"
+        },
+        "foo": ""
+    }
+}


### PR DESCRIPTION
These changes add support for evaluating environment decls that contain parse errors. All current parse errors manifest as missing nodes. These changes add a `missingExpr` expression type to handle those cases. Missing expressions are treated as `any`-typed null literals.

The primary benefit of these changes is that they enable type checking environments with parse errors (i.e. calling `CheckEnvironment`). This is important for live analysis scenarios.