### PR TITLE
eval: merge final environment schema

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,4 +3,7 @@
 - Allow evaluation of environments with parse errors.
   [#222](https://github.com/pulumi/esc/pull/222)
 
+- Return a properly-merged root schema from environment evaluation.
+  [#229](https://github.com/pulumi/esc/pull/229)
+
 ### Bug Fixes

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -112,12 +112,11 @@ func evalEnvironment(
 
 	s := schema.Never().Schema()
 	if v != nil {
-		object := v.repr.(map[string]*value)
-		properties := make(map[string]schema.Builder, len(object))
-		for k, v := range object {
-			properties[k] = v.schema
+		if v.base != nil {
+			s = mergedSchema(v.base.schema, v.schema)
+		} else {
+			s = v.schema
 		}
-		s = schema.Record(properties).Schema()
 	}
 
 	return &esc.Environment{

--- a/eval/testdata/eval/import-merge-2/expected.json
+++ b/eval/testdata/eval/import-merge-2/expected.json
@@ -149,7 +149,29 @@
             }
         },
         "schema": {
-            "type": "object"
+            "properties": {
+                "alpha": {
+                    "type": "string",
+                    "const": "beta"
+                },
+                "some_object": {
+                    "properties": {
+                        "baz": {
+                            "type": "string",
+                            "const": "qux"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "baz"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "alpha",
+                "some_object"
+            ]
         }
     },
     "checkJson": {
@@ -345,7 +367,39 @@
             }
         },
         "schema": {
-            "type": "object"
+            "properties": {
+                "alpha": {
+                    "type": "string",
+                    "const": "beta"
+                },
+                "some_object": {
+                    "properties": {
+                        "baz": {
+                            "type": "string",
+                            "const": "qux"
+                        },
+                        "beta": {
+                            "type": "string",
+                            "const": "gamma"
+                        },
+                        "foo": {
+                            "type": "string",
+                            "const": "bar"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "baz",
+                        "beta",
+                        "foo"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "alpha",
+                "some_object"
+            ]
         }
     },
     "evalJsonRedacted": {

--- a/eval/testdata/eval/import-merge/expected.json
+++ b/eval/testdata/eval/import-merge/expected.json
@@ -113,7 +113,34 @@
             }
         },
         "schema": {
-            "type": "object"
+            "properties": {
+                "alpha": {
+                    "type": "string",
+                    "const": "beta"
+                },
+                "some_object": {
+                    "properties": {
+                        "baz": {
+                            "type": "string",
+                            "const": "qux"
+                        },
+                        "foo": {
+                            "type": "string",
+                            "const": "bar"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "baz",
+                        "foo"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "alpha",
+                "some_object"
+            ]
         }
     },
     "checkJson": {
@@ -237,7 +264,34 @@
             }
         },
         "schema": {
-            "type": "object"
+            "properties": {
+                "alpha": {
+                    "type": "string",
+                    "const": "beta"
+                },
+                "some_object": {
+                    "properties": {
+                        "baz": {
+                            "type": "string",
+                            "const": "qux"
+                        },
+                        "foo": {
+                            "type": "string",
+                            "const": "bar"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "baz",
+                        "foo"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "alpha",
+                "some_object"
+            ]
         }
     },
     "evalJsonRedacted": {

--- a/eval/testdata/eval/imports/expected.json
+++ b/eval/testdata/eval/imports/expected.json
@@ -1060,6 +1060,10 @@
                     "items": false,
                     "type": "array"
                 },
+                "some_number": {
+                    "type": "number",
+                    "const": 42
+                },
                 "some_object": {
                     "properties": {
                         "alpha": {
@@ -1109,6 +1113,7 @@
             "type": "object",
             "required": [
                 "some_list",
+                "some_number",
                 "some_object",
                 "some_string"
             ]
@@ -2192,6 +2197,10 @@
                     "items": false,
                     "type": "array"
                 },
+                "some_number": {
+                    "type": "number",
+                    "const": 42
+                },
                 "some_object": {
                     "properties": {
                         "alpha": {
@@ -2241,6 +2250,7 @@
             "type": "object",
             "required": [
                 "some_list",
+                "some_number",
                 "some_object",
                 "some_string"
             ]

--- a/eval/testdata/eval/invalid-access/expected.json
+++ b/eval/testdata/eval/invalid-access/expected.json
@@ -3848,6 +3848,18 @@
                     },
                     "type": "object"
                 },
+                "otherObject": {
+                    "properties": {
+                        "foo": {
+                            "type": "string",
+                            "const": "bar"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "foo"
+                    ]
+                },
                 "string": {
                     "type": "string",
                     "const": "esc"
@@ -3860,6 +3872,7 @@
                 "myObject",
                 "object",
                 "open",
+                "otherObject",
                 "string"
             ]
         }
@@ -8106,6 +8119,18 @@
                         "tuple"
                     ]
                 },
+                "otherObject": {
+                    "properties": {
+                        "foo": {
+                            "type": "string",
+                            "const": "bar"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "foo"
+                    ]
+                },
                 "string": {
                     "type": "string",
                     "const": "esc"
@@ -8118,6 +8143,7 @@
                 "myObject",
                 "object",
                 "open",
+                "otherObject",
                 "string"
             ]
         }

--- a/eval/testdata/eval/omnibus/expected.json
+++ b/eval/testdata/eval/omnibus/expected.json
@@ -1358,6 +1358,20 @@
                     "type": "string",
                     "const": "hunter2"
                 },
+                "strings": {
+                    "prefixItems": [
+                        {
+                            "type": "string",
+                            "const": "hello"
+                        },
+                        {
+                            "type": "string",
+                            "const": "world"
+                        }
+                    ],
+                    "items": false,
+                    "type": "array"
+                },
                 "toBase64": {
                     "type": "string"
                 },
@@ -1378,6 +1392,7 @@
                 "open",
                 "open2",
                 "secret",
+                "strings",
                 "toBase64",
                 "toJSON",
                 "toString"
@@ -3515,6 +3530,20 @@
                     "type": "string",
                     "const": "hunter2"
                 },
+                "strings": {
+                    "prefixItems": [
+                        {
+                            "type": "string",
+                            "const": "hello"
+                        },
+                        {
+                            "type": "string",
+                            "const": "world"
+                        }
+                    ],
+                    "items": false,
+                    "type": "array"
+                },
                 "toBase64": {
                     "type": "string"
                 },
@@ -3535,6 +3564,7 @@
                 "open",
                 "open2",
                 "secret",
+                "strings",
                 "toBase64",
                 "toJSON",
                 "toString"


### PR DESCRIPTION
The schema returned by the evaluator did not represent the schema of the final, merged value. These changes correct that mistake.