### PR TITLE
ast: clarify property name parser

### DIFF
--- a/ast/interpolation.go
+++ b/ast/interpolation.go
@@ -36,6 +36,7 @@ func parseInterpolate(node syntax.Node, value string) ([]Interpolation, syntax.D
 			value = value[2:]
 		case strings.HasPrefix(value, "${"):
 			rest, access, accessDiags := parsePropertyAccess(node, value[2:])
+
 			diags.Extend(accessDiags...)
 			parts = append(parts, Interpolation{
 				Text:  str.String(),

--- a/ast/testdata/parse/invalid-interpolations/expected.json
+++ b/ast/testdata/parse/invalid-interpolations/expected.json
@@ -50,6 +50,9 @@
                                             "Accessors": [
                                                 {
                                                     "Name": "property"
+                                                },
+                                                {
+                                                    "Name": ""
                                                 }
                                             ]
                                         }
@@ -68,6 +71,9 @@
                                             "Accessors": [
                                                 {
                                                     "Name": "property"
+                                                },
+                                                {
+                                                    "Index": ""
                                                 }
                                             ]
                                         }
@@ -105,7 +111,7 @@
                                                     "Name": "integer"
                                                 },
                                                 {
-                                                    "Index": 0
+                                                    "Index": "subscript"
                                                 }
                                             ]
                                         }
@@ -167,7 +173,30 @@
         },
         {
             "Severity": 1,
-            "Summary": "missing closing bracket in list index",
+            "Summary": "missing property name",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-interpolations",
+                "Start": {
+                    "Line": 6,
+                    "Column": 7,
+                    "Byte": 86
+                },
+                "End": {
+                    "Line": 6,
+                    "Column": 32,
+                    "Byte": 111
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.interpolations[3]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "invalid list index",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-interpolations",
@@ -190,7 +219,53 @@
         },
         {
             "Severity": 1,
-            "Summary": "missing closing quote in property name",
+            "Summary": "missing closing bracket in subscript",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-interpolations",
+                "Start": {
+                    "Line": 7,
+                    "Column": 7,
+                    "Byte": 118
+                },
+                "End": {
+                    "Line": 7,
+                    "Column": 37,
+                    "Byte": 148
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.interpolations[4]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "missing closing quote in subscript",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-interpolations",
+                "Start": {
+                    "Line": 8,
+                    "Column": 7,
+                    "Byte": 155
+                },
+                "End": {
+                    "Line": 8,
+                    "Column": 31,
+                    "Byte": 179
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.interpolations[5]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "missing closing bracket in subscript",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-interpolations",

--- a/eval/testdata/eval/invalid-access-load/expected.json
+++ b/eval/testdata/eval/invalid-access-load/expected.json
@@ -25,7 +25,7 @@
         },
         {
             "Severity": 1,
-            "Summary": "missing closing bracket in property access",
+            "Summary": "missing closing bracket in subscript",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-access-load",
@@ -48,7 +48,30 @@
         },
         {
             "Severity": 1,
-            "Summary": "missing closing quote in property name",
+            "Summary": "missing closing quote in subscript",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 5,
+                    "Column": 7,
+                    "Byte": 65
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 20,
+                    "Byte": 78
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[2]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "missing closing bracket in subscript",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-access-load",
@@ -117,30 +140,7 @@
         },
         {
             "Severity": 1,
-            "Summary": "missing closing bracket in list index",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-access-load",
-                "Start": {
-                    "Line": 7,
-                    "Column": 7,
-                    "Byte": 105
-                },
-                "End": {
-                    "Line": 7,
-                    "Column": 17,
-                    "Byte": 115
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.propertyAccessTest[4]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "unterminated interpolation",
+            "Summary": "missing closing bracket in subscript",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-access-load",
@@ -209,7 +209,7 @@
         },
         {
             "Severity": 1,
-            "Summary": "the root property must be a string subscript or a name",
+            "Summary": "missing property name",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-access-load",
@@ -229,29 +229,6 @@
             "EvalContext": null,
             "Extra": null,
             "Path": "values.propertyAccessTest[8]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "the root property must be a string subscript or a name",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-access-load",
-                "Start": {
-                    "Line": 12,
-                    "Column": 7,
-                    "Byte": 191
-                },
-                "End": {
-                    "Line": 12,
-                    "Column": 16,
-                    "Byte": 200
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.propertyAccessTest[9]"
         },
         {
             "Severity": 1,
@@ -833,7 +810,7 @@
                                 }
                             },
                             {
-                                "index": 0,
+                                "key": "notAnIndex",
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -936,6 +913,22 @@
                         "symbol": [
                             {
                                 "key": "2",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 7,
+                                        "byte": 172
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 19,
+                                        "byte": 184
+                                    }
+                                }
+                            },
+                            {
+                                "key": "",
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1871,7 +1864,7 @@
                                 }
                             },
                             {
-                                "index": 0,
+                                "key": "notAnIndex",
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1974,6 +1967,22 @@
                         "symbol": [
                             {
                                 "key": "2",
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 7,
+                                        "byte": 172
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 19,
+                                        "byte": 184
+                                    }
+                                }
+                            },
+                            {
+                                "key": "",
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {


### PR DESCRIPTION
The property access parser has been getting increasingly gnarly, and will continue to do so as it evolves to handle accessor ranges. These changes refactor the parser for simplicity and clarity. As a nice side-effect, they also improve some error reporting.