### PR TITLE
ast: ranges for accessors in single-line flow strings

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,4 +9,7 @@
 - Improve property accessor diagnostics.
   [#230](https://github.com/pulumi/esc/pull/230)
 
+- Populate source positions for property accessors in single-line flow scalars.
+  [#231](https://github.com/pulumi/esc/pull/231)
+
 ### Bug Fixes

--- a/ast/interpolation.go
+++ b/ast/interpolation.go
@@ -29,13 +29,14 @@ func parseInterpolate(node syntax.Node, value string) ([]Interpolation, syntax.D
 	var parts []Interpolation
 	var str strings.Builder
 	var diags syntax.Diagnostics
+	offset := 0
 	for len(value) > 0 {
 		switch {
 		case strings.HasPrefix(value, "$$"):
 			str.WriteByte('$')
-			value = value[2:]
+			value, offset = value[2:], offset+2
 		case strings.HasPrefix(value, "${"):
-			rest, access, accessDiags := parsePropertyAccess(node, value[2:])
+			end, rest, access, accessDiags := parsePropertyAccess(node, offset+2, value[2:])
 
 			diags.Extend(accessDiags...)
 			parts = append(parts, Interpolation{
@@ -44,10 +45,10 @@ func parseInterpolate(node syntax.Node, value string) ([]Interpolation, syntax.D
 			})
 			str.Reset()
 
-			value = rest
+			value, offset = rest, end
 		default:
 			str.WriteByte(value[0])
-			value = value[1:]
+			value, offset = value[1:], offset+1
 		}
 	}
 	if str.Len() != 0 {

--- a/ast/testdata/parse/invalid-interpolations/env.yaml
+++ b/ast/testdata/parse/invalid-interpolations/env.yaml
@@ -2,6 +2,7 @@ values:
   interpolations:
     - ${
     - ${}
+    - ${foo.
     - unterminated ${interpolation
     - missing ${property.} name
     - missing ${property[} subscript

--- a/ast/testdata/parse/invalid-interpolations/expected.json
+++ b/ast/testdata/parse/invalid-interpolations/expected.json
@@ -14,7 +14,20 @@
                                 "Property": {
                                     "Accessors": [
                                         {
-                                            "Name": ""
+                                            "Name": "",
+                                            "AccessorRange": {
+                                                "Filename": "invalid-interpolations",
+                                                "Start": {
+                                                    "Line": 3,
+                                                    "Column": 9,
+                                                    "Byte": 34
+                                                },
+                                                "End": {
+                                                    "Line": 3,
+                                                    "Column": 9,
+                                                    "Byte": 34
+                                                }
+                                            }
                                         }
                                     ]
                                 }
@@ -23,7 +36,58 @@
                                 "Property": {
                                     "Accessors": [
                                         {
-                                            "Name": ""
+                                            "Name": "",
+                                            "AccessorRange": {
+                                                "Filename": "invalid-interpolations",
+                                                "Start": {
+                                                    "Line": 4,
+                                                    "Column": 9,
+                                                    "Byte": 43
+                                                },
+                                                "End": {
+                                                    "Line": 4,
+                                                    "Column": 10,
+                                                    "Byte": 44
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Property": {
+                                    "Accessors": [
+                                        {
+                                            "Name": "foo",
+                                            "AccessorRange": {
+                                                "Filename": "invalid-interpolations",
+                                                "Start": {
+                                                    "Line": 5,
+                                                    "Column": 9,
+                                                    "Byte": 53
+                                                },
+                                                "End": {
+                                                    "Line": 5,
+                                                    "Column": 12,
+                                                    "Byte": 56
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "Name": "",
+                                            "AccessorRange": {
+                                                "Filename": "invalid-interpolations",
+                                                "Start": {
+                                                    "Line": 5,
+                                                    "Column": 12,
+                                                    "Byte": 56
+                                                },
+                                                "End": {
+                                                    "Line": 5,
+                                                    "Column": 13,
+                                                    "Byte": 57
+                                                }
+                                            }
                                         }
                                     ]
                                 }
@@ -35,7 +99,20 @@
                                         "Value": {
                                             "Accessors": [
                                                 {
-                                                    "Name": "interpolation"
+                                                    "Name": "interpolation",
+                                                    "AccessorRange": {
+                                                        "Filename": "invalid-interpolations",
+                                                        "Start": {
+                                                            "Line": 6,
+                                                            "Column": 22,
+                                                            "Byte": 79
+                                                        },
+                                                        "End": {
+                                                            "Line": 6,
+                                                            "Column": 35,
+                                                            "Byte": 92
+                                                        }
+                                                    }
                                                 }
                                             ]
                                         }
@@ -49,10 +126,36 @@
                                         "Value": {
                                             "Accessors": [
                                                 {
-                                                    "Name": "property"
+                                                    "Name": "property",
+                                                    "AccessorRange": {
+                                                        "Filename": "invalid-interpolations",
+                                                        "Start": {
+                                                            "Line": 7,
+                                                            "Column": 17,
+                                                            "Byte": 109
+                                                        },
+                                                        "End": {
+                                                            "Line": 7,
+                                                            "Column": 25,
+                                                            "Byte": 117
+                                                        }
+                                                    }
                                                 },
                                                 {
-                                                    "Name": ""
+                                                    "Name": "",
+                                                    "AccessorRange": {
+                                                        "Filename": "invalid-interpolations",
+                                                        "Start": {
+                                                            "Line": 7,
+                                                            "Column": 25,
+                                                            "Byte": 117
+                                                        },
+                                                        "End": {
+                                                            "Line": 7,
+                                                            "Column": 26,
+                                                            "Byte": 118
+                                                        }
+                                                    }
                                                 }
                                             ]
                                         }
@@ -70,10 +173,36 @@
                                         "Value": {
                                             "Accessors": [
                                                 {
-                                                    "Name": "property"
+                                                    "Name": "property",
+                                                    "AccessorRange": {
+                                                        "Filename": "invalid-interpolations",
+                                                        "Start": {
+                                                            "Line": 8,
+                                                            "Column": 17,
+                                                            "Byte": 141
+                                                        },
+                                                        "End": {
+                                                            "Line": 8,
+                                                            "Column": 25,
+                                                            "Byte": 149
+                                                        }
+                                                    }
                                                 },
                                                 {
-                                                    "Index": ""
+                                                    "Index": "",
+                                                    "AccessorRange": {
+                                                        "Filename": "invalid-interpolations",
+                                                        "Start": {
+                                                            "Line": 8,
+                                                            "Column": 25,
+                                                            "Byte": 149
+                                                        },
+                                                        "End": {
+                                                            "Line": 8,
+                                                            "Column": 26,
+                                                            "Byte": 150
+                                                        }
+                                                    }
                                                 }
                                             ]
                                         }
@@ -91,10 +220,36 @@
                                         "Value": {
                                             "Accessors": [
                                                 {
-                                                    "Name": "closing"
+                                                    "Name": "closing",
+                                                    "AccessorRange": {
+                                                        "Filename": "invalid-interpolations",
+                                                        "Start": {
+                                                            "Line": 9,
+                                                            "Column": 17,
+                                                            "Byte": 178
+                                                        },
+                                                        "End": {
+                                                            "Line": 9,
+                                                            "Column": 24,
+                                                            "Byte": 185
+                                                        }
+                                                    }
                                                 },
                                                 {
-                                                    "Index": "quote"
+                                                    "Index": "quote",
+                                                    "AccessorRange": {
+                                                        "Filename": "invalid-interpolations",
+                                                        "Start": {
+                                                            "Line": 9,
+                                                            "Column": 24,
+                                                            "Byte": 185
+                                                        },
+                                                        "End": {
+                                                            "Line": 9,
+                                                            "Column": 31,
+                                                            "Byte": 192
+                                                        }
+                                                    }
                                                 }
                                             ]
                                         }
@@ -108,10 +263,36 @@
                                         "Value": {
                                             "Accessors": [
                                                 {
-                                                    "Name": "integer"
+                                                    "Name": "integer",
+                                                    "AccessorRange": {
+                                                        "Filename": "invalid-interpolations",
+                                                        "Start": {
+                                                            "Line": 10,
+                                                            "Column": 17,
+                                                            "Byte": 209
+                                                        },
+                                                        "End": {
+                                                            "Line": 10,
+                                                            "Column": 24,
+                                                            "Byte": 216
+                                                        }
+                                                    }
                                                 },
                                                 {
-                                                    "Index": "subscript"
+                                                    "Index": "subscript",
+                                                    "AccessorRange": {
+                                                        "Filename": "invalid-interpolations",
+                                                        "Start": {
+                                                            "Line": 10,
+                                                            "Column": 24,
+                                                            "Byte": 216
+                                                        },
+                                                        "End": {
+                                                            "Line": 10,
+                                                            "Column": 35,
+                                                            "Byte": 227
+                                                        }
+                                                    }
                                                 }
                                             ]
                                         }
@@ -150,6 +331,29 @@
         },
         {
             "Severity": 1,
+            "Summary": "property name must not be empty",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-interpolations",
+                "Start": {
+                    "Line": 5,
+                    "Column": 7,
+                    "Byte": 51
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 13,
+                    "Byte": 57
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.interpolations[2]"
+        },
+        {
+            "Severity": 1,
             "Summary": "missing closing brace '}' in interpolation",
             "Detail": "",
             "Subject": {
@@ -161,8 +365,8 @@
                 },
                 "End": {
                     "Line": 5,
-                    "Column": 35,
-                    "Byte": 79
+                    "Column": 13,
+                    "Byte": 57
                 }
             },
             "Context": null,
@@ -173,19 +377,19 @@
         },
         {
             "Severity": 1,
-            "Summary": "property name must not be empty",
+            "Summary": "missing closing brace '}' in interpolation",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-interpolations",
                 "Start": {
                     "Line": 6,
                     "Column": 7,
-                    "Byte": 86
+                    "Byte": 64
                 },
                 "End": {
                     "Line": 6,
-                    "Column": 32,
-                    "Byte": 111
+                    "Column": 35,
+                    "Byte": 92
                 }
             },
             "Context": null,
@@ -196,19 +400,19 @@
         },
         {
             "Severity": 1,
-            "Summary": "numeric subscript must be a positive base-10 integer",
+            "Summary": "property name must not be empty",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-interpolations",
                 "Start": {
                     "Line": 7,
                     "Column": 7,
-                    "Byte": 118
+                    "Byte": 99
                 },
                 "End": {
                     "Line": 7,
-                    "Column": 37,
-                    "Byte": 148
+                    "Column": 32,
+                    "Byte": 124
                 }
             },
             "Context": null,
@@ -219,26 +423,49 @@
         },
         {
             "Severity": 1,
-            "Summary": "subscript is missing closing bracket ']'",
+            "Summary": "numeric subscript must be a positive base-10 integer",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-interpolations",
                 "Start": {
-                    "Line": 7,
+                    "Line": 8,
                     "Column": 7,
-                    "Byte": 118
+                    "Byte": 131
                 },
                 "End": {
-                    "Line": 7,
+                    "Line": 8,
                     "Column": 37,
-                    "Byte": 148
+                    "Byte": 161
                 }
             },
             "Context": null,
             "Expression": null,
             "EvalContext": null,
             "Extra": null,
-            "Path": "values.interpolations[4]"
+            "Path": "values.interpolations[5]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "subscript is missing closing bracket ']'",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-interpolations",
+                "Start": {
+                    "Line": 8,
+                    "Column": 7,
+                    "Byte": 131
+                },
+                "End": {
+                    "Line": 8,
+                    "Column": 37,
+                    "Byte": 161
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.interpolations[5]"
         },
         {
             "Severity": 1,
@@ -247,21 +474,21 @@
             "Subject": {
                 "Filename": "invalid-interpolations",
                 "Start": {
-                    "Line": 8,
+                    "Line": 9,
                     "Column": 7,
-                    "Byte": 155
+                    "Byte": 168
                 },
                 "End": {
-                    "Line": 8,
+                    "Line": 9,
                     "Column": 31,
-                    "Byte": 179
+                    "Byte": 192
                 }
             },
             "Context": null,
             "Expression": null,
             "EvalContext": null,
             "Extra": null,
-            "Path": "values.interpolations[5]"
+            "Path": "values.interpolations[6]"
         },
         {
             "Severity": 1,
@@ -270,21 +497,21 @@
             "Subject": {
                 "Filename": "invalid-interpolations",
                 "Start": {
-                    "Line": 8,
+                    "Line": 9,
                     "Column": 7,
-                    "Byte": 155
+                    "Byte": 168
                 },
                 "End": {
-                    "Line": 8,
+                    "Line": 9,
                     "Column": 31,
-                    "Byte": 179
+                    "Byte": 192
                 }
             },
             "Context": null,
             "Expression": null,
             "EvalContext": null,
             "Extra": null,
-            "Path": "values.interpolations[5]"
+            "Path": "values.interpolations[6]"
         },
         {
             "Severity": 1,
@@ -293,21 +520,21 @@
             "Subject": {
                 "Filename": "invalid-interpolations",
                 "Start": {
-                    "Line": 8,
+                    "Line": 9,
                     "Column": 7,
-                    "Byte": 155
+                    "Byte": 168
                 },
                 "End": {
-                    "Line": 8,
+                    "Line": 9,
                     "Column": 31,
-                    "Byte": 179
+                    "Byte": 192
                 }
             },
             "Context": null,
             "Expression": null,
             "EvalContext": null,
             "Extra": null,
-            "Path": "values.interpolations[5]"
+            "Path": "values.interpolations[6]"
         },
         {
             "Severity": 1,
@@ -316,21 +543,21 @@
             "Subject": {
                 "Filename": "invalid-interpolations",
                 "Start": {
-                    "Line": 9,
+                    "Line": 10,
                     "Column": 7,
-                    "Byte": 186
+                    "Byte": 199
                 },
                 "End": {
-                    "Line": 9,
+                    "Line": 10,
                     "Column": 36,
-                    "Byte": 215
+                    "Byte": 228
                 }
             },
             "Context": null,
             "Expression": null,
             "EvalContext": null,
             "Extra": null,
-            "Path": "values.interpolations[6]"
+            "Path": "values.interpolations[7]"
         }
     ]
 }

--- a/cmd/esc/cli/testdata/open-json-error.yaml
+++ b/cmd/esc/cli/testdata/open-json-error.yaml
@@ -9,5 +9,5 @@ stdout: |
   > esc open test --format json
 stderr: |
   > esc open test --format json
-  test:3:14: unknown property "foo"
+  test:3:16: unknown property "foo"
   test:4:31: expected string, got object

--- a/eval/testdata/eval/builtin-combine/expected.json
+++ b/eval/testdata/eval/builtin-combine/expected.json
@@ -163,6 +163,19 @@
                                                 "symbol": [
                                                     {
                                                         "key": "password",
+                                                        "range": {
+                                                            "environment": "builtin-combine",
+                                                            "begin": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            },
+                                                            "end": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            }
+                                                        },
                                                         "value": {
                                                             "environment": "builtin-combine",
                                                             "begin": {
@@ -197,6 +210,19 @@
                                                 "symbol": [
                                                     {
                                                         "key": "open",
+                                                        "range": {
+                                                            "environment": "builtin-combine",
+                                                            "begin": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            },
+                                                            "end": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            }
+                                                        },
                                                         "value": {
                                                             "environment": "builtin-combine",
                                                             "begin": {
@@ -213,6 +239,19 @@
                                                     },
                                                     {
                                                         "key": "foo",
+                                                        "range": {
+                                                            "environment": "builtin-combine",
+                                                            "begin": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            },
+                                                            "end": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            }
+                                                        },
                                                         "value": {
                                                             "environment": "builtin-combine",
                                                             "begin": {
@@ -292,6 +331,19 @@
                                         "value": [
                                             {
                                                 "key": "password",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -313,6 +365,19 @@
                                         "value": [
                                             {
                                                 "key": "open",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -329,6 +394,19 @@
                                             },
                                             {
                                                 "key": "foo",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -404,6 +482,19 @@
                                         "value": [
                                             {
                                                 "key": "password",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -425,6 +516,19 @@
                                         "value": [
                                             {
                                                 "key": "open",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -441,6 +545,19 @@
                                             },
                                             {
                                                 "key": "foo",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -516,6 +633,19 @@
                                         "value": [
                                             {
                                                 "key": "password",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -537,6 +667,19 @@
                                         "value": [
                                             {
                                                 "key": "open",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -553,6 +696,19 @@
                                             },
                                             {
                                                 "key": "foo",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -1074,6 +1230,19 @@
                                                 "symbol": [
                                                     {
                                                         "key": "password",
+                                                        "range": {
+                                                            "environment": "builtin-combine",
+                                                            "begin": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            },
+                                                            "end": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            }
+                                                        },
                                                         "value": {
                                                             "environment": "builtin-combine",
                                                             "begin": {
@@ -1111,6 +1280,19 @@
                                                 "symbol": [
                                                     {
                                                         "key": "open",
+                                                        "range": {
+                                                            "environment": "builtin-combine",
+                                                            "begin": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            },
+                                                            "end": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            }
+                                                        },
                                                         "value": {
                                                             "environment": "builtin-combine",
                                                             "begin": {
@@ -1127,6 +1309,19 @@
                                                     },
                                                     {
                                                         "key": "foo",
+                                                        "range": {
+                                                            "environment": "builtin-combine",
+                                                            "begin": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            },
+                                                            "end": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            }
+                                                        },
                                                         "value": {
                                                             "environment": "builtin-combine",
                                                             "begin": {
@@ -1206,6 +1401,19 @@
                                         "value": [
                                             {
                                                 "key": "password",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -1227,6 +1435,19 @@
                                         "value": [
                                             {
                                                 "key": "open",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -1243,6 +1464,19 @@
                                             },
                                             {
                                                 "key": "foo",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -1318,6 +1552,19 @@
                                         "value": [
                                             {
                                                 "key": "password",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -1339,6 +1586,19 @@
                                         "value": [
                                             {
                                                 "key": "open",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -1355,6 +1615,19 @@
                                             },
                                             {
                                                 "key": "foo",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -1430,6 +1703,19 @@
                                         "value": [
                                             {
                                                 "key": "password",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -1451,6 +1737,19 @@
                                         "value": [
                                             {
                                                 "key": "open",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {
@@ -1467,6 +1766,19 @@
                                             },
                                             {
                                                 "key": "foo",
+                                                "range": {
+                                                    "environment": "builtin-combine",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-combine",
                                                     "begin": {

--- a/eval/testdata/eval/builtin-errs/expected.json
+++ b/eval/testdata/eval/builtin-errs/expected.json
@@ -253,6 +253,19 @@
                                 "symbol": [
                                     {
                                         "key": "missing",
+                                        "range": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
                                         "value": {
                                             "environment": "builtin-errs",
                                             "begin": {
@@ -371,6 +384,19 @@
                                         "symbol": [
                                             {
                                                 "key": "missing",
+                                                "range": {
+                                                    "environment": "builtin-errs",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-errs",
                                                     "begin": {
@@ -519,6 +545,19 @@
                                                 "symbol": [
                                                     {
                                                         "key": "number",
+                                                        "range": {
+                                                            "environment": "builtin-errs",
+                                                            "begin": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            },
+                                                            "end": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            }
+                                                        },
                                                         "value": {
                                                             "environment": "builtin-errs",
                                                             "begin": {
@@ -594,6 +633,19 @@
                                 "symbol": [
                                     {
                                         "key": "missing",
+                                        "range": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
                                         "value": {
                                             "environment": "builtin-errs",
                                             "begin": {
@@ -668,6 +720,19 @@
                                 "symbol": [
                                     {
                                         "key": "number",
+                                        "range": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
                                         "value": {
                                             "environment": "builtin-errs",
                                             "begin": {
@@ -737,6 +802,19 @@
                                 "symbol": [
                                     {
                                         "key": "missing",
+                                        "range": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
                                         "value": {
                                             "environment": "builtin-errs",
                                             "begin": {
@@ -806,6 +884,19 @@
                                 "symbol": [
                                     {
                                         "key": "missing",
+                                        "range": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
                                         "value": {
                                             "environment": "builtin-errs",
                                             "begin": {
@@ -1317,6 +1408,19 @@
                                 "symbol": [
                                     {
                                         "key": "missing",
+                                        "range": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
                                         "value": {
                                             "environment": "builtin-errs",
                                             "begin": {
@@ -1435,6 +1539,19 @@
                                         "symbol": [
                                             {
                                                 "key": "missing",
+                                                "range": {
+                                                    "environment": "builtin-errs",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "builtin-errs",
                                                     "begin": {
@@ -1583,6 +1700,19 @@
                                                 "symbol": [
                                                     {
                                                         "key": "number",
+                                                        "range": {
+                                                            "environment": "builtin-errs",
+                                                            "begin": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            },
+                                                            "end": {
+                                                                "line": 0,
+                                                                "column": 0,
+                                                                "byte": 0
+                                                            }
+                                                        },
                                                         "value": {
                                                             "environment": "builtin-errs",
                                                             "begin": {
@@ -1658,6 +1788,19 @@
                                 "symbol": [
                                     {
                                         "key": "missing",
+                                        "range": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
                                         "value": {
                                             "environment": "builtin-errs",
                                             "begin": {
@@ -1732,6 +1875,19 @@
                                 "symbol": [
                                     {
                                         "key": "number",
+                                        "range": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
                                         "value": {
                                             "environment": "builtin-errs",
                                             "begin": {
@@ -1801,6 +1957,19 @@
                                 "symbol": [
                                     {
                                         "key": "missing",
+                                        "range": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
                                         "value": {
                                             "environment": "builtin-errs",
                                             "begin": {
@@ -1870,6 +2039,19 @@
                                 "symbol": [
                                     {
                                         "key": "missing",
+                                        "range": {
+                                            "environment": "builtin-errs",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
                                         "value": {
                                             "environment": "builtin-errs",
                                             "begin": {

--- a/eval/testdata/eval/cycle/expected.json
+++ b/eval/testdata/eval/cycle/expected.json
@@ -106,6 +106,19 @@
                         "symbol": [
                             {
                                 "key": "a",
+                                "range": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 10,
+                                        "byte": 22
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 11,
+                                        "byte": 23
+                                    }
+                                },
                                 "value": {
                                     "environment": "cycle",
                                     "begin": {
@@ -122,6 +135,19 @@
                             },
                             {
                                 "key": "p",
+                                "range": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 11,
+                                        "byte": 23
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 13,
+                                        "byte": 25
+                                    }
+                                },
                                 "value": {
                                     "environment": "cycle",
                                     "begin": {
@@ -197,6 +223,19 @@
                         "symbol": [
                             {
                                 "key": "c",
+                                "range": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 10,
+                                        "byte": 41
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 11,
+                                        "byte": 42
+                                    }
+                                },
                                 "value": {
                                     "environment": "cycle",
                                     "begin": {
@@ -213,6 +252,19 @@
                             },
                             {
                                 "key": "p",
+                                "range": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 11,
+                                        "byte": 42
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 13,
+                                        "byte": 44
+                                    }
+                                },
                                 "value": {
                                     "environment": "cycle",
                                     "begin": {
@@ -288,6 +340,19 @@
                         "symbol": [
                             {
                                 "key": "b",
+                                "range": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 10,
+                                        "byte": 60
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 11,
+                                        "byte": 61
+                                    }
+                                },
                                 "value": {
                                     "environment": "cycle",
                                     "begin": {
@@ -304,6 +369,19 @@
                             },
                             {
                                 "key": "p",
+                                "range": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 11,
+                                        "byte": 61
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 13,
+                                        "byte": 63
+                                    }
+                                },
                                 "value": {
                                     "environment": "cycle",
                                     "begin": {
@@ -592,6 +670,19 @@
                         "symbol": [
                             {
                                 "key": "a",
+                                "range": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 10,
+                                        "byte": 22
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 11,
+                                        "byte": 23
+                                    }
+                                },
                                 "value": {
                                     "environment": "cycle",
                                     "begin": {
@@ -608,6 +699,19 @@
                             },
                             {
                                 "key": "p",
+                                "range": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 11,
+                                        "byte": 23
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 13,
+                                        "byte": 25
+                                    }
+                                },
                                 "value": {
                                     "environment": "cycle",
                                     "begin": {
@@ -683,6 +787,19 @@
                         "symbol": [
                             {
                                 "key": "c",
+                                "range": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 10,
+                                        "byte": 41
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 11,
+                                        "byte": 42
+                                    }
+                                },
                                 "value": {
                                     "environment": "cycle",
                                     "begin": {
@@ -699,6 +816,19 @@
                             },
                             {
                                 "key": "p",
+                                "range": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 11,
+                                        "byte": 42
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 13,
+                                        "byte": 44
+                                    }
+                                },
                                 "value": {
                                     "environment": "cycle",
                                     "begin": {
@@ -774,6 +904,19 @@
                         "symbol": [
                             {
                                 "key": "b",
+                                "range": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 10,
+                                        "byte": 60
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 11,
+                                        "byte": 61
+                                    }
+                                },
                                 "value": {
                                     "environment": "cycle",
                                     "begin": {
@@ -790,6 +933,19 @@
                             },
                             {
                                 "key": "p",
+                                "range": {
+                                    "environment": "cycle",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 11,
+                                        "byte": 61
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 13,
+                                        "byte": 63
+                                    }
+                                },
                                 "value": {
                                     "environment": "cycle",
                                     "begin": {

--- a/eval/testdata/eval/imports/expected.json
+++ b/eval/testdata/eval/imports/expected.json
@@ -461,6 +461,19 @@
                         "symbol": [
                             {
                                 "key": "imports",
+                                "range": {
+                                    "environment": "imports",
+                                    "begin": {
+                                        "line": 14,
+                                        "column": 13,
+                                        "byte": 192
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 20,
+                                        "byte": 199
+                                    }
+                                },
                                 "value": {
                                     "environment": "imports",
                                     "begin": {
@@ -477,6 +490,19 @@
                             },
                             {
                                 "key": "c",
+                                "range": {
+                                    "environment": "imports",
+                                    "begin": {
+                                        "line": 14,
+                                        "column": 20,
+                                        "byte": 199
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 22,
+                                        "byte": 201
+                                    }
+                                },
                                 "value": {
                                     "environment": "imports",
                                     "begin": {
@@ -493,6 +519,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "imports",
+                                    "begin": {
+                                        "line": 14,
+                                        "column": 22,
+                                        "byte": 201
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 26,
+                                        "byte": 205
+                                    }
+                                },
                                 "value": {
                                     "environment": "c",
                                     "begin": {
@@ -570,6 +609,19 @@
                         "symbol": [
                             {
                                 "key": "some_object",
+                                "range": {
+                                    "environment": "imports",
+                                    "begin": {
+                                        "line": 15,
+                                        "column": 12,
+                                        "byte": 218
+                                    },
+                                    "end": {
+                                        "line": 15,
+                                        "column": 23,
+                                        "byte": 229
+                                    }
+                                },
                                 "value": {
                                     "environment": "imports",
                                     "begin": {
@@ -586,6 +638,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "imports",
+                                    "begin": {
+                                        "line": 15,
+                                        "column": 23,
+                                        "byte": 229
+                                    },
+                                    "end": {
+                                        "line": 15,
+                                        "column": 27,
+                                        "byte": 233
+                                    }
+                                },
                                 "value": {
                                     "environment": "b",
                                     "begin": {
@@ -1598,6 +1663,19 @@
                         "symbol": [
                             {
                                 "key": "imports",
+                                "range": {
+                                    "environment": "imports",
+                                    "begin": {
+                                        "line": 14,
+                                        "column": 13,
+                                        "byte": 192
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 20,
+                                        "byte": 199
+                                    }
+                                },
                                 "value": {
                                     "environment": "imports",
                                     "begin": {
@@ -1614,6 +1692,19 @@
                             },
                             {
                                 "key": "c",
+                                "range": {
+                                    "environment": "imports",
+                                    "begin": {
+                                        "line": 14,
+                                        "column": 20,
+                                        "byte": 199
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 22,
+                                        "byte": 201
+                                    }
+                                },
                                 "value": {
                                     "environment": "imports",
                                     "begin": {
@@ -1630,6 +1721,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "imports",
+                                    "begin": {
+                                        "line": 14,
+                                        "column": 22,
+                                        "byte": 201
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 26,
+                                        "byte": 205
+                                    }
+                                },
                                 "value": {
                                     "environment": "c",
                                     "begin": {
@@ -1707,6 +1811,19 @@
                         "symbol": [
                             {
                                 "key": "some_object",
+                                "range": {
+                                    "environment": "imports",
+                                    "begin": {
+                                        "line": 15,
+                                        "column": 12,
+                                        "byte": 218
+                                    },
+                                    "end": {
+                                        "line": 15,
+                                        "column": 23,
+                                        "byte": 229
+                                    }
+                                },
                                 "value": {
                                     "environment": "imports",
                                     "begin": {
@@ -1723,6 +1840,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "imports",
+                                    "begin": {
+                                        "line": 15,
+                                        "column": 23,
+                                        "byte": 229
+                                    },
+                                    "end": {
+                                        "line": 15,
+                                        "column": 27,
+                                        "byte": 233
+                                    }
+                                },
                                 "value": {
                                     "environment": "b",
                                     "begin": {

--- a/eval/testdata/eval/interp/expected.json
+++ b/eval/testdata/eval/interp/expected.json
@@ -192,6 +192,19 @@
                         "symbol": [
                             {
                                 "key": "a",
+                                "range": {
+                                    "environment": "interp",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 10,
+                                        "byte": 22
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 11,
+                                        "byte": 23
+                                    }
+                                },
                                 "value": {
                                     "environment": "interp",
                                     "begin": {
@@ -208,6 +221,19 @@
                             },
                             {
                                 "key": "q",
+                                "range": {
+                                    "environment": "interp",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 11,
+                                        "byte": 23
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 13,
+                                        "byte": 25
+                                    }
+                                },
                                 "value": {
                                     "environment": "interp",
                                     "begin": {
@@ -373,6 +399,19 @@
                         "symbol": [
                             {
                                 "key": "a",
+                                "range": {
+                                    "environment": "interp",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 10,
+                                        "byte": 77
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 11,
+                                        "byte": 78
+                                    }
+                                },
                                 "value": {
                                     "environment": "interp",
                                     "begin": {
@@ -389,6 +428,19 @@
                             },
                             {
                                 "key": "p",
+                                "range": {
+                                    "environment": "interp",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 11,
+                                        "byte": 78
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 13,
+                                        "byte": 80
+                                    }
+                                },
                                 "value": {
                                     "environment": "interp",
                                     "begin": {
@@ -563,6 +615,19 @@
                                 "symbol": [
                                     {
                                         "key": "b",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 10,
+                                                "column": 11,
+                                                "byte": 104
+                                            },
+                                            "end": {
+                                                "line": 10,
+                                                "column": 12,
+                                                "byte": 105
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
@@ -579,6 +644,19 @@
                                     },
                                     {
                                         "key": "p",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 10,
+                                                "column": 12,
+                                                "byte": 105
+                                            },
+                                            "end": {
+                                                "line": 10,
+                                                "column": 14,
+                                                "byte": 107
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
@@ -618,6 +696,19 @@
                                         "value": [
                                             {
                                                 "key": "c",
+                                                "range": {
+                                                    "environment": "interp",
+                                                    "begin": {
+                                                        "line": 11,
+                                                        "column": 18,
+                                                        "byte": 126
+                                                    },
+                                                    "end": {
+                                                        "line": 11,
+                                                        "column": 19,
+                                                        "byte": 127
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "interp",
                                                     "begin": {
@@ -634,6 +725,19 @@
                                             },
                                             {
                                                 "key": "b",
+                                                "range": {
+                                                    "environment": "interp",
+                                                    "begin": {
+                                                        "line": 11,
+                                                        "column": 19,
+                                                        "byte": 127
+                                                    },
+                                                    "end": {
+                                                        "line": 11,
+                                                        "column": 21,
+                                                        "byte": 129
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "interp",
                                                     "begin": {
@@ -674,6 +778,19 @@
                                         "value": [
                                             {
                                                 "key": "c",
+                                                "range": {
+                                                    "environment": "interp",
+                                                    "begin": {
+                                                        "line": 12,
+                                                        "column": 11,
+                                                        "byte": 141
+                                                    },
+                                                    "end": {
+                                                        "line": 12,
+                                                        "column": 12,
+                                                        "byte": 142
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "interp",
                                                     "begin": {
@@ -690,6 +807,19 @@
                                             },
                                             {
                                                 "key": "a",
+                                                "range": {
+                                                    "environment": "interp",
+                                                    "begin": {
+                                                        "line": 12,
+                                                        "column": 12,
+                                                        "byte": 142
+                                                    },
+                                                    "end": {
+                                                        "line": 12,
+                                                        "column": 14,
+                                                        "byte": 144
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "interp",
                                                     "begin": {
@@ -706,6 +836,19 @@
                                             },
                                             {
                                                 "index": 0,
+                                                "range": {
+                                                    "environment": "interp",
+                                                    "begin": {
+                                                        "line": 12,
+                                                        "column": 14,
+                                                        "byte": 144
+                                                    },
+                                                    "end": {
+                                                        "line": 12,
+                                                        "column": 17,
+                                                        "byte": 147
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "interp",
                                                     "begin": {
@@ -803,6 +946,19 @@
                                 "symbol": [
                                     {
                                         "key": "a",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 15,
+                                                "column": 11,
+                                                "byte": 184
+                                            },
+                                            "end": {
+                                                "line": 15,
+                                                "column": 12,
+                                                "byte": 185
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
@@ -819,6 +975,19 @@
                                     },
                                     {
                                         "key": "u",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 15,
+                                                "column": 12,
+                                                "byte": 185
+                                            },
+                                            "end": {
+                                                "line": 15,
+                                                "column": 14,
+                                                "byte": 187
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
@@ -835,6 +1004,19 @@
                                     },
                                     {
                                         "key": "\"baz",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 15,
+                                                "column": 14,
+                                                "byte": 187
+                                            },
+                                            "end": {
+                                                "line": 15,
+                                                "column": 23,
+                                                "byte": 196
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
@@ -872,6 +1054,19 @@
                                 "symbol": [
                                     {
                                         "key": "34",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 16,
+                                                "column": 11,
+                                                "byte": 208
+                                            },
+                                            "end": {
+                                                "line": 16,
+                                                "column": 17,
+                                                "byte": 214
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
@@ -909,6 +1104,19 @@
                                 "symbol": [
                                     {
                                         "key": "35",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 11,
+                                                "byte": 226
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 17,
+                                                "byte": 232
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
@@ -925,6 +1133,19 @@
                                     },
                                     {
                                         "key": "okay",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 17,
+                                                "byte": 232
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 22,
+                                                "byte": 237
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
@@ -1656,6 +1877,19 @@
                         "symbol": [
                             {
                                 "key": "a",
+                                "range": {
+                                    "environment": "interp",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 10,
+                                        "byte": 22
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 11,
+                                        "byte": 23
+                                    }
+                                },
                                 "value": {
                                     "environment": "interp",
                                     "begin": {
@@ -1672,6 +1906,19 @@
                             },
                             {
                                 "key": "q",
+                                "range": {
+                                    "environment": "interp",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 11,
+                                        "byte": 23
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 13,
+                                        "byte": 25
+                                    }
+                                },
                                 "value": {
                                     "environment": "interp",
                                     "begin": {
@@ -1837,6 +2084,19 @@
                         "symbol": [
                             {
                                 "key": "a",
+                                "range": {
+                                    "environment": "interp",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 10,
+                                        "byte": 77
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 11,
+                                        "byte": 78
+                                    }
+                                },
                                 "value": {
                                     "environment": "interp",
                                     "begin": {
@@ -1853,6 +2113,19 @@
                             },
                             {
                                 "key": "p",
+                                "range": {
+                                    "environment": "interp",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 11,
+                                        "byte": 78
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 13,
+                                        "byte": 80
+                                    }
+                                },
                                 "value": {
                                     "environment": "interp",
                                     "begin": {
@@ -2027,6 +2300,19 @@
                                 "symbol": [
                                     {
                                         "key": "b",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 10,
+                                                "column": 11,
+                                                "byte": 104
+                                            },
+                                            "end": {
+                                                "line": 10,
+                                                "column": 12,
+                                                "byte": 105
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
@@ -2043,6 +2329,19 @@
                                     },
                                     {
                                         "key": "p",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 10,
+                                                "column": 12,
+                                                "byte": 105
+                                            },
+                                            "end": {
+                                                "line": 10,
+                                                "column": 14,
+                                                "byte": 107
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
@@ -2082,6 +2381,19 @@
                                         "value": [
                                             {
                                                 "key": "c",
+                                                "range": {
+                                                    "environment": "interp",
+                                                    "begin": {
+                                                        "line": 11,
+                                                        "column": 18,
+                                                        "byte": 126
+                                                    },
+                                                    "end": {
+                                                        "line": 11,
+                                                        "column": 19,
+                                                        "byte": 127
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "interp",
                                                     "begin": {
@@ -2098,6 +2410,19 @@
                                             },
                                             {
                                                 "key": "b",
+                                                "range": {
+                                                    "environment": "interp",
+                                                    "begin": {
+                                                        "line": 11,
+                                                        "column": 19,
+                                                        "byte": 127
+                                                    },
+                                                    "end": {
+                                                        "line": 11,
+                                                        "column": 21,
+                                                        "byte": 129
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "interp",
                                                     "begin": {
@@ -2138,6 +2463,19 @@
                                         "value": [
                                             {
                                                 "key": "c",
+                                                "range": {
+                                                    "environment": "interp",
+                                                    "begin": {
+                                                        "line": 12,
+                                                        "column": 11,
+                                                        "byte": 141
+                                                    },
+                                                    "end": {
+                                                        "line": 12,
+                                                        "column": 12,
+                                                        "byte": 142
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "interp",
                                                     "begin": {
@@ -2154,6 +2492,19 @@
                                             },
                                             {
                                                 "key": "a",
+                                                "range": {
+                                                    "environment": "interp",
+                                                    "begin": {
+                                                        "line": 12,
+                                                        "column": 12,
+                                                        "byte": 142
+                                                    },
+                                                    "end": {
+                                                        "line": 12,
+                                                        "column": 14,
+                                                        "byte": 144
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "interp",
                                                     "begin": {
@@ -2170,6 +2521,19 @@
                                             },
                                             {
                                                 "index": 0,
+                                                "range": {
+                                                    "environment": "interp",
+                                                    "begin": {
+                                                        "line": 12,
+                                                        "column": 14,
+                                                        "byte": 144
+                                                    },
+                                                    "end": {
+                                                        "line": 12,
+                                                        "column": 17,
+                                                        "byte": 147
+                                                    }
+                                                },
                                                 "value": {
                                                     "environment": "interp",
                                                     "begin": {
@@ -2267,6 +2631,19 @@
                                 "symbol": [
                                     {
                                         "key": "a",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 15,
+                                                "column": 11,
+                                                "byte": 184
+                                            },
+                                            "end": {
+                                                "line": 15,
+                                                "column": 12,
+                                                "byte": 185
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
@@ -2283,6 +2660,19 @@
                                     },
                                     {
                                         "key": "u",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 15,
+                                                "column": 12,
+                                                "byte": 185
+                                            },
+                                            "end": {
+                                                "line": 15,
+                                                "column": 14,
+                                                "byte": 187
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
@@ -2299,6 +2689,19 @@
                                     },
                                     {
                                         "key": "\"baz",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 15,
+                                                "column": 14,
+                                                "byte": 187
+                                            },
+                                            "end": {
+                                                "line": 15,
+                                                "column": 23,
+                                                "byte": 196
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
@@ -2336,6 +2739,19 @@
                                 "symbol": [
                                     {
                                         "key": "34",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 16,
+                                                "column": 11,
+                                                "byte": 208
+                                            },
+                                            "end": {
+                                                "line": 16,
+                                                "column": 17,
+                                                "byte": 214
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
@@ -2373,6 +2789,19 @@
                                 "symbol": [
                                     {
                                         "key": "35",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 11,
+                                                "byte": 226
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 17,
+                                                "byte": 232
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {
@@ -2389,6 +2818,19 @@
                                     },
                                     {
                                         "key": "okay",
+                                        "range": {
+                                            "environment": "interp",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 17,
+                                                "byte": 232
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 22,
+                                                "byte": 237
+                                            }
+                                        },
                                         "value": {
                                             "environment": "interp",
                                             "begin": {

--- a/eval/testdata/eval/invalid-access-load/expected.json
+++ b/eval/testdata/eval/invalid-access-load/expected.json
@@ -240,8 +240,8 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 3,
-                    "Column": 7,
-                    "Byte": 36
+                    "Column": 9,
+                    "Byte": 38
                 },
                 "End": {
                     "Line": 3,
@@ -263,13 +263,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 4,
-                    "Column": 7,
-                    "Byte": 45
+                    "Column": 9,
+                    "Byte": 47
                 },
                 "End": {
                     "Line": 4,
-                    "Column": 20,
-                    "Byte": 58
+                    "Column": 13,
+                    "Byte": 51
                 }
             },
             "Context": null,
@@ -286,13 +286,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 5,
-                    "Column": 7,
-                    "Byte": 65
+                    "Column": 9,
+                    "Byte": 67
                 },
                 "End": {
                     "Line": 5,
-                    "Column": 20,
-                    "Byte": 78
+                    "Column": 13,
+                    "Byte": 71
                 }
             },
             "Context": null,
@@ -309,13 +309,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 6,
-                    "Column": 7,
-                    "Byte": 85
+                    "Column": 9,
+                    "Byte": 87
                 },
                 "End": {
                     "Line": 6,
-                    "Column": 20,
-                    "Byte": 98
+                    "Column": 13,
+                    "Byte": 91
                 }
             },
             "Context": null,
@@ -332,13 +332,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 7,
-                    "Column": 7,
-                    "Byte": 105
+                    "Column": 9,
+                    "Byte": 107
                 },
                 "End": {
                     "Line": 7,
-                    "Column": 17,
-                    "Byte": 115
+                    "Column": 14,
+                    "Byte": 112
                 }
             },
             "Context": null,
@@ -355,13 +355,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 8,
-                    "Column": 7,
-                    "Byte": 122
+                    "Column": 9,
+                    "Byte": 124
                 },
                 "End": {
                     "Line": 8,
-                    "Column": 27,
-                    "Byte": 142
+                    "Column": 14,
+                    "Byte": 129
                 }
             },
             "Context": null,
@@ -378,8 +378,8 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 9,
-                    "Column": 7,
-                    "Byte": 149
+                    "Column": 9,
+                    "Byte": 151
                 },
                 "End": {
                     "Line": 9,
@@ -401,13 +401,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 10,
-                    "Column": 7,
-                    "Byte": 159
+                    "Column": 9,
+                    "Byte": 161
                 },
                 "End": {
                     "Line": 10,
-                    "Column": 13,
-                    "Byte": 165
+                    "Column": 12,
+                    "Byte": 164
                 }
             },
             "Context": null,
@@ -424,13 +424,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 11,
-                    "Column": 7,
-                    "Byte": 172
+                    "Column": 9,
+                    "Byte": 174
                 },
                 "End": {
                     "Line": 11,
-                    "Column": 19,
-                    "Byte": 184
+                    "Column": 10,
+                    "Byte": 175
                 }
             },
             "Context": null,
@@ -447,13 +447,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 12,
-                    "Column": 7,
-                    "Byte": 191
+                    "Column": 9,
+                    "Byte": 193
                 },
                 "End": {
                     "Line": 12,
-                    "Column": 16,
-                    "Byte": 200
+                    "Column": 11,
+                    "Byte": 195
                 }
             },
             "Context": null,
@@ -470,13 +470,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 13,
-                    "Column": 7,
-                    "Byte": 207
+                    "Column": 9,
+                    "Byte": 209
                 },
                 "End": {
                     "Line": 13,
-                    "Column": 14,
-                    "Byte": 214
+                    "Column": 13,
+                    "Byte": 213
                 }
             },
             "Context": null,
@@ -538,6 +538,19 @@
                         "symbol": [
                             {
                                 "key": "",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 9,
+                                        "byte": 38
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 9,
+                                        "byte": 38
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -572,6 +585,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 9,
+                                        "byte": 47
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 13,
+                                        "byte": 51
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -588,6 +614,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 13,
+                                        "byte": 51
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 19,
+                                        "byte": 57
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -622,6 +661,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 9,
+                                        "byte": 67
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 13,
+                                        "byte": 71
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -638,6 +690,19 @@
                             },
                             {
                                 "key": "foo]}",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 13,
+                                        "byte": 71
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 20,
+                                        "byte": 78
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -672,6 +737,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 9,
+                                        "byte": 87
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 13,
+                                        "byte": 91
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -688,6 +766,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 13,
+                                        "byte": 91
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 20,
+                                        "byte": 98
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -722,6 +813,19 @@
                         "symbol": [
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 9,
+                                        "byte": 107
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 14,
+                                        "byte": 112
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -738,6 +842,19 @@
                             },
                             {
                                 "index": 1,
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 14,
+                                        "byte": 112
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 16,
+                                        "byte": 114
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -772,6 +889,19 @@
                         "symbol": [
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 9,
+                                        "byte": 124
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 14,
+                                        "byte": 129
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -788,6 +918,19 @@
                             },
                             {
                                 "key": "notAnIndex",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 14,
+                                        "byte": 129
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 26,
+                                        "byte": 141
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -822,6 +965,19 @@
                         "symbol": [
                             {
                                 "key": "",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 9,
+                                        "column": 9,
+                                        "byte": 151
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 10,
+                                        "byte": 152
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -856,6 +1012,19 @@
                         "symbol": [
                             {
                                 "index": 2,
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 9,
+                                        "byte": 161
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 12,
+                                        "byte": 164
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -890,6 +1059,19 @@
                         "symbol": [
                             {
                                 "key": "2",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 9,
+                                        "byte": 174
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 10,
+                                        "byte": 175
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -906,6 +1088,19 @@
                             },
                             {
                                 "key": "",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 10,
+                                        "byte": 175
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 11,
+                                        "byte": 176
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -922,6 +1117,19 @@
                             },
                             {
                                 "key": "bad",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 11,
+                                        "byte": 176
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 18,
+                                        "byte": 183
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -956,6 +1164,19 @@
                         "symbol": [
                             {
                                 "key": "34",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 9,
+                                        "byte": 193
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 11,
+                                        "byte": 195
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -972,6 +1193,19 @@
                             },
                             {
                                 "key": "bad",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 11,
+                                        "byte": 195
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 15,
+                                        "byte": 199
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1006,6 +1240,19 @@
                         "symbol": [
                             {
                                 "key": "bad",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 13,
+                                        "column": 9,
+                                        "byte": 209
+                                    },
+                                    "end": {
+                                        "line": 13,
+                                        "column": 13,
+                                        "byte": 213
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1294,8 +1541,8 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 3,
-                    "Column": 7,
-                    "Byte": 36
+                    "Column": 9,
+                    "Byte": 38
                 },
                 "End": {
                     "Line": 3,
@@ -1317,13 +1564,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 4,
-                    "Column": 7,
-                    "Byte": 45
+                    "Column": 9,
+                    "Byte": 47
                 },
                 "End": {
                     "Line": 4,
-                    "Column": 20,
-                    "Byte": 58
+                    "Column": 13,
+                    "Byte": 51
                 }
             },
             "Context": null,
@@ -1340,13 +1587,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 5,
-                    "Column": 7,
-                    "Byte": 65
+                    "Column": 9,
+                    "Byte": 67
                 },
                 "End": {
                     "Line": 5,
-                    "Column": 20,
-                    "Byte": 78
+                    "Column": 13,
+                    "Byte": 71
                 }
             },
             "Context": null,
@@ -1363,13 +1610,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 6,
-                    "Column": 7,
-                    "Byte": 85
+                    "Column": 9,
+                    "Byte": 87
                 },
                 "End": {
                     "Line": 6,
-                    "Column": 20,
-                    "Byte": 98
+                    "Column": 13,
+                    "Byte": 91
                 }
             },
             "Context": null,
@@ -1386,13 +1633,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 7,
-                    "Column": 7,
-                    "Byte": 105
+                    "Column": 9,
+                    "Byte": 107
                 },
                 "End": {
                     "Line": 7,
-                    "Column": 17,
-                    "Byte": 115
+                    "Column": 14,
+                    "Byte": 112
                 }
             },
             "Context": null,
@@ -1409,13 +1656,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 8,
-                    "Column": 7,
-                    "Byte": 122
+                    "Column": 9,
+                    "Byte": 124
                 },
                 "End": {
                     "Line": 8,
-                    "Column": 27,
-                    "Byte": 142
+                    "Column": 14,
+                    "Byte": 129
                 }
             },
             "Context": null,
@@ -1432,8 +1679,8 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 9,
-                    "Column": 7,
-                    "Byte": 149
+                    "Column": 9,
+                    "Byte": 151
                 },
                 "End": {
                     "Line": 9,
@@ -1455,13 +1702,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 10,
-                    "Column": 7,
-                    "Byte": 159
+                    "Column": 9,
+                    "Byte": 161
                 },
                 "End": {
                     "Line": 10,
-                    "Column": 13,
-                    "Byte": 165
+                    "Column": 12,
+                    "Byte": 164
                 }
             },
             "Context": null,
@@ -1478,13 +1725,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 11,
-                    "Column": 7,
-                    "Byte": 172
+                    "Column": 9,
+                    "Byte": 174
                 },
                 "End": {
                     "Line": 11,
-                    "Column": 19,
-                    "Byte": 184
+                    "Column": 10,
+                    "Byte": 175
                 }
             },
             "Context": null,
@@ -1501,13 +1748,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 12,
-                    "Column": 7,
-                    "Byte": 191
+                    "Column": 9,
+                    "Byte": 193
                 },
                 "End": {
                     "Line": 12,
-                    "Column": 16,
-                    "Byte": 200
+                    "Column": 11,
+                    "Byte": 195
                 }
             },
             "Context": null,
@@ -1524,13 +1771,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 13,
-                    "Column": 7,
-                    "Byte": 207
+                    "Column": 9,
+                    "Byte": 209
                 },
                 "End": {
                     "Line": 13,
-                    "Column": 14,
-                    "Byte": 214
+                    "Column": 13,
+                    "Byte": 213
                 }
             },
             "Context": null,
@@ -1592,6 +1839,19 @@
                         "symbol": [
                             {
                                 "key": "",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 9,
+                                        "byte": 38
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 9,
+                                        "byte": 38
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1626,6 +1886,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 9,
+                                        "byte": 47
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 13,
+                                        "byte": 51
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1642,6 +1915,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 13,
+                                        "byte": 51
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 19,
+                                        "byte": 57
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1676,6 +1962,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 9,
+                                        "byte": 67
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 13,
+                                        "byte": 71
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1692,6 +1991,19 @@
                             },
                             {
                                 "key": "foo]}",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 13,
+                                        "byte": 71
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 20,
+                                        "byte": 78
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1726,6 +2038,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 9,
+                                        "byte": 87
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 13,
+                                        "byte": 91
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1742,6 +2067,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 13,
+                                        "byte": 91
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 20,
+                                        "byte": 98
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1776,6 +2114,19 @@
                         "symbol": [
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 9,
+                                        "byte": 107
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 14,
+                                        "byte": 112
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1792,6 +2143,19 @@
                             },
                             {
                                 "index": 1,
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 14,
+                                        "byte": 112
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 16,
+                                        "byte": 114
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1826,6 +2190,19 @@
                         "symbol": [
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 9,
+                                        "byte": 124
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 14,
+                                        "byte": 129
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1842,6 +2219,19 @@
                             },
                             {
                                 "key": "notAnIndex",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 14,
+                                        "byte": 129
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 26,
+                                        "byte": 141
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1876,6 +2266,19 @@
                         "symbol": [
                             {
                                 "key": "",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 9,
+                                        "column": 9,
+                                        "byte": 151
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 10,
+                                        "byte": 152
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1910,6 +2313,19 @@
                         "symbol": [
                             {
                                 "index": 2,
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 9,
+                                        "byte": 161
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 12,
+                                        "byte": 164
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1944,6 +2360,19 @@
                         "symbol": [
                             {
                                 "key": "2",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 9,
+                                        "byte": 174
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 10,
+                                        "byte": 175
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1960,6 +2389,19 @@
                             },
                             {
                                 "key": "",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 10,
+                                        "byte": 175
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 11,
+                                        "byte": 176
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -1976,6 +2418,19 @@
                             },
                             {
                                 "key": "bad",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 11,
+                                        "byte": 176
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 18,
+                                        "byte": 183
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -2010,6 +2465,19 @@
                         "symbol": [
                             {
                                 "key": "34",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 9,
+                                        "byte": 193
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 11,
+                                        "byte": 195
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -2026,6 +2494,19 @@
                             },
                             {
                                 "key": "bad",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 11,
+                                        "byte": 195
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 15,
+                                        "byte": 199
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {
@@ -2060,6 +2541,19 @@
                         "symbol": [
                             {
                                 "key": "bad",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 13,
+                                        "column": 9,
+                                        "byte": 209
+                                    },
+                                    "end": {
+                                        "line": 13,
+                                        "column": 13,
+                                        "byte": 213
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access-load",
                                     "begin": {

--- a/eval/testdata/eval/invalid-access/expected.json
+++ b/eval/testdata/eval/invalid-access/expected.json
@@ -8,13 +8,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 29,
-                    "Column": 7,
-                    "Byte": 517
+                    "Column": 15,
+                    "Byte": 525
                 },
                 "End": {
                     "Line": 29,
-                    "Column": 20,
-                    "Byte": 530
+                    "Column": 19,
+                    "Byte": 529
                 }
             },
             "Context": null,
@@ -31,13 +31,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 30,
-                    "Column": 7,
-                    "Byte": 537
+                    "Column": 14,
+                    "Byte": 544
                 },
                 "End": {
                     "Line": 30,
-                    "Column": 19,
-                    "Byte": 549
+                    "Column": 18,
+                    "Byte": 548
                 }
             },
             "Context": null,
@@ -54,13 +54,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 31,
-                    "Column": 7,
-                    "Byte": 556
+                    "Column": 14,
+                    "Byte": 563
                 },
                 "End": {
                     "Line": 31,
-                    "Column": 22,
-                    "Byte": 571
+                    "Column": 21,
+                    "Byte": 570
                 }
             },
             "Context": null,
@@ -77,13 +77,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 32,
-                    "Column": 7,
-                    "Byte": 578
+                    "Column": 14,
+                    "Byte": 585
                 },
                 "End": {
                     "Line": 32,
-                    "Column": 18,
-                    "Byte": 589
+                    "Column": 17,
+                    "Byte": 588
                 }
             },
             "Context": null,
@@ -100,13 +100,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 33,
-                    "Column": 7,
-                    "Byte": 596
+                    "Column": 14,
+                    "Byte": 603
                 },
                 "End": {
                     "Line": 33,
-                    "Column": 19,
-                    "Byte": 608
+                    "Column": 18,
+                    "Byte": 607
                 }
             },
             "Context": null,
@@ -123,13 +123,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 34,
-                    "Column": 7,
-                    "Byte": 615
+                    "Column": 15,
+                    "Byte": 623
                 },
                 "End": {
                     "Line": 34,
-                    "Column": 19,
-                    "Byte": 627
+                    "Column": 18,
+                    "Byte": 626
                 }
             },
             "Context": null,
@@ -146,13 +146,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 35,
-                    "Column": 7,
-                    "Byte": 634
+                    "Column": 15,
+                    "Byte": 642
                 },
                 "End": {
                     "Line": 35,
-                    "Column": 20,
-                    "Byte": 647
+                    "Column": 19,
+                    "Byte": 646
                 }
             },
             "Context": null,
@@ -169,13 +169,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 36,
-                    "Column": 7,
-                    "Byte": 654
+                    "Column": 17,
+                    "Byte": 664
                 },
                 "End": {
                     "Line": 36,
-                    "Column": 22,
-                    "Byte": 669
+                    "Column": 21,
+                    "Byte": 668
                 }
             },
             "Context": null,
@@ -192,13 +192,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 37,
-                    "Column": 7,
-                    "Byte": 676
+                    "Column": 20,
+                    "Byte": 689
                 },
                 "End": {
                     "Line": 37,
-                    "Column": 24,
-                    "Byte": 693
+                    "Column": 23,
+                    "Byte": 692
                 }
             },
             "Context": null,
@@ -215,13 +215,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 38,
-                    "Column": 7,
-                    "Byte": 700
+                    "Column": 20,
+                    "Byte": 713
                 },
                 "End": {
                     "Line": 38,
-                    "Column": 25,
-                    "Byte": 718
+                    "Column": 24,
+                    "Byte": 717
                 }
             },
             "Context": null,
@@ -238,13 +238,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 39,
-                    "Column": 7,
-                    "Byte": 725
+                    "Column": 19,
+                    "Byte": 737
                 },
                 "End": {
                     "Line": 39,
-                    "Column": 24,
-                    "Byte": 742
+                    "Column": 23,
+                    "Byte": 741
                 }
             },
             "Context": null,
@@ -261,13 +261,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 40,
-                    "Column": 7,
-                    "Byte": 749
+                    "Column": 19,
+                    "Byte": 761
                 },
                 "End": {
                     "Line": 40,
-                    "Column": 27,
-                    "Byte": 769
+                    "Column": 26,
+                    "Byte": 768
                 }
             },
             "Context": null,
@@ -284,13 +284,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 41,
-                    "Column": 7,
-                    "Byte": 776
+                    "Column": 20,
+                    "Byte": 789
                 },
                 "End": {
                     "Line": 41,
-                    "Column": 24,
-                    "Byte": 793
+                    "Column": 23,
+                    "Byte": 792
                 }
             },
             "Context": null,
@@ -449,6 +449,19 @@
                         "symbol": [
                             {
                                 "key": "string",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 29,
+                                        "column": 9,
+                                        "byte": 519
+                                    },
+                                    "end": {
+                                        "line": 29,
+                                        "column": 15,
+                                        "byte": 525
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -465,6 +478,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 29,
+                                        "column": 15,
+                                        "byte": 525
+                                    },
+                                    "end": {
+                                        "line": 29,
+                                        "column": 19,
+                                        "byte": 529
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -499,6 +525,19 @@
                         "symbol": [
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 30,
+                                        "column": 9,
+                                        "byte": 539
+                                    },
+                                    "end": {
+                                        "line": 30,
+                                        "column": 14,
+                                        "byte": 544
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -515,6 +554,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 30,
+                                        "column": 14,
+                                        "byte": 544
+                                    },
+                                    "end": {
+                                        "line": 30,
+                                        "column": 18,
+                                        "byte": 548
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -549,6 +601,19 @@
                         "symbol": [
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 31,
+                                        "column": 9,
+                                        "byte": 558
+                                    },
+                                    "end": {
+                                        "line": 31,
+                                        "column": 14,
+                                        "byte": 563
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -565,6 +630,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 31,
+                                        "column": 14,
+                                        "byte": 563
+                                    },
+                                    "end": {
+                                        "line": 31,
+                                        "column": 21,
+                                        "byte": 570
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -599,6 +677,19 @@
                         "symbol": [
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 32,
+                                        "column": 9,
+                                        "byte": 580
+                                    },
+                                    "end": {
+                                        "line": 32,
+                                        "column": 14,
+                                        "byte": 585
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -615,6 +706,19 @@
                             },
                             {
                                 "index": 3,
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 32,
+                                        "column": 14,
+                                        "byte": 585
+                                    },
+                                    "end": {
+                                        "line": 32,
+                                        "column": 17,
+                                        "byte": 588
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -649,6 +753,19 @@
                         "symbol": [
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 33,
+                                        "column": 9,
+                                        "byte": 598
+                                    },
+                                    "end": {
+                                        "line": 33,
+                                        "column": 14,
+                                        "byte": 603
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -665,6 +782,19 @@
                             },
                             {
                                 "index": -1,
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 33,
+                                        "column": 14,
+                                        "byte": 603
+                                    },
+                                    "end": {
+                                        "line": 33,
+                                        "column": 18,
+                                        "byte": 607
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -699,6 +829,19 @@
                         "symbol": [
                             {
                                 "key": "object",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 9,
+                                        "byte": 617
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 15,
+                                        "byte": 623
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -715,6 +858,19 @@
                             },
                             {
                                 "index": 1,
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 15,
+                                        "byte": 623
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 18,
+                                        "byte": 626
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -749,6 +905,19 @@
                         "symbol": [
                             {
                                 "key": "object",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 35,
+                                        "column": 9,
+                                        "byte": 636
+                                    },
+                                    "end": {
+                                        "line": 35,
+                                        "column": 15,
+                                        "byte": 642
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -765,6 +934,19 @@
                             },
                             {
                                 "key": "bar",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 35,
+                                        "column": 15,
+                                        "byte": 642
+                                    },
+                                    "end": {
+                                        "line": 35,
+                                        "column": 19,
+                                        "byte": 646
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -799,6 +981,19 @@
                         "symbol": [
                             {
                                 "key": "myObject",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 36,
+                                        "column": 9,
+                                        "byte": 656
+                                    },
+                                    "end": {
+                                        "line": 36,
+                                        "column": 17,
+                                        "byte": 664
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -815,6 +1010,19 @@
                             },
                             {
                                 "key": "bar",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 36,
+                                        "column": 17,
+                                        "byte": 664
+                                    },
+                                    "end": {
+                                        "line": 36,
+                                        "column": 21,
+                                        "byte": 668
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -849,6 +1057,19 @@
                         "symbol": [
                             {
                                 "key": "otherObject",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 37,
+                                        "column": 9,
+                                        "byte": 678
+                                    },
+                                    "end": {
+                                        "line": 37,
+                                        "column": 20,
+                                        "byte": 689
+                                    }
+                                },
                                 "value": {
                                     "environment": "a",
                                     "begin": {
@@ -865,6 +1086,19 @@
                             },
                             {
                                 "index": 0,
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 37,
+                                        "column": 20,
+                                        "byte": 689
+                                    },
+                                    "end": {
+                                        "line": 37,
+                                        "column": 23,
+                                        "byte": 692
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -899,6 +1133,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 38,
+                                        "column": 9,
+                                        "byte": 702
+                                    },
+                                    "end": {
+                                        "line": 38,
+                                        "column": 13,
+                                        "byte": 706
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -915,6 +1162,19 @@
                             },
                             {
                                 "key": "string",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 38,
+                                        "column": 13,
+                                        "byte": 706
+                                    },
+                                    "end": {
+                                        "line": 38,
+                                        "column": 20,
+                                        "byte": 713
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -931,6 +1191,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 38,
+                                        "column": 20,
+                                        "byte": 713
+                                    },
+                                    "end": {
+                                        "line": 38,
+                                        "column": 24,
+                                        "byte": 717
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -965,6 +1238,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 39,
+                                        "column": 9,
+                                        "byte": 727
+                                    },
+                                    "end": {
+                                        "line": 39,
+                                        "column": 13,
+                                        "byte": 731
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -981,6 +1267,19 @@
                             },
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 39,
+                                        "column": 13,
+                                        "byte": 731
+                                    },
+                                    "end": {
+                                        "line": 39,
+                                        "column": 19,
+                                        "byte": 737
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -997,6 +1296,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 39,
+                                        "column": 19,
+                                        "byte": 737
+                                    },
+                                    "end": {
+                                        "line": 39,
+                                        "column": 23,
+                                        "byte": 741
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -1031,6 +1343,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 9,
+                                        "byte": 751
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 13,
+                                        "byte": 755
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -1047,6 +1372,19 @@
                             },
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 13,
+                                        "byte": 755
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 19,
+                                        "byte": 761
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -1063,6 +1401,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 19,
+                                        "byte": 761
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 26,
+                                        "byte": 768
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -1097,6 +1448,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 41,
+                                        "column": 9,
+                                        "byte": 778
+                                    },
+                                    "end": {
+                                        "line": 41,
+                                        "column": 13,
+                                        "byte": 782
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -1113,6 +1477,19 @@
                             },
                             {
                                 "key": "record",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 41,
+                                        "column": 13,
+                                        "byte": 782
+                                    },
+                                    "end": {
+                                        "line": 41,
+                                        "column": 20,
+                                        "byte": 789
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -1129,6 +1506,19 @@
                             },
                             {
                                 "index": 1,
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 41,
+                                        "column": 20,
+                                        "byte": 789
+                                    },
+                                    "end": {
+                                        "line": 41,
+                                        "column": 23,
+                                        "byte": 792
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -3920,13 +4310,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 29,
-                    "Column": 7,
-                    "Byte": 517
+                    "Column": 15,
+                    "Byte": 525
                 },
                 "End": {
                     "Line": 29,
-                    "Column": 20,
-                    "Byte": 530
+                    "Column": 19,
+                    "Byte": 529
                 }
             },
             "Context": null,
@@ -3943,13 +4333,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 30,
-                    "Column": 7,
-                    "Byte": 537
+                    "Column": 14,
+                    "Byte": 544
                 },
                 "End": {
                     "Line": 30,
-                    "Column": 19,
-                    "Byte": 549
+                    "Column": 18,
+                    "Byte": 548
                 }
             },
             "Context": null,
@@ -3966,13 +4356,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 31,
-                    "Column": 7,
-                    "Byte": 556
+                    "Column": 14,
+                    "Byte": 563
                 },
                 "End": {
                     "Line": 31,
-                    "Column": 22,
-                    "Byte": 571
+                    "Column": 21,
+                    "Byte": 570
                 }
             },
             "Context": null,
@@ -3989,13 +4379,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 32,
-                    "Column": 7,
-                    "Byte": 578
+                    "Column": 14,
+                    "Byte": 585
                 },
                 "End": {
                     "Line": 32,
-                    "Column": 18,
-                    "Byte": 589
+                    "Column": 17,
+                    "Byte": 588
                 }
             },
             "Context": null,
@@ -4012,13 +4402,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 33,
-                    "Column": 7,
-                    "Byte": 596
+                    "Column": 14,
+                    "Byte": 603
                 },
                 "End": {
                     "Line": 33,
-                    "Column": 19,
-                    "Byte": 608
+                    "Column": 18,
+                    "Byte": 607
                 }
             },
             "Context": null,
@@ -4035,13 +4425,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 34,
-                    "Column": 7,
-                    "Byte": 615
+                    "Column": 15,
+                    "Byte": 623
                 },
                 "End": {
                     "Line": 34,
-                    "Column": 19,
-                    "Byte": 627
+                    "Column": 18,
+                    "Byte": 626
                 }
             },
             "Context": null,
@@ -4058,13 +4448,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 35,
-                    "Column": 7,
-                    "Byte": 634
+                    "Column": 15,
+                    "Byte": 642
                 },
                 "End": {
                     "Line": 35,
-                    "Column": 20,
-                    "Byte": 647
+                    "Column": 19,
+                    "Byte": 646
                 }
             },
             "Context": null,
@@ -4081,13 +4471,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 36,
-                    "Column": 7,
-                    "Byte": 654
+                    "Column": 17,
+                    "Byte": 664
                 },
                 "End": {
                     "Line": 36,
-                    "Column": 22,
-                    "Byte": 669
+                    "Column": 21,
+                    "Byte": 668
                 }
             },
             "Context": null,
@@ -4104,13 +4494,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 37,
-                    "Column": 7,
-                    "Byte": 676
+                    "Column": 20,
+                    "Byte": 689
                 },
                 "End": {
                     "Line": 37,
-                    "Column": 24,
-                    "Byte": 693
+                    "Column": 23,
+                    "Byte": 692
                 }
             },
             "Context": null,
@@ -4127,13 +4517,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 38,
-                    "Column": 7,
-                    "Byte": 700
+                    "Column": 20,
+                    "Byte": 713
                 },
                 "End": {
                     "Line": 38,
-                    "Column": 25,
-                    "Byte": 718
+                    "Column": 24,
+                    "Byte": 717
                 }
             },
             "Context": null,
@@ -4150,13 +4540,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 39,
-                    "Column": 7,
-                    "Byte": 725
+                    "Column": 19,
+                    "Byte": 737
                 },
                 "End": {
                     "Line": 39,
-                    "Column": 24,
-                    "Byte": 742
+                    "Column": 23,
+                    "Byte": 741
                 }
             },
             "Context": null,
@@ -4173,13 +4563,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 40,
-                    "Column": 7,
-                    "Byte": 749
+                    "Column": 19,
+                    "Byte": 761
                 },
                 "End": {
                     "Line": 40,
-                    "Column": 27,
-                    "Byte": 769
+                    "Column": 26,
+                    "Byte": 768
                 }
             },
             "Context": null,
@@ -4196,13 +4586,13 @@
                 "Filename": "invalid-access",
                 "Start": {
                     "Line": 41,
-                    "Column": 7,
-                    "Byte": 776
+                    "Column": 20,
+                    "Byte": 789
                 },
                 "End": {
                     "Line": 41,
-                    "Column": 24,
-                    "Byte": 793
+                    "Column": 23,
+                    "Byte": 792
                 }
             },
             "Context": null,
@@ -4361,6 +4751,19 @@
                         "symbol": [
                             {
                                 "key": "string",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 29,
+                                        "column": 9,
+                                        "byte": 519
+                                    },
+                                    "end": {
+                                        "line": 29,
+                                        "column": 15,
+                                        "byte": 525
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4377,6 +4780,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 29,
+                                        "column": 15,
+                                        "byte": 525
+                                    },
+                                    "end": {
+                                        "line": 29,
+                                        "column": 19,
+                                        "byte": 529
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4411,6 +4827,19 @@
                         "symbol": [
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 30,
+                                        "column": 9,
+                                        "byte": 539
+                                    },
+                                    "end": {
+                                        "line": 30,
+                                        "column": 14,
+                                        "byte": 544
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4427,6 +4856,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 30,
+                                        "column": 14,
+                                        "byte": 544
+                                    },
+                                    "end": {
+                                        "line": 30,
+                                        "column": 18,
+                                        "byte": 548
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4461,6 +4903,19 @@
                         "symbol": [
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 31,
+                                        "column": 9,
+                                        "byte": 558
+                                    },
+                                    "end": {
+                                        "line": 31,
+                                        "column": 14,
+                                        "byte": 563
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4477,6 +4932,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 31,
+                                        "column": 14,
+                                        "byte": 563
+                                    },
+                                    "end": {
+                                        "line": 31,
+                                        "column": 21,
+                                        "byte": 570
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4511,6 +4979,19 @@
                         "symbol": [
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 32,
+                                        "column": 9,
+                                        "byte": 580
+                                    },
+                                    "end": {
+                                        "line": 32,
+                                        "column": 14,
+                                        "byte": 585
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4527,6 +5008,19 @@
                             },
                             {
                                 "index": 3,
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 32,
+                                        "column": 14,
+                                        "byte": 585
+                                    },
+                                    "end": {
+                                        "line": 32,
+                                        "column": 17,
+                                        "byte": 588
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4561,6 +5055,19 @@
                         "symbol": [
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 33,
+                                        "column": 9,
+                                        "byte": 598
+                                    },
+                                    "end": {
+                                        "line": 33,
+                                        "column": 14,
+                                        "byte": 603
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4577,6 +5084,19 @@
                             },
                             {
                                 "index": -1,
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 33,
+                                        "column": 14,
+                                        "byte": 603
+                                    },
+                                    "end": {
+                                        "line": 33,
+                                        "column": 18,
+                                        "byte": 607
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4611,6 +5131,19 @@
                         "symbol": [
                             {
                                 "key": "object",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 9,
+                                        "byte": 617
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 15,
+                                        "byte": 623
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4627,6 +5160,19 @@
                             },
                             {
                                 "index": 1,
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 15,
+                                        "byte": 623
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 18,
+                                        "byte": 626
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4661,6 +5207,19 @@
                         "symbol": [
                             {
                                 "key": "object",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 35,
+                                        "column": 9,
+                                        "byte": 636
+                                    },
+                                    "end": {
+                                        "line": 35,
+                                        "column": 15,
+                                        "byte": 642
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4677,6 +5236,19 @@
                             },
                             {
                                 "key": "bar",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 35,
+                                        "column": 15,
+                                        "byte": 642
+                                    },
+                                    "end": {
+                                        "line": 35,
+                                        "column": 19,
+                                        "byte": 646
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4711,6 +5283,19 @@
                         "symbol": [
                             {
                                 "key": "myObject",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 36,
+                                        "column": 9,
+                                        "byte": 656
+                                    },
+                                    "end": {
+                                        "line": 36,
+                                        "column": 17,
+                                        "byte": 664
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4727,6 +5312,19 @@
                             },
                             {
                                 "key": "bar",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 36,
+                                        "column": 17,
+                                        "byte": 664
+                                    },
+                                    "end": {
+                                        "line": 36,
+                                        "column": 21,
+                                        "byte": 668
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4761,6 +5359,19 @@
                         "symbol": [
                             {
                                 "key": "otherObject",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 37,
+                                        "column": 9,
+                                        "byte": 678
+                                    },
+                                    "end": {
+                                        "line": 37,
+                                        "column": 20,
+                                        "byte": 689
+                                    }
+                                },
                                 "value": {
                                     "environment": "a",
                                     "begin": {
@@ -4777,6 +5388,19 @@
                             },
                             {
                                 "index": 0,
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 37,
+                                        "column": 20,
+                                        "byte": 689
+                                    },
+                                    "end": {
+                                        "line": 37,
+                                        "column": 23,
+                                        "byte": 692
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4811,6 +5435,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 38,
+                                        "column": 9,
+                                        "byte": 702
+                                    },
+                                    "end": {
+                                        "line": 38,
+                                        "column": 13,
+                                        "byte": 706
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4827,6 +5464,19 @@
                             },
                             {
                                 "key": "string",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 38,
+                                        "column": 13,
+                                        "byte": 706
+                                    },
+                                    "end": {
+                                        "line": 38,
+                                        "column": 20,
+                                        "byte": 713
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4843,6 +5493,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 38,
+                                        "column": 20,
+                                        "byte": 713
+                                    },
+                                    "end": {
+                                        "line": 38,
+                                        "column": 24,
+                                        "byte": 717
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4877,6 +5540,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 39,
+                                        "column": 9,
+                                        "byte": 727
+                                    },
+                                    "end": {
+                                        "line": 39,
+                                        "column": 13,
+                                        "byte": 731
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4893,6 +5569,19 @@
                             },
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 39,
+                                        "column": 13,
+                                        "byte": 731
+                                    },
+                                    "end": {
+                                        "line": 39,
+                                        "column": 19,
+                                        "byte": 737
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4909,6 +5598,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 39,
+                                        "column": 19,
+                                        "byte": 737
+                                    },
+                                    "end": {
+                                        "line": 39,
+                                        "column": 23,
+                                        "byte": 741
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4943,6 +5645,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 9,
+                                        "byte": 751
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 13,
+                                        "byte": 755
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4959,6 +5674,19 @@
                             },
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 13,
+                                        "byte": 755
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 19,
+                                        "byte": 761
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -4975,6 +5703,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 19,
+                                        "byte": 761
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 26,
+                                        "byte": 768
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -5009,6 +5750,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 41,
+                                        "column": 9,
+                                        "byte": 778
+                                    },
+                                    "end": {
+                                        "line": 41,
+                                        "column": 13,
+                                        "byte": 782
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -5025,6 +5779,19 @@
                             },
                             {
                                 "key": "record",
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 41,
+                                        "column": 13,
+                                        "byte": 782
+                                    },
+                                    "end": {
+                                        "line": 41,
+                                        "column": 20,
+                                        "byte": 789
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {
@@ -5041,6 +5808,19 @@
                             },
                             {
                                 "index": 1,
+                                "range": {
+                                    "environment": "invalid-access",
+                                    "begin": {
+                                        "line": 41,
+                                        "column": 20,
+                                        "byte": 789
+                                    },
+                                    "end": {
+                                        "line": 41,
+                                        "column": 23,
+                                        "byte": 792
+                                    }
+                                },
                                 "value": {
                                     "environment": "invalid-access",
                                     "begin": {

--- a/eval/testdata/eval/merge-base/expected.json
+++ b/eval/testdata/eval/merge-base/expected.json
@@ -212,6 +212,19 @@
                 "symbol": [
                     {
                         "key": "some_object",
+                        "range": {
+                            "environment": "merge-base",
+                            "begin": {
+                                "line": 40,
+                                "column": 19,
+                                "byte": 1005
+                            },
+                            "end": {
+                                "line": 40,
+                                "column": 30,
+                                "byte": 1016
+                            }
+                        },
                         "value": {
                             "environment": "merge-base",
                             "begin": {
@@ -1435,6 +1448,19 @@
                 "symbol": [
                     {
                         "key": "some_object",
+                        "range": {
+                            "environment": "merge-base",
+                            "begin": {
+                                "line": 40,
+                                "column": 19,
+                                "byte": 1005
+                            },
+                            "end": {
+                                "line": 40,
+                                "column": 30,
+                                "byte": 1016
+                            }
+                        },
                         "value": {
                             "environment": "merge-base",
                             "begin": {

--- a/eval/testdata/eval/merge-unknown/expected.json
+++ b/eval/testdata/eval/merge-unknown/expected.json
@@ -223,7 +223,20 @@
                                 },
                                 "accessors": [
                                     {
-                                        "key": "baz"
+                                        "key": "baz",
+                                        "range": {
+                                            "environment": "merge-unknown",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
                                     }
                                 ]
                             }
@@ -293,10 +306,36 @@
                                         },
                                         "accessors": [
                                             {
-                                                "key": "baz"
+                                                "key": "baz",
+                                                "range": {
+                                                    "environment": "merge-unknown",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                }
                                             },
                                             {
-                                                "key": "qux"
+                                                "key": "qux",
+                                                "range": {
+                                                    "environment": "merge-unknown",
+                                                    "begin": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    },
+                                                    "end": {
+                                                        "line": 0,
+                                                        "column": 0,
+                                                        "byte": 0
+                                                    }
+                                                }
                                             }
                                         ]
                                     }
@@ -354,7 +393,20 @@
                                 },
                                 "accessors": [
                                     {
-                                        "key": "foo"
+                                        "key": "foo",
+                                        "range": {
+                                            "environment": "merge-unknown",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
                                     }
                                 ]
                             }

--- a/eval/testdata/eval/nested-unknowns-secrets/expected.json
+++ b/eval/testdata/eval/nested-unknowns-secrets/expected.json
@@ -57,6 +57,19 @@
                         "symbol": [
                             {
                                 "key": "cloudflare",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 21,
+                                        "byte": 1080
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 31,
+                                        "byte": 1090
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -73,6 +86,19 @@
                             },
                             {
                                 "key": "apiKey",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 31,
+                                        "byte": 1090
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 38,
+                                        "byte": 1097
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -144,6 +170,19 @@
                         "symbol": [
                             {
                                 "key": "deeplyNestedProvider",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 21,
+                                        "byte": 873
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 41,
+                                        "byte": 893
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -160,6 +199,19 @@
                             },
                             {
                                 "key": "oneStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 41,
+                                        "byte": 893
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 49,
+                                        "byte": 901
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -176,6 +228,19 @@
                             },
                             {
                                 "key": "twoStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 49,
+                                        "byte": 901
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 57,
+                                        "byte": 909
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -192,6 +257,19 @@
                             },
                             {
                                 "key": "threeStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 57,
+                                        "byte": 909
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 67,
+                                        "byte": 919
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -208,6 +286,19 @@
                             },
                             {
                                 "key": "fourStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 67,
+                                        "byte": 919
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 76,
+                                        "byte": 928
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -224,6 +315,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 76,
+                                        "byte": 928
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 80,
+                                        "byte": 932
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -739,6 +843,19 @@
                         "symbol": [
                             {
                                 "key": "cloudflare",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 23,
+                                        "column": 22,
+                                        "byte": 484
+                                    },
+                                    "end": {
+                                        "line": 23,
+                                        "column": 32,
+                                        "byte": 494
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -755,6 +872,19 @@
                             },
                             {
                                 "key": "apiKey",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 23,
+                                        "column": 32,
+                                        "byte": 494
+                                    },
+                                    "end": {
+                                        "line": 23,
+                                        "column": 39,
+                                        "byte": 501
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -789,6 +919,19 @@
                         "symbol": [
                             {
                                 "key": "deeplyNestedProvider",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 17,
+                                        "byte": 519
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 37,
+                                        "byte": 539
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -805,6 +948,19 @@
                             },
                             {
                                 "key": "oneStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 37,
+                                        "byte": 539
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 45,
+                                        "byte": 547
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -821,6 +977,19 @@
                             },
                             {
                                 "key": "twoStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 45,
+                                        "byte": 547
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 53,
+                                        "byte": 555
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -837,6 +1006,19 @@
                             },
                             {
                                 "key": "threeStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 53,
+                                        "byte": 555
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 63,
+                                        "byte": 565
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -853,6 +1035,19 @@
                             },
                             {
                                 "key": "fourStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 63,
+                                        "byte": 565
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 72,
+                                        "byte": 574
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -869,6 +1064,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 72,
+                                        "byte": 574
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 76,
+                                        "byte": 578
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -1259,6 +1467,19 @@
                         "symbol": [
                             {
                                 "key": "cloudflare",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 42,
+                                        "column": 29,
+                                        "byte": 1151
+                                    },
+                                    "end": {
+                                        "line": 42,
+                                        "column": 39,
+                                        "byte": 1161
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -1275,6 +1496,19 @@
                             },
                             {
                                 "key": "apiToken",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 42,
+                                        "column": 39,
+                                        "byte": 1161
+                                    },
+                                    "end": {
+                                        "line": 42,
+                                        "column": 48,
+                                        "byte": 1170
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -1357,6 +1591,19 @@
                         "symbol": [
                             {
                                 "key": "comboSecretAndUnknown",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 26,
+                                        "column": 19,
+                                        "byte": 617
+                                    },
+                                    "end": {
+                                        "line": 26,
+                                        "column": 40,
+                                        "byte": 638
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -1470,6 +1717,19 @@
                         "symbol": [
                             {
                                 "key": "cloudflare",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 36,
+                                        "column": 19,
+                                        "byte": 972
+                                    },
+                                    "end": {
+                                        "line": 36,
+                                        "column": 29,
+                                        "byte": 982
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -1571,6 +1831,19 @@
                         "symbol": [
                             {
                                 "key": "deeplyNestedProvider",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 30,
+                                        "column": 19,
+                                        "byte": 743
+                                    },
+                                    "end": {
+                                        "line": 30,
+                                        "column": 39,
+                                        "byte": 763
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -1670,6 +1943,19 @@
                         "symbol": [
                             {
                                 "key": "cloudflare",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 44,
+                                        "column": 18,
+                                        "byte": 1205
+                                    },
+                                    "end": {
+                                        "line": 44,
+                                        "column": 28,
+                                        "byte": 1215
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -1686,6 +1972,19 @@
                             },
                             {
                                 "key": "account",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 44,
+                                        "column": 28,
+                                        "byte": 1215
+                                    },
+                                    "end": {
+                                        "line": 44,
+                                        "column": 36,
+                                        "byte": 1223
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -1702,6 +2001,19 @@
                             },
                             {
                                 "key": "id",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 44,
+                                        "column": 36,
+                                        "byte": 1223
+                                    },
+                                    "end": {
+                                        "line": 44,
+                                        "column": 39,
+                                        "byte": 1226
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -1739,6 +2051,19 @@
                         "symbol": [
                             {
                                 "key": "top-level-secret",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 45,
+                                        "column": 26,
+                                        "byte": 1253
+                                    },
+                                    "end": {
+                                        "line": 45,
+                                        "column": 42,
+                                        "byte": 1269
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -1821,6 +2146,19 @@
                         "symbol": [
                             {
                                 "key": "comboSecretAndUnknown",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 28,
+                                        "column": 21,
+                                        "byte": 681
+                                    },
+                                    "end": {
+                                        "line": 28,
+                                        "column": 42,
+                                        "byte": 702
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -1934,6 +2272,19 @@
                         "symbol": [
                             {
                                 "key": "cloudflare",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 38,
+                                        "column": 21,
+                                        "byte": 1026
+                                    },
+                                    "end": {
+                                        "line": 38,
+                                        "column": 31,
+                                        "byte": 1036
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -2035,6 +2386,19 @@
                         "symbol": [
                             {
                                 "key": "deeplyNestedProvider",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 32,
+                                        "column": 21,
+                                        "byte": 808
+                                    },
+                                    "end": {
+                                        "line": 32,
+                                        "column": 41,
+                                        "byte": 828
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -2944,6 +3308,19 @@
                         "symbol": [
                             {
                                 "key": "cloudflare",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 21,
+                                        "byte": 1080
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 31,
+                                        "byte": 1090
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -2960,6 +3337,19 @@
                             },
                             {
                                 "key": "apiKey",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 31,
+                                        "byte": 1090
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 38,
+                                        "byte": 1097
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -3034,6 +3424,19 @@
                         "symbol": [
                             {
                                 "key": "deeplyNestedProvider",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 21,
+                                        "byte": 873
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 41,
+                                        "byte": 893
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -3050,6 +3453,19 @@
                             },
                             {
                                 "key": "oneStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 41,
+                                        "byte": 893
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 49,
+                                        "byte": 901
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -3066,6 +3482,19 @@
                             },
                             {
                                 "key": "twoStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 49,
+                                        "byte": 901
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 57,
+                                        "byte": 909
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -3082,6 +3511,19 @@
                             },
                             {
                                 "key": "threeStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 57,
+                                        "byte": 909
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 67,
+                                        "byte": 919
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -3098,6 +3540,19 @@
                             },
                             {
                                 "key": "fourStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 67,
+                                        "byte": 919
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 76,
+                                        "byte": 928
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -3114,6 +3569,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 34,
+                                        "column": 76,
+                                        "byte": 928
+                                    },
+                                    "end": {
+                                        "line": 34,
+                                        "column": 80,
+                                        "byte": 932
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -3632,6 +4100,19 @@
                         "symbol": [
                             {
                                 "key": "cloudflare",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 23,
+                                        "column": 22,
+                                        "byte": 484
+                                    },
+                                    "end": {
+                                        "line": 23,
+                                        "column": 32,
+                                        "byte": 494
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -3648,6 +4129,19 @@
                             },
                             {
                                 "key": "apiKey",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 23,
+                                        "column": 32,
+                                        "byte": 494
+                                    },
+                                    "end": {
+                                        "line": 23,
+                                        "column": 39,
+                                        "byte": 501
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -3685,6 +4179,19 @@
                         "symbol": [
                             {
                                 "key": "deeplyNestedProvider",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 17,
+                                        "byte": 519
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 37,
+                                        "byte": 539
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -3701,6 +4208,19 @@
                             },
                             {
                                 "key": "oneStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 37,
+                                        "byte": 539
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 45,
+                                        "byte": 547
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -3717,6 +4237,19 @@
                             },
                             {
                                 "key": "twoStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 45,
+                                        "byte": 547
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 53,
+                                        "byte": 555
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -3733,6 +4266,19 @@
                             },
                             {
                                 "key": "threeStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 53,
+                                        "byte": 555
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 63,
+                                        "byte": 565
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -3749,6 +4295,19 @@
                             },
                             {
                                 "key": "fourStep",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 63,
+                                        "byte": 565
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 72,
+                                        "byte": 574
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -3765,6 +4324,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 72,
+                                        "byte": 574
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 76,
+                                        "byte": 578
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -4210,6 +4782,19 @@
                         "symbol": [
                             {
                                 "key": "cloudflare",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 42,
+                                        "column": 29,
+                                        "byte": 1151
+                                    },
+                                    "end": {
+                                        "line": 42,
+                                        "column": 39,
+                                        "byte": 1161
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -4226,6 +4811,19 @@
                             },
                             {
                                 "key": "apiToken",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 42,
+                                        "column": 39,
+                                        "byte": 1161
+                                    },
+                                    "end": {
+                                        "line": 42,
+                                        "column": 48,
+                                        "byte": 1170
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -4311,6 +4909,19 @@
                         "symbol": [
                             {
                                 "key": "comboSecretAndUnknown",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 26,
+                                        "column": 19,
+                                        "byte": 617
+                                    },
+                                    "end": {
+                                        "line": 26,
+                                        "column": 40,
+                                        "byte": 638
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -4424,6 +5035,19 @@
                         "symbol": [
                             {
                                 "key": "cloudflare",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 36,
+                                        "column": 19,
+                                        "byte": 972
+                                    },
+                                    "end": {
+                                        "line": 36,
+                                        "column": 29,
+                                        "byte": 982
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -4536,6 +5160,19 @@
                         "symbol": [
                             {
                                 "key": "deeplyNestedProvider",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 30,
+                                        "column": 19,
+                                        "byte": 743
+                                    },
+                                    "end": {
+                                        "line": 30,
+                                        "column": 39,
+                                        "byte": 763
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -4635,6 +5272,19 @@
                         "symbol": [
                             {
                                 "key": "cloudflare",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 44,
+                                        "column": 18,
+                                        "byte": 1205
+                                    },
+                                    "end": {
+                                        "line": 44,
+                                        "column": 28,
+                                        "byte": 1215
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -4651,6 +5301,19 @@
                             },
                             {
                                 "key": "account",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 44,
+                                        "column": 28,
+                                        "byte": 1215
+                                    },
+                                    "end": {
+                                        "line": 44,
+                                        "column": 36,
+                                        "byte": 1223
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -4667,6 +5330,19 @@
                             },
                             {
                                 "key": "id",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 44,
+                                        "column": 36,
+                                        "byte": 1223
+                                    },
+                                    "end": {
+                                        "line": 44,
+                                        "column": 39,
+                                        "byte": 1226
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -4704,6 +5380,19 @@
                         "symbol": [
                             {
                                 "key": "top-level-secret",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 45,
+                                        "column": 26,
+                                        "byte": 1253
+                                    },
+                                    "end": {
+                                        "line": 45,
+                                        "column": 42,
+                                        "byte": 1269
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -4789,6 +5478,19 @@
                         "symbol": [
                             {
                                 "key": "comboSecretAndUnknown",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 28,
+                                        "column": 21,
+                                        "byte": 681
+                                    },
+                                    "end": {
+                                        "line": 28,
+                                        "column": 42,
+                                        "byte": 702
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -4902,6 +5604,19 @@
                         "symbol": [
                             {
                                 "key": "cloudflare",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 38,
+                                        "column": 21,
+                                        "byte": 1026
+                                    },
+                                    "end": {
+                                        "line": 38,
+                                        "column": 31,
+                                        "byte": 1036
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {
@@ -5014,6 +5729,19 @@
                         "symbol": [
                             {
                                 "key": "deeplyNestedProvider",
+                                "range": {
+                                    "environment": "nested-unknowns-secrets",
+                                    "begin": {
+                                        "line": 32,
+                                        "column": 21,
+                                        "byte": 808
+                                    },
+                                    "end": {
+                                        "line": 32,
+                                        "column": 41,
+                                        "byte": 828
+                                    }
+                                },
                                 "value": {
                                     "environment": "nested-unknowns-secrets",
                                     "begin": {

--- a/eval/testdata/eval/omnibus/expected.json
+++ b/eval/testdata/eval/omnibus/expected.json
@@ -19,6 +19,19 @@
                 "symbol": [
                     {
                         "key": "open",
+                        "range": {
+                            "environment": "omnibus",
+                            "begin": {
+                                "line": 29,
+                                "column": 13,
+                                "byte": 483
+                            },
+                            "end": {
+                                "line": 29,
+                                "column": 17,
+                                "byte": 487
+                            }
+                        },
                         "value": {
                             "environment": "omnibus",
                             "begin": {
@@ -35,6 +48,19 @@
                     },
                     {
                         "key": "baz",
+                        "range": {
+                            "environment": "omnibus",
+                            "begin": {
+                                "line": 29,
+                                "column": 17,
+                                "byte": 487
+                            },
+                            "end": {
+                                "line": 29,
+                                "column": 24,
+                                "byte": 494
+                            }
+                        },
                         "value": {
                             "environment": "omnibus",
                             "begin": {
@@ -106,6 +132,19 @@
                         "symbol": [
                             {
                                 "key": "toBase64",
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 23,
+                                        "byte": 59
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 31,
+                                        "byte": 67
+                                    }
+                                },
                                 "value": {
                                     "environment": "omnibus",
                                     "begin": {
@@ -175,6 +214,19 @@
                         "symbol": [
                             {
                                 "key": "toJSON",
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 21,
+                                        "byte": 101
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 27,
+                                        "byte": 107
+                                    }
+                                },
                                 "value": {
                                     "environment": "omnibus",
                                     "begin": {
@@ -216,6 +268,19 @@
                         "value": [
                             {
                                 "key": "toString",
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 28,
+                                        "column": 20,
+                                        "byte": 461
+                                    },
+                                    "end": {
+                                        "line": 28,
+                                        "column": 28,
+                                        "byte": 469
+                                    }
+                                },
                                 "value": {
                                     "environment": "omnibus",
                                     "begin": {
@@ -347,6 +412,19 @@
                                 "symbol": [
                                     {
                                         "key": "strings",
+                                        "range": {
+                                            "environment": "omnibus",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
                                         "value": {
                                             "environment": "a",
                                             "begin": {
@@ -759,6 +837,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 27,
+                                        "column": 23,
+                                        "byte": 436
+                                    },
+                                    "end": {
+                                        "line": 27,
+                                        "column": 27,
+                                        "byte": 440
+                                    }
+                                },
                                 "value": {
                                     "environment": "omnibus",
                                     "begin": {
@@ -888,6 +979,19 @@
                         "symbol": [
                             {
                                 "key": "join",
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 21,
+                                        "column": 21,
+                                        "byte": 327
+                                    },
+                                    "end": {
+                                        "line": 21,
+                                        "column": 25,
+                                        "byte": 331
+                                    }
+                                },
                                 "value": {
                                     "environment": "omnibus",
                                     "begin": {
@@ -957,6 +1061,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 23,
+                                        "column": 19,
+                                        "byte": 361
+                                    },
+                                    "end": {
+                                        "line": 23,
+                                        "column": 23,
+                                        "byte": 365
+                                    }
+                                },
                                 "value": {
                                     "environment": "omnibus",
                                     "begin": {
@@ -1026,6 +1143,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 25,
+                                        "column": 21,
+                                        "byte": 399
+                                    },
+                                    "end": {
+                                        "line": 25,
+                                        "column": 25,
+                                        "byte": 403
+                                    }
+                                },
                                 "value": {
                                     "environment": "omnibus",
                                     "begin": {
@@ -1439,6 +1569,19 @@
                 "symbol": [
                     {
                         "key": "open",
+                        "range": {
+                            "environment": "omnibus",
+                            "begin": {
+                                "line": 29,
+                                "column": 13,
+                                "byte": 483
+                            },
+                            "end": {
+                                "line": 29,
+                                "column": 17,
+                                "byte": 487
+                            }
+                        },
                         "value": {
                             "environment": "omnibus",
                             "begin": {
@@ -1455,6 +1598,19 @@
                     },
                     {
                         "key": "baz",
+                        "range": {
+                            "environment": "omnibus",
+                            "begin": {
+                                "line": 29,
+                                "column": 17,
+                                "byte": 487
+                            },
+                            "end": {
+                                "line": 29,
+                                "column": 24,
+                                "byte": 494
+                            }
+                        },
                         "value": {
                             "environment": "omnibus",
                             "begin": {
@@ -1526,6 +1682,19 @@
                         "symbol": [
                             {
                                 "key": "toBase64",
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 23,
+                                        "byte": 59
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 31,
+                                        "byte": 67
+                                    }
+                                },
                                 "value": {
                                     "environment": "omnibus",
                                     "begin": {
@@ -1636,6 +1805,19 @@
                         "symbol": [
                             {
                                 "key": "toJSON",
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 21,
+                                        "byte": 101
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 27,
+                                        "byte": 107
+                                    }
+                                },
                                 "value": {
                                     "environment": "omnibus",
                                     "begin": {
@@ -1677,6 +1859,19 @@
                         "value": [
                             {
                                 "key": "toString",
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 28,
+                                        "column": 20,
+                                        "byte": 461
+                                    },
+                                    "end": {
+                                        "line": 28,
+                                        "column": 28,
+                                        "byte": 469
+                                    }
+                                },
                                 "value": {
                                     "environment": "omnibus",
                                     "begin": {
@@ -1808,6 +2003,19 @@
                                 "symbol": [
                                     {
                                         "key": "strings",
+                                        "range": {
+                                            "environment": "omnibus",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
                                         "value": {
                                             "environment": "a",
                                             "begin": {
@@ -2343,6 +2551,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 27,
+                                        "column": 23,
+                                        "byte": 436
+                                    },
+                                    "end": {
+                                        "line": 27,
+                                        "column": 27,
+                                        "byte": 440
+                                    }
+                                },
                                 "value": {
                                     "environment": "omnibus",
                                     "begin": {
@@ -2472,6 +2693,19 @@
                         "symbol": [
                             {
                                 "key": "join",
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 21,
+                                        "column": 21,
+                                        "byte": 327
+                                    },
+                                    "end": {
+                                        "line": 21,
+                                        "column": 25,
+                                        "byte": 331
+                                    }
+                                },
                                 "value": {
                                     "environment": "omnibus",
                                     "begin": {
@@ -2582,6 +2816,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 23,
+                                        "column": 19,
+                                        "byte": 361
+                                    },
+                                    "end": {
+                                        "line": 23,
+                                        "column": 23,
+                                        "byte": 365
+                                    }
+                                },
                                 "value": {
                                     "environment": "omnibus",
                                     "begin": {
@@ -2692,6 +2939,19 @@
                         "symbol": [
                             {
                                 "key": "open",
+                                "range": {
+                                    "environment": "omnibus",
+                                    "begin": {
+                                        "line": 25,
+                                        "column": 21,
+                                        "byte": 399
+                                    },
+                                    "end": {
+                                        "line": 25,
+                                        "column": 25,
+                                        "byte": 403
+                                    }
+                                },
                                 "value": {
                                     "environment": "omnibus",
                                     "begin": {

--- a/eval/testdata/eval/open-unknown/expected.json
+++ b/eval/testdata/eval/open-unknown/expected.json
@@ -99,6 +99,19 @@
                                 "symbol": [
                                     {
                                         "key": "error",
+                                        "range": {
+                                            "environment": "open-unknown",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 14,
+                                                "byte": 104
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 19,
+                                                "byte": 109
+                                            }
+                                        },
                                         "value": {
                                             "environment": "open-unknown",
                                             "begin": {
@@ -406,6 +419,19 @@
                                 "symbol": [
                                     {
                                         "key": "error",
+                                        "range": {
+                                            "environment": "open-unknown",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 14,
+                                                "byte": 104
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 19,
+                                                "byte": 109
+                                            }
+                                        },
                                         "value": {
                                             "environment": "open-unknown",
                                             "begin": {

--- a/eval/testdata/eval/open/expected.json
+++ b/eval/testdata/eval/open/expected.json
@@ -103,6 +103,19 @@
                         "symbol": [
                             {
                                 "key": "test",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 15,
+                                        "column": 12,
+                                        "byte": 222
+                                    },
+                                    "end": {
+                                        "line": 15,
+                                        "column": 16,
+                                        "byte": 226
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -119,6 +132,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 15,
+                                        "column": 16,
+                                        "byte": 226
+                                    },
+                                    "end": {
+                                        "line": 15,
+                                        "column": 20,
+                                        "byte": 230
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -153,6 +179,19 @@
                         "symbol": [
                             {
                                 "key": "test",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 16,
+                                        "column": 13,
+                                        "byte": 244
+                                    },
+                                    "end": {
+                                        "line": 16,
+                                        "column": 17,
+                                        "byte": 248
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -169,6 +208,19 @@
                             },
                             {
                                 "key": "list",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 16,
+                                        "column": 17,
+                                        "byte": 248
+                                    },
+                                    "end": {
+                                        "line": 16,
+                                        "column": 22,
+                                        "byte": 253
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -185,6 +237,19 @@
                             },
                             {
                                 "index": 0,
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 16,
+                                        "column": 22,
+                                        "byte": 253
+                                    },
+                                    "end": {
+                                        "line": 16,
+                                        "column": 25,
+                                        "byte": 256
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -219,6 +284,19 @@
                         "symbol": [
                             {
                                 "key": "test",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 17,
+                                        "column": 15,
+                                        "byte": 272
+                                    },
+                                    "end": {
+                                        "line": 17,
+                                        "column": 19,
+                                        "byte": 276
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -235,6 +313,19 @@
                             },
                             {
                                 "key": "object",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 17,
+                                        "column": 19,
+                                        "byte": 276
+                                    },
+                                    "end": {
+                                        "line": 17,
+                                        "column": 26,
+                                        "byte": 283
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -251,6 +342,19 @@
                             },
                             {
                                 "key": "key",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 17,
+                                        "column": 26,
+                                        "byte": 283
+                                    },
+                                    "end": {
+                                        "line": 17,
+                                        "column": 30,
+                                        "byte": 287
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -285,6 +389,19 @@
                         "symbol": [
                             {
                                 "key": "test",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 14,
+                                        "column": 13,
+                                        "byte": 205
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 17,
+                                        "byte": 209
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -982,6 +1099,19 @@
                         "symbol": [
                             {
                                 "key": "test",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 15,
+                                        "column": 12,
+                                        "byte": 222
+                                    },
+                                    "end": {
+                                        "line": 15,
+                                        "column": 16,
+                                        "byte": 226
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -998,6 +1128,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 15,
+                                        "column": 16,
+                                        "byte": 226
+                                    },
+                                    "end": {
+                                        "line": 15,
+                                        "column": 20,
+                                        "byte": 230
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -1035,6 +1178,19 @@
                         "symbol": [
                             {
                                 "key": "test",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 16,
+                                        "column": 13,
+                                        "byte": 244
+                                    },
+                                    "end": {
+                                        "line": 16,
+                                        "column": 17,
+                                        "byte": 248
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -1051,6 +1207,19 @@
                             },
                             {
                                 "key": "list",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 16,
+                                        "column": 17,
+                                        "byte": 248
+                                    },
+                                    "end": {
+                                        "line": 16,
+                                        "column": 22,
+                                        "byte": 253
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -1067,6 +1236,19 @@
                             },
                             {
                                 "index": 0,
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 16,
+                                        "column": 22,
+                                        "byte": 253
+                                    },
+                                    "end": {
+                                        "line": 16,
+                                        "column": 25,
+                                        "byte": 256
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -1104,6 +1286,19 @@
                         "symbol": [
                             {
                                 "key": "test",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 17,
+                                        "column": 15,
+                                        "byte": 272
+                                    },
+                                    "end": {
+                                        "line": 17,
+                                        "column": 19,
+                                        "byte": 276
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -1120,6 +1315,19 @@
                             },
                             {
                                 "key": "object",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 17,
+                                        "column": 19,
+                                        "byte": 276
+                                    },
+                                    "end": {
+                                        "line": 17,
+                                        "column": 26,
+                                        "byte": 283
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -1136,6 +1344,19 @@
                             },
                             {
                                 "key": "key",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 17,
+                                        "column": 26,
+                                        "byte": 283
+                                    },
+                                    "end": {
+                                        "line": 17,
+                                        "column": 30,
+                                        "byte": 287
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {
@@ -1214,6 +1435,19 @@
                         "symbol": [
                             {
                                 "key": "test",
+                                "range": {
+                                    "environment": "open",
+                                    "begin": {
+                                        "line": 14,
+                                        "column": 13,
+                                        "byte": 205
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 17,
+                                        "byte": 209
+                                    }
+                                },
                                 "value": {
                                     "environment": "open",
                                     "begin": {

--- a/eval/testdata/eval/schema-error/expected.json
+++ b/eval/testdata/eval/schema-error/expected.json
@@ -1298,6 +1298,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 42,
+                                                "column": 16,
+                                                "byte": 1002
+                                            },
+                                            "end": {
+                                                "line": 42,
+                                                "column": 22,
+                                                "byte": 1008
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1314,6 +1327,19 @@
                                     },
                                     {
                                         "key": "false",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 42,
+                                                "column": 22,
+                                                "byte": 1008
+                                            },
+                                            "end": {
+                                                "line": 42,
+                                                "column": 28,
+                                                "byte": 1014
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1350,6 +1376,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 38,
+                                                "column": 18,
+                                                "byte": 882
+                                            },
+                                            "end": {
+                                                "line": 38,
+                                                "column": 24,
+                                                "byte": 888
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1366,6 +1405,19 @@
                                     },
                                     {
                                         "key": "null",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 38,
+                                                "column": 24,
+                                                "byte": 888
+                                            },
+                                            "end": {
+                                                "line": 38,
+                                                "column": 29,
+                                                "byte": 893
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1402,6 +1454,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 44,
+                                                "column": 22,
+                                                "byte": 1066
+                                            },
+                                            "end": {
+                                                "line": 44,
+                                                "column": 28,
+                                                "byte": 1072
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1418,6 +1483,19 @@
                                     },
                                     {
                                         "key": "string",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 44,
+                                                "column": 28,
+                                                "byte": 1072
+                                            },
+                                            "end": {
+                                                "line": 44,
+                                                "column": 35,
+                                                "byte": 1079
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1454,6 +1532,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 45,
+                                                "column": 23,
+                                                "byte": 1103
+                                            },
+                                            "end": {
+                                                "line": 45,
+                                                "column": 29,
+                                                "byte": 1109
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1470,6 +1561,19 @@
                                     },
                                     {
                                         "key": "string",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 45,
+                                                "column": 29,
+                                                "byte": 1109
+                                            },
+                                            "end": {
+                                                "line": 45,
+                                                "column": 36,
+                                                "byte": 1116
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1514,6 +1618,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 49,
+                                                "column": 23,
+                                                "byte": 1231
+                                            },
+                                            "end": {
+                                                "line": 49,
+                                                "column": 29,
+                                                "byte": 1237
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1530,6 +1647,19 @@
                                     },
                                     {
                                         "key": "record",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 49,
+                                                "column": 29,
+                                                "byte": 1237
+                                            },
+                                            "end": {
+                                                "line": 49,
+                                                "column": 36,
+                                                "byte": 1244
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1578,6 +1708,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 47,
+                                                "column": 17,
+                                                "byte": 1163
+                                            },
+                                            "end": {
+                                                "line": 47,
+                                                "column": 23,
+                                                "byte": 1169
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1594,6 +1737,19 @@
                                     },
                                     {
                                         "key": "triple",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 47,
+                                                "column": 23,
+                                                "byte": 1169
+                                            },
+                                            "end": {
+                                                "line": 47,
+                                                "column": 30,
+                                                "byte": 1176
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1630,6 +1786,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 46,
+                                                "column": 15,
+                                                "byte": 1132
+                                            },
+                                            "end": {
+                                                "line": 46,
+                                                "column": 21,
+                                                "byte": 1138
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1646,6 +1815,19 @@
                                     },
                                     {
                                         "key": "string",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 46,
+                                                "column": 21,
+                                                "byte": 1138
+                                            },
+                                            "end": {
+                                                "line": 46,
+                                                "column": 28,
+                                                "byte": 1145
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1683,6 +1865,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 54,
+                                                "column": 27,
+                                                "byte": 1427
+                                            },
+                                            "end": {
+                                                "line": 54,
+                                                "column": 33,
+                                                "byte": 1433
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1699,6 +1894,19 @@
                                     },
                                     {
                                         "key": "maximum",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 54,
+                                                "column": 33,
+                                                "byte": 1433
+                                            },
+                                            "end": {
+                                                "line": 54,
+                                                "column": 41,
+                                                "byte": 1441
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1736,6 +1944,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 52,
+                                                "column": 27,
+                                                "byte": 1343
+                                            },
+                                            "end": {
+                                                "line": 52,
+                                                "column": 33,
+                                                "byte": 1349
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1752,6 +1973,19 @@
                                     },
                                     {
                                         "key": "minimum",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 52,
+                                                "column": 33,
+                                                "byte": 1349
+                                            },
+                                            "end": {
+                                                "line": 52,
+                                                "column": 41,
+                                                "byte": 1357
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1800,6 +2034,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 59,
+                                                "column": 19,
+                                                "byte": 1580
+                                            },
+                                            "end": {
+                                                "line": 59,
+                                                "column": 25,
+                                                "byte": 1586
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1816,6 +2063,19 @@
                                     },
                                     {
                                         "key": "triple",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 59,
+                                                "column": 25,
+                                                "byte": 1586
+                                            },
+                                            "end": {
+                                                "line": 59,
+                                                "column": 32,
+                                                "byte": 1593
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1852,6 +2112,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 56,
+                                                "column": 20,
+                                                "byte": 1482
+                                            },
+                                            "end": {
+                                                "line": 56,
+                                                "column": 26,
+                                                "byte": 1488
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1868,6 +2141,19 @@
                                     },
                                     {
                                         "key": "string",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 56,
+                                                "column": 26,
+                                                "byte": 1488
+                                            },
+                                            "end": {
+                                                "line": 56,
+                                                "column": 33,
+                                                "byte": 1495
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1917,6 +2203,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 61,
+                                                "column": 24,
+                                                "byte": 1656
+                                            },
+                                            "end": {
+                                                "line": 61,
+                                                "column": 30,
+                                                "byte": 1662
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1933,6 +2232,19 @@
                                     },
                                     {
                                         "key": "dependentReq",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 61,
+                                                "column": 30,
+                                                "byte": 1662
+                                            },
+                                            "end": {
+                                                "line": 61,
+                                                "column": 43,
+                                                "byte": 1675
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1970,6 +2282,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 53,
+                                                "column": 18,
+                                                "byte": 1376
+                                            },
+                                            "end": {
+                                                "line": 53,
+                                                "column": 24,
+                                                "byte": 1382
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -1986,6 +2311,19 @@
                                     },
                                     {
                                         "key": "exclusiveMinimum",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 53,
+                                                "column": 24,
+                                                "byte": 1382
+                                            },
+                                            "end": {
+                                                "line": 53,
+                                                "column": 41,
+                                                "byte": 1399
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2031,6 +2369,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 58,
+                                                "column": 19,
+                                                "byte": 1547
+                                            },
+                                            "end": {
+                                                "line": 58,
+                                                "column": 25,
+                                                "byte": 1553
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2047,6 +2398,19 @@
                                     },
                                     {
                                         "key": "double",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 58,
+                                                "column": 25,
+                                                "byte": 1553
+                                            },
+                                            "end": {
+                                                "line": 58,
+                                                "column": 32,
+                                                "byte": 1560
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2101,6 +2465,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 60,
+                                                "column": 24,
+                                                "byte": 1618
+                                            },
+                                            "end": {
+                                                "line": 60,
+                                                "column": 30,
+                                                "byte": 1624
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2117,6 +2494,19 @@
                                     },
                                     {
                                         "key": "always",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 60,
+                                                "column": 30,
+                                                "byte": 1624
+                                            },
+                                            "end": {
+                                                "line": 60,
+                                                "column": 37,
+                                                "byte": 1631
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2154,6 +2544,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 51,
+                                                "column": 18,
+                                                "byte": 1292
+                                            },
+                                            "end": {
+                                                "line": 51,
+                                                "column": 24,
+                                                "byte": 1298
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2170,6 +2573,19 @@
                                     },
                                     {
                                         "key": "exclusiveMaximum",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 51,
+                                                "column": 24,
+                                                "byte": 1298
+                                            },
+                                            "end": {
+                                                "line": 51,
+                                                "column": 41,
+                                                "byte": 1315
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2207,6 +2623,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 50,
+                                                "column": 19,
+                                                "byte": 1264
+                                            },
+                                            "end": {
+                                                "line": 50,
+                                                "column": 25,
+                                                "byte": 1270
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2223,6 +2652,19 @@
                                     },
                                     {
                                         "key": "pi",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 50,
+                                                "column": 25,
+                                                "byte": 1270
+                                            },
+                                            "end": {
+                                                "line": 50,
+                                                "column": 28,
+                                                "byte": 1273
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2267,6 +2709,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 40,
+                                                "column": 17,
+                                                "byte": 941
+                                            },
+                                            "end": {
+                                                "line": 40,
+                                                "column": 23,
+                                                "byte": 947
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2283,6 +2738,19 @@
                                     },
                                     {
                                         "key": "record",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 40,
+                                                "column": 23,
+                                                "byte": 947
+                                            },
+                                            "end": {
+                                                "line": 40,
+                                                "column": 30,
+                                                "byte": 954
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2320,6 +2788,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 43,
+                                                "column": 16,
+                                                "byte": 1031
+                                            },
+                                            "end": {
+                                                "line": 43,
+                                                "column": 22,
+                                                "byte": 1037
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2336,6 +2817,19 @@
                                     },
                                     {
                                         "key": "false",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 43,
+                                                "column": 22,
+                                                "byte": 1037
+                                            },
+                                            "end": {
+                                                "line": 43,
+                                                "column": 28,
+                                                "byte": 1043
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2372,6 +2866,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 57,
+                                                "column": 18,
+                                                "byte": 1514
+                                            },
+                                            "end": {
+                                                "line": 57,
+                                                "column": 24,
+                                                "byte": 1520
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2388,6 +2895,19 @@
                                     },
                                     {
                                         "key": "string",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 57,
+                                                "column": 24,
+                                                "byte": 1520
+                                            },
+                                            "end": {
+                                                "line": 57,
+                                                "column": 31,
+                                                "byte": 1527
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2422,6 +2942,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 41,
+                                                "column": 17,
+                                                "byte": 972
+                                            },
+                                            "end": {
+                                                "line": 41,
+                                                "column": 23,
+                                                "byte": 978
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2438,6 +2971,19 @@
                                     },
                                     {
                                         "key": "always",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 41,
+                                                "column": 23,
+                                                "byte": 978
+                                            },
+                                            "end": {
+                                                "line": 41,
+                                                "column": 30,
+                                                "byte": 985
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2475,6 +3021,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 39,
+                                                "column": 17,
+                                                "byte": 911
+                                            },
+                                            "end": {
+                                                "line": 39,
+                                                "column": 23,
+                                                "byte": 917
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2491,6 +3050,19 @@
                                     },
                                     {
                                         "key": "array",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 39,
+                                                "column": 23,
+                                                "byte": 917
+                                            },
+                                            "end": {
+                                                "line": 39,
+                                                "column": 29,
+                                                "byte": 923
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2536,6 +3108,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 48,
+                                                "column": 17,
+                                                "byte": 1194
+                                            },
+                                            "end": {
+                                                "line": 48,
+                                                "column": 23,
+                                                "byte": 1200
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -2552,6 +3137,19 @@
                                     },
                                     {
                                         "key": "double",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 48,
+                                                "column": 23,
+                                                "byte": 1200
+                                            },
+                                            "end": {
+                                                "line": 48,
+                                                "column": 30,
+                                                "byte": 1207
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7404,6 +8002,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 42,
+                                                "column": 16,
+                                                "byte": 1002
+                                            },
+                                            "end": {
+                                                "line": 42,
+                                                "column": 22,
+                                                "byte": 1008
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7420,6 +8031,19 @@
                                     },
                                     {
                                         "key": "false",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 42,
+                                                "column": 22,
+                                                "byte": 1008
+                                            },
+                                            "end": {
+                                                "line": 42,
+                                                "column": 28,
+                                                "byte": 1014
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7456,6 +8080,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 38,
+                                                "column": 18,
+                                                "byte": 882
+                                            },
+                                            "end": {
+                                                "line": 38,
+                                                "column": 24,
+                                                "byte": 888
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7472,6 +8109,19 @@
                                     },
                                     {
                                         "key": "null",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 38,
+                                                "column": 24,
+                                                "byte": 888
+                                            },
+                                            "end": {
+                                                "line": 38,
+                                                "column": 29,
+                                                "byte": 893
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7509,6 +8159,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 44,
+                                                "column": 22,
+                                                "byte": 1066
+                                            },
+                                            "end": {
+                                                "line": 44,
+                                                "column": 28,
+                                                "byte": 1072
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7525,6 +8188,19 @@
                                     },
                                     {
                                         "key": "string",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 44,
+                                                "column": 28,
+                                                "byte": 1072
+                                            },
+                                            "end": {
+                                                "line": 44,
+                                                "column": 35,
+                                                "byte": 1079
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7562,6 +8238,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 45,
+                                                "column": 23,
+                                                "byte": 1103
+                                            },
+                                            "end": {
+                                                "line": 45,
+                                                "column": 29,
+                                                "byte": 1109
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7578,6 +8267,19 @@
                                     },
                                     {
                                         "key": "string",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 45,
+                                                "column": 29,
+                                                "byte": 1109
+                                            },
+                                            "end": {
+                                                "line": 45,
+                                                "column": 36,
+                                                "byte": 1116
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7623,6 +8325,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 49,
+                                                "column": 23,
+                                                "byte": 1231
+                                            },
+                                            "end": {
+                                                "line": 49,
+                                                "column": 29,
+                                                "byte": 1237
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7639,6 +8354,19 @@
                                     },
                                     {
                                         "key": "record",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 49,
+                                                "column": 29,
+                                                "byte": 1237
+                                            },
+                                            "end": {
+                                                "line": 49,
+                                                "column": 36,
+                                                "byte": 1244
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7690,6 +8418,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 47,
+                                                "column": 17,
+                                                "byte": 1163
+                                            },
+                                            "end": {
+                                                "line": 47,
+                                                "column": 23,
+                                                "byte": 1169
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7706,6 +8447,19 @@
                                     },
                                     {
                                         "key": "triple",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 47,
+                                                "column": 23,
+                                                "byte": 1169
+                                            },
+                                            "end": {
+                                                "line": 47,
+                                                "column": 30,
+                                                "byte": 1176
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7743,6 +8497,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 46,
+                                                "column": 15,
+                                                "byte": 1132
+                                            },
+                                            "end": {
+                                                "line": 46,
+                                                "column": 21,
+                                                "byte": 1138
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7759,6 +8526,19 @@
                                     },
                                     {
                                         "key": "string",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 46,
+                                                "column": 21,
+                                                "byte": 1138
+                                            },
+                                            "end": {
+                                                "line": 46,
+                                                "column": 28,
+                                                "byte": 1145
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7796,6 +8576,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 54,
+                                                "column": 27,
+                                                "byte": 1427
+                                            },
+                                            "end": {
+                                                "line": 54,
+                                                "column": 33,
+                                                "byte": 1433
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7812,6 +8605,19 @@
                                     },
                                     {
                                         "key": "maximum",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 54,
+                                                "column": 33,
+                                                "byte": 1433
+                                            },
+                                            "end": {
+                                                "line": 54,
+                                                "column": 41,
+                                                "byte": 1441
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7849,6 +8655,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 52,
+                                                "column": 27,
+                                                "byte": 1343
+                                            },
+                                            "end": {
+                                                "line": 52,
+                                                "column": 33,
+                                                "byte": 1349
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7865,6 +8684,19 @@
                                     },
                                     {
                                         "key": "minimum",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 52,
+                                                "column": 33,
+                                                "byte": 1349
+                                            },
+                                            "end": {
+                                                "line": 52,
+                                                "column": 41,
+                                                "byte": 1357
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7916,6 +8748,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 59,
+                                                "column": 19,
+                                                "byte": 1580
+                                            },
+                                            "end": {
+                                                "line": 59,
+                                                "column": 25,
+                                                "byte": 1586
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7932,6 +8777,19 @@
                                     },
                                     {
                                         "key": "triple",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 59,
+                                                "column": 25,
+                                                "byte": 1586
+                                            },
+                                            "end": {
+                                                "line": 59,
+                                                "column": 32,
+                                                "byte": 1593
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7969,6 +8827,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 56,
+                                                "column": 20,
+                                                "byte": 1482
+                                            },
+                                            "end": {
+                                                "line": 56,
+                                                "column": 26,
+                                                "byte": 1488
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -7985,6 +8856,19 @@
                                     },
                                     {
                                         "key": "string",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 56,
+                                                "column": 26,
+                                                "byte": 1488
+                                            },
+                                            "end": {
+                                                "line": 56,
+                                                "column": 33,
+                                                "byte": 1495
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8035,6 +8919,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 61,
+                                                "column": 24,
+                                                "byte": 1656
+                                            },
+                                            "end": {
+                                                "line": 61,
+                                                "column": 30,
+                                                "byte": 1662
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8051,6 +8948,19 @@
                                     },
                                     {
                                         "key": "dependentReq",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 61,
+                                                "column": 30,
+                                                "byte": 1662
+                                            },
+                                            "end": {
+                                                "line": 61,
+                                                "column": 43,
+                                                "byte": 1675
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8088,6 +8998,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 53,
+                                                "column": 18,
+                                                "byte": 1376
+                                            },
+                                            "end": {
+                                                "line": 53,
+                                                "column": 24,
+                                                "byte": 1382
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8104,6 +9027,19 @@
                                     },
                                     {
                                         "key": "exclusiveMinimum",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 53,
+                                                "column": 24,
+                                                "byte": 1382
+                                            },
+                                            "end": {
+                                                "line": 53,
+                                                "column": 41,
+                                                "byte": 1399
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8151,6 +9087,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 58,
+                                                "column": 19,
+                                                "byte": 1547
+                                            },
+                                            "end": {
+                                                "line": 58,
+                                                "column": 25,
+                                                "byte": 1553
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8167,6 +9116,19 @@
                                     },
                                     {
                                         "key": "double",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 58,
+                                                "column": 25,
+                                                "byte": 1553
+                                            },
+                                            "end": {
+                                                "line": 58,
+                                                "column": 32,
+                                                "byte": 1560
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8223,6 +9185,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 60,
+                                                "column": 24,
+                                                "byte": 1618
+                                            },
+                                            "end": {
+                                                "line": 60,
+                                                "column": 30,
+                                                "byte": 1624
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8239,6 +9214,19 @@
                                     },
                                     {
                                         "key": "always",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 60,
+                                                "column": 30,
+                                                "byte": 1624
+                                            },
+                                            "end": {
+                                                "line": 60,
+                                                "column": 37,
+                                                "byte": 1631
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8276,6 +9264,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 51,
+                                                "column": 18,
+                                                "byte": 1292
+                                            },
+                                            "end": {
+                                                "line": 51,
+                                                "column": 24,
+                                                "byte": 1298
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8292,6 +9293,19 @@
                                     },
                                     {
                                         "key": "exclusiveMaximum",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 51,
+                                                "column": 24,
+                                                "byte": 1298
+                                            },
+                                            "end": {
+                                                "line": 51,
+                                                "column": 41,
+                                                "byte": 1315
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8329,6 +9343,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 50,
+                                                "column": 19,
+                                                "byte": 1264
+                                            },
+                                            "end": {
+                                                "line": 50,
+                                                "column": 25,
+                                                "byte": 1270
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8345,6 +9372,19 @@
                                     },
                                     {
                                         "key": "pi",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 50,
+                                                "column": 25,
+                                                "byte": 1270
+                                            },
+                                            "end": {
+                                                "line": 50,
+                                                "column": 28,
+                                                "byte": 1273
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8390,6 +9430,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 40,
+                                                "column": 17,
+                                                "byte": 941
+                                            },
+                                            "end": {
+                                                "line": 40,
+                                                "column": 23,
+                                                "byte": 947
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8406,6 +9459,19 @@
                                     },
                                     {
                                         "key": "record",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 40,
+                                                "column": 23,
+                                                "byte": 947
+                                            },
+                                            "end": {
+                                                "line": 40,
+                                                "column": 30,
+                                                "byte": 954
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8443,6 +9509,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 43,
+                                                "column": 16,
+                                                "byte": 1031
+                                            },
+                                            "end": {
+                                                "line": 43,
+                                                "column": 22,
+                                                "byte": 1037
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8459,6 +9538,19 @@
                                     },
                                     {
                                         "key": "false",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 43,
+                                                "column": 22,
+                                                "byte": 1037
+                                            },
+                                            "end": {
+                                                "line": 43,
+                                                "column": 28,
+                                                "byte": 1043
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8496,6 +9588,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 57,
+                                                "column": 18,
+                                                "byte": 1514
+                                            },
+                                            "end": {
+                                                "line": 57,
+                                                "column": 24,
+                                                "byte": 1520
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8512,6 +9617,19 @@
                                     },
                                     {
                                         "key": "string",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 57,
+                                                "column": 24,
+                                                "byte": 1520
+                                            },
+                                            "end": {
+                                                "line": 57,
+                                                "column": 31,
+                                                "byte": 1527
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8548,6 +9666,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 41,
+                                                "column": 17,
+                                                "byte": 972
+                                            },
+                                            "end": {
+                                                "line": 41,
+                                                "column": 23,
+                                                "byte": 978
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8564,6 +9695,19 @@
                                     },
                                     {
                                         "key": "always",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 41,
+                                                "column": 23,
+                                                "byte": 978
+                                            },
+                                            "end": {
+                                                "line": 41,
+                                                "column": 30,
+                                                "byte": 985
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8633,6 +9777,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 39,
+                                                "column": 17,
+                                                "byte": 911
+                                            },
+                                            "end": {
+                                                "line": 39,
+                                                "column": 23,
+                                                "byte": 917
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8649,6 +9806,19 @@
                                     },
                                     {
                                         "key": "array",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 39,
+                                                "column": 23,
+                                                "byte": 917
+                                            },
+                                            "end": {
+                                                "line": 39,
+                                                "column": 29,
+                                                "byte": 923
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8696,6 +9866,19 @@
                                 "symbol": [
                                     {
                                         "key": "source",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 48,
+                                                "column": 17,
+                                                "byte": 1194
+                                            },
+                                            "end": {
+                                                "line": 48,
+                                                "column": 23,
+                                                "byte": 1200
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {
@@ -8712,6 +9895,19 @@
                                     },
                                     {
                                         "key": "double",
+                                        "range": {
+                                            "environment": "schema-error",
+                                            "begin": {
+                                                "line": 48,
+                                                "column": 23,
+                                                "byte": 1200
+                                            },
+                                            "end": {
+                                                "line": 48,
+                                                "column": 30,
+                                                "byte": 1207
+                                            }
+                                        },
                                         "value": {
                                             "environment": "schema-error",
                                             "begin": {

--- a/eval/testdata/eval/schema/expected.json
+++ b/eval/testdata/eval/schema/expected.json
@@ -53,6 +53,19 @@
                         "symbol": [
                             {
                                 "key": "sink",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 39,
+                                        "column": 9,
+                                        "byte": 895
+                                    },
+                                    "end": {
+                                        "line": 39,
+                                        "column": 13,
+                                        "byte": 899
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -69,6 +82,19 @@
                             },
                             {
                                 "key": "record",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 39,
+                                        "column": 13,
+                                        "byte": 899
+                                    },
+                                    "end": {
+                                        "line": 39,
+                                        "column": 20,
+                                        "byte": 906
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -85,6 +111,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 39,
+                                        "column": 20,
+                                        "byte": 906
+                                    },
+                                    "end": {
+                                        "line": 39,
+                                        "column": 24,
+                                        "byte": 910
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -122,6 +161,19 @@
                         "symbol": [
                             {
                                 "key": "sink",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 9,
+                                        "byte": 920
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 13,
+                                        "byte": 924
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -138,6 +190,19 @@
                             },
                             {
                                 "key": "tuple",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 13,
+                                        "byte": 924
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 19,
+                                        "byte": 930
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -154,6 +219,19 @@
                             },
                             {
                                 "index": 0,
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 19,
+                                        "byte": 930
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 22,
+                                        "byte": 933
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -188,6 +266,19 @@
                         "symbol": [
                             {
                                 "key": "sink",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 41,
+                                        "column": 9,
+                                        "byte": 943
+                                    },
+                                    "end": {
+                                        "line": 41,
+                                        "column": 13,
+                                        "byte": 947
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -204,6 +295,19 @@
                             },
                             {
                                 "key": "map",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 41,
+                                        "column": 13,
+                                        "byte": 947
+                                    },
+                                    "end": {
+                                        "line": 41,
+                                        "column": 17,
+                                        "byte": 951
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -220,6 +324,19 @@
                             },
                             {
                                 "key": "hello",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 41,
+                                        "column": 17,
+                                        "byte": 951
+                                    },
+                                    "end": {
+                                        "line": 41,
+                                        "column": 23,
+                                        "byte": 957
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -254,6 +371,19 @@
                         "symbol": [
                             {
                                 "key": "sink",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 42,
+                                        "column": 9,
+                                        "byte": 967
+                                    },
+                                    "end": {
+                                        "line": 42,
+                                        "column": 13,
+                                        "byte": 971
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -270,6 +400,19 @@
                             },
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 42,
+                                        "column": 13,
+                                        "byte": 971
+                                    },
+                                    "end": {
+                                        "line": 42,
+                                        "column": 19,
+                                        "byte": 977
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -286,6 +429,19 @@
                             },
                             {
                                 "index": 1,
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 42,
+                                        "column": 19,
+                                        "byte": 977
+                                    },
+                                    "end": {
+                                        "line": 42,
+                                        "column": 22,
+                                        "byte": 980
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -320,6 +476,19 @@
                         "symbol": [
                             {
                                 "key": "sink",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 43,
+                                        "column": 9,
+                                        "byte": 990
+                                    },
+                                    "end": {
+                                        "line": 43,
+                                        "column": 13,
+                                        "byte": 994
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -336,6 +505,19 @@
                             },
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 43,
+                                        "column": 13,
+                                        "byte": 994
+                                    },
+                                    "end": {
+                                        "line": 43,
+                                        "column": 19,
+                                        "byte": 1000
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -352,6 +534,19 @@
                             },
                             {
                                 "index": 2,
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 43,
+                                        "column": 19,
+                                        "byte": 1000
+                                    },
+                                    "end": {
+                                        "line": 43,
+                                        "column": 22,
+                                        "byte": 1003
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -368,6 +563,19 @@
                             },
                             {
                                 "key": "some",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 43,
+                                        "column": 22,
+                                        "byte": 1003
+                                    },
+                                    "end": {
+                                        "line": 43,
+                                        "column": 27,
+                                        "byte": 1008
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -402,6 +610,19 @@
                         "symbol": [
                             {
                                 "key": "sink",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 44,
+                                        "column": 9,
+                                        "byte": 1018
+                                    },
+                                    "end": {
+                                        "line": 44,
+                                        "column": 13,
+                                        "byte": 1022
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -418,6 +639,19 @@
                             },
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 44,
+                                        "column": 13,
+                                        "byte": 1022
+                                    },
+                                    "end": {
+                                        "line": 44,
+                                        "column": 19,
+                                        "byte": 1028
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -434,6 +668,19 @@
                             },
                             {
                                 "index": 3,
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 44,
+                                        "column": 19,
+                                        "byte": 1028
+                                    },
+                                    "end": {
+                                        "line": 44,
+                                        "column": 22,
+                                        "byte": 1031
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -450,6 +697,19 @@
                             },
                             {
                                 "index": 0,
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 44,
+                                        "column": 22,
+                                        "byte": 1031
+                                    },
+                                    "end": {
+                                        "line": 44,
+                                        "column": 25,
+                                        "byte": 1034
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -1171,6 +1431,19 @@
                         "symbol": [
                             {
                                 "key": "source",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 37,
+                                        "column": 25,
+                                        "byte": 867
+                                    },
+                                    "end": {
+                                        "line": 37,
+                                        "column": 31,
+                                        "byte": 873
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4544,6 +4817,19 @@
                         "symbol": [
                             {
                                 "key": "sink",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 39,
+                                        "column": 9,
+                                        "byte": 895
+                                    },
+                                    "end": {
+                                        "line": 39,
+                                        "column": 13,
+                                        "byte": 899
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4560,6 +4846,19 @@
                             },
                             {
                                 "key": "record",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 39,
+                                        "column": 13,
+                                        "byte": 899
+                                    },
+                                    "end": {
+                                        "line": 39,
+                                        "column": 20,
+                                        "byte": 906
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4576,6 +4875,19 @@
                             },
                             {
                                 "key": "foo",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 39,
+                                        "column": 20,
+                                        "byte": 906
+                                    },
+                                    "end": {
+                                        "line": 39,
+                                        "column": 24,
+                                        "byte": 910
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4613,6 +4925,19 @@
                         "symbol": [
                             {
                                 "key": "sink",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 9,
+                                        "byte": 920
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 13,
+                                        "byte": 924
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4629,6 +4954,19 @@
                             },
                             {
                                 "key": "tuple",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 13,
+                                        "byte": 924
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 19,
+                                        "byte": 930
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4645,6 +4983,19 @@
                             },
                             {
                                 "index": 0,
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 40,
+                                        "column": 19,
+                                        "byte": 930
+                                    },
+                                    "end": {
+                                        "line": 40,
+                                        "column": 22,
+                                        "byte": 933
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4682,6 +5033,19 @@
                         "symbol": [
                             {
                                 "key": "sink",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 41,
+                                        "column": 9,
+                                        "byte": 943
+                                    },
+                                    "end": {
+                                        "line": 41,
+                                        "column": 13,
+                                        "byte": 947
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4698,6 +5062,19 @@
                             },
                             {
                                 "key": "map",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 41,
+                                        "column": 13,
+                                        "byte": 947
+                                    },
+                                    "end": {
+                                        "line": 41,
+                                        "column": 17,
+                                        "byte": 951
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4714,6 +5091,19 @@
                             },
                             {
                                 "key": "hello",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 41,
+                                        "column": 17,
+                                        "byte": 951
+                                    },
+                                    "end": {
+                                        "line": 41,
+                                        "column": 23,
+                                        "byte": 957
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4751,6 +5141,19 @@
                         "symbol": [
                             {
                                 "key": "sink",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 42,
+                                        "column": 9,
+                                        "byte": 967
+                                    },
+                                    "end": {
+                                        "line": 42,
+                                        "column": 13,
+                                        "byte": 971
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4767,6 +5170,19 @@
                             },
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 42,
+                                        "column": 13,
+                                        "byte": 971
+                                    },
+                                    "end": {
+                                        "line": 42,
+                                        "column": 19,
+                                        "byte": 977
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4783,6 +5199,19 @@
                             },
                             {
                                 "index": 1,
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 42,
+                                        "column": 19,
+                                        "byte": 977
+                                    },
+                                    "end": {
+                                        "line": 42,
+                                        "column": 22,
+                                        "byte": 980
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4820,6 +5249,19 @@
                         "symbol": [
                             {
                                 "key": "sink",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 43,
+                                        "column": 9,
+                                        "byte": 990
+                                    },
+                                    "end": {
+                                        "line": 43,
+                                        "column": 13,
+                                        "byte": 994
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4836,6 +5278,19 @@
                             },
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 43,
+                                        "column": 13,
+                                        "byte": 994
+                                    },
+                                    "end": {
+                                        "line": 43,
+                                        "column": 19,
+                                        "byte": 1000
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4852,6 +5307,19 @@
                             },
                             {
                                 "index": 2,
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 43,
+                                        "column": 19,
+                                        "byte": 1000
+                                    },
+                                    "end": {
+                                        "line": 43,
+                                        "column": 22,
+                                        "byte": 1003
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4868,6 +5336,19 @@
                             },
                             {
                                 "key": "some",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 43,
+                                        "column": 22,
+                                        "byte": 1003
+                                    },
+                                    "end": {
+                                        "line": 43,
+                                        "column": 27,
+                                        "byte": 1008
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4905,6 +5386,19 @@
                         "symbol": [
                             {
                                 "key": "sink",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 44,
+                                        "column": 9,
+                                        "byte": 1018
+                                    },
+                                    "end": {
+                                        "line": 44,
+                                        "column": 13,
+                                        "byte": 1022
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4921,6 +5415,19 @@
                             },
                             {
                                 "key": "array",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 44,
+                                        "column": 13,
+                                        "byte": 1022
+                                    },
+                                    "end": {
+                                        "line": 44,
+                                        "column": 19,
+                                        "byte": 1028
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4937,6 +5444,19 @@
                             },
                             {
                                 "index": 3,
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 44,
+                                        "column": 19,
+                                        "byte": 1028
+                                    },
+                                    "end": {
+                                        "line": 44,
+                                        "column": 22,
+                                        "byte": 1031
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -4953,6 +5473,19 @@
                             },
                             {
                                 "index": 0,
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 44,
+                                        "column": 22,
+                                        "byte": 1031
+                                    },
+                                    "end": {
+                                        "line": 44,
+                                        "column": 25,
+                                        "byte": 1034
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {
@@ -5850,6 +6383,19 @@
                         "symbol": [
                             {
                                 "key": "source",
+                                "range": {
+                                    "environment": "schema",
+                                    "begin": {
+                                        "line": 37,
+                                        "column": 25,
+                                        "byte": 867
+                                    },
+                                    "end": {
+                                        "line": 37,
+                                        "column": 31,
+                                        "byte": 873
+                                    }
+                                },
                                 "value": {
                                     "environment": "schema",
                                     "begin": {

--- a/eval/testdata/eval/secret-objects/expected.json
+++ b/eval/testdata/eval/secret-objects/expected.json
@@ -22,6 +22,19 @@
                 "symbol": [
                     {
                         "key": "unmarshalled_secret_array",
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 10,
+                                "column": 29,
+                                "byte": 305
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 54,
+                                "byte": 330
+                            }
+                        },
                         "value": {
                             "environment": "secret-objects",
                             "begin": {
@@ -38,6 +51,19 @@
                     },
                     {
                         "index": 0,
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 10,
+                                "column": 54,
+                                "byte": 330
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 57,
+                                "byte": 333
+                            }
+                        },
                         "value": {
                             "environment": "secret-objects",
                             "begin": {
@@ -75,6 +101,19 @@
                 "symbol": [
                     {
                         "key": "unmarshalled_secret_object",
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 11,
+                                "column": 30,
+                                "byte": 364
+                            },
+                            "end": {
+                                "line": 11,
+                                "column": 56,
+                                "byte": 390
+                            }
+                        },
                         "value": {
                             "environment": "secret-objects",
                             "begin": {
@@ -91,6 +130,19 @@
                     },
                     {
                         "key": "haha",
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 11,
+                                "column": 56,
+                                "byte": 390
+                            },
+                            "end": {
+                                "line": 11,
+                                "column": 61,
+                                "byte": 395
+                            }
+                        },
                         "value": {
                             "environment": "secret-objects",
                             "begin": {
@@ -292,6 +344,19 @@
                         "symbol": [
                             {
                                 "key": "secret_array",
+                                "range": {
+                                    "environment": "secret-objects",
+                                    "begin": {
+                                        "line": 9,
+                                        "column": 21,
+                                        "byte": 263
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 33,
+                                        "byte": 275
+                                    }
+                                },
                                 "value": {
                                     "environment": "secret-objects",
                                     "begin": {
@@ -378,6 +443,19 @@
                         "symbol": [
                             {
                                 "key": "secret_object",
+                                "range": {
+                                    "environment": "secret-objects",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 21,
+                                        "byte": 129
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 34,
+                                        "byte": 142
+                                    }
+                                },
                                 "value": {
                                     "environment": "secret-objects",
                                     "begin": {
@@ -729,6 +807,19 @@
                 "symbol": [
                     {
                         "key": "unmarshalled_secret_array",
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 10,
+                                "column": 29,
+                                "byte": 305
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 54,
+                                "byte": 330
+                            }
+                        },
                         "value": {
                             "environment": "secret-objects",
                             "begin": {
@@ -745,6 +836,19 @@
                     },
                     {
                         "index": 0,
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 10,
+                                "column": 54,
+                                "byte": 330
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 57,
+                                "byte": 333
+                            }
+                        },
                         "value": {
                             "environment": "secret-objects",
                             "begin": {
@@ -782,6 +886,19 @@
                 "symbol": [
                     {
                         "key": "unmarshalled_secret_object",
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 11,
+                                "column": 30,
+                                "byte": 364
+                            },
+                            "end": {
+                                "line": 11,
+                                "column": 56,
+                                "byte": 390
+                            }
+                        },
                         "value": {
                             "environment": "secret-objects",
                             "begin": {
@@ -798,6 +915,19 @@
                     },
                     {
                         "key": "haha",
+                        "range": {
+                            "environment": "secret-objects",
+                            "begin": {
+                                "line": 11,
+                                "column": 56,
+                                "byte": 390
+                            },
+                            "end": {
+                                "line": 11,
+                                "column": 61,
+                                "byte": 395
+                            }
+                        },
                         "value": {
                             "environment": "secret-objects",
                             "begin": {
@@ -999,6 +1129,19 @@
                         "symbol": [
                             {
                                 "key": "secret_array",
+                                "range": {
+                                    "environment": "secret-objects",
+                                    "begin": {
+                                        "line": 9,
+                                        "column": 21,
+                                        "byte": 263
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 33,
+                                        "byte": 275
+                                    }
+                                },
                                 "value": {
                                     "environment": "secret-objects",
                                     "begin": {
@@ -1085,6 +1228,19 @@
                         "symbol": [
                             {
                                 "key": "secret_object",
+                                "range": {
+                                    "environment": "secret-objects",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 21,
+                                        "byte": 129
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 34,
+                                        "byte": 142
+                                    }
+                                },
                                 "value": {
                                     "environment": "secret-objects",
                                     "begin": {

--- a/expr.go
+++ b/expr.go
@@ -75,6 +75,9 @@ type Accessor struct {
 
 	// The key of the property to access. Mutually exclusive with Index.
 	Key *string `json:"key,omitempty"`
+
+	// The range of the accessor.
+	Range Range `json:"range,omitempty"`
 }
 
 // A PropertyAccessor is a single accessor that is associated with a resolved value.

--- a/syntax/encoding/yaml.go
+++ b/syntax/encoding/yaml.go
@@ -54,6 +54,31 @@ func (s YAMLSyntax) Path() string {
 	return s.path
 }
 
+func (s YAMLSyntax) ScalarRange(start, end int) *hcl.Range {
+	if s.rng == nil || s.Kind != yaml.ScalarNode {
+		return nil
+	}
+
+	// TODO: handle multi-line and quoted scalars.
+	if s.rng.Start.Line != s.rng.End.Line || (s.Style != 0 && s.Style != yaml.FlowStyle) {
+		return nil
+	}
+
+	startPos := s.rng.Start
+	startPos.Byte += start
+	startPos.Column += uniseg.StringWidth(s.Value[:start])
+
+	endPos := s.rng.Start
+	endPos.Byte += end
+	endPos.Column += uniseg.StringWidth(s.Value[:end])
+
+	return &hcl.Range{
+		Filename: s.rng.Filename,
+		Start:    startPos,
+		End:      endPos,
+	}
+}
+
 func (s YAMLSyntax) HeadComment() string {
 	return s.Node.HeadComment
 }

--- a/syntax/encoding/yaml.go
+++ b/syntax/encoding/yaml.go
@@ -59,7 +59,7 @@ func (s YAMLSyntax) ScalarRange(start, end int) *hcl.Range {
 		return nil
 	}
 
-	// TODO: handle multi-line and quoted scalars.
+	// #237: handle other string styles
 	if s.rng.Start.Line != s.rng.End.Line || (s.Style != 0 && s.Style != yaml.FlowStyle) {
 		return nil
 	}

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -35,6 +35,12 @@ func (noSyntax) Path() string {
 	return ""
 }
 
+type Scalar interface {
+	Syntax
+
+	ScalarRange(start, end int) *hcl.Range
+}
+
 type Trivia interface {
 	Syntax
 


### PR DESCRIPTION
These changes add support for reporting ranges for accessors in single-line flow strings (i.e. single-line strings that are not quoted).

Multi-line strings are quite a bit more complicated to support. The string we get from the YAML parser has already been processed to remove indentation, fold newlines, etc., so its bytes do not represent the bytes in the original file. We will want to add support for these strings in the future, but doing so is something of an open problem.