### PR TITLE
ast: refine ranges for property errors

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,4 +12,7 @@
 - Populate source positions for property accessors in single-line flow scalars.
   [#231](https://github.com/pulumi/esc/pull/231)
 
+- Provide more accurate accessor diagnostic positions.
+  [#238](https://github.com/pulumi/esc/pull/238)
+
 ### Bug Fixes

--- a/ast/testdata/parse/invalid-interpolations/expected.json
+++ b/ast/testdata/parse/invalid-interpolations/expected.json
@@ -314,8 +314,8 @@
                 "Filename": "invalid-interpolations",
                 "Start": {
                     "Line": 3,
-                    "Column": 7,
-                    "Byte": 32
+                    "Column": 9,
+                    "Byte": 34
                 },
                 "End": {
                     "Line": 3,
@@ -337,8 +337,8 @@
                 "Filename": "invalid-interpolations",
                 "Start": {
                     "Line": 5,
-                    "Column": 7,
-                    "Byte": 51
+                    "Column": 12,
+                    "Byte": 56
                 },
                 "End": {
                     "Line": 5,
@@ -360,8 +360,8 @@
                 "Filename": "invalid-interpolations",
                 "Start": {
                     "Line": 5,
-                    "Column": 7,
-                    "Byte": 51
+                    "Column": 13,
+                    "Byte": 57
                 },
                 "End": {
                     "Line": 5,
@@ -383,8 +383,8 @@
                 "Filename": "invalid-interpolations",
                 "Start": {
                     "Line": 6,
-                    "Column": 7,
-                    "Byte": 64
+                    "Column": 35,
+                    "Byte": 92
                 },
                 "End": {
                     "Line": 6,
@@ -406,13 +406,13 @@
                 "Filename": "invalid-interpolations",
                 "Start": {
                     "Line": 7,
-                    "Column": 7,
-                    "Byte": 99
+                    "Column": 25,
+                    "Byte": 117
                 },
                 "End": {
                     "Line": 7,
-                    "Column": 32,
-                    "Byte": 124
+                    "Column": 26,
+                    "Byte": 118
                 }
             },
             "Context": null,
@@ -423,19 +423,42 @@
         },
         {
             "Severity": 1,
+            "Summary": "subscript is missing closing bracket ']'",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-interpolations",
+                "Start": {
+                    "Line": 8,
+                    "Column": 25,
+                    "Byte": 149
+                },
+                "End": {
+                    "Line": 8,
+                    "Column": 26,
+                    "Byte": 150
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.interpolations[5]"
+        },
+        {
+            "Severity": 1,
             "Summary": "numeric subscript must be a positive base-10 integer",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-interpolations",
                 "Start": {
                     "Line": 8,
-                    "Column": 7,
-                    "Byte": 131
+                    "Column": 26,
+                    "Byte": 150
                 },
                 "End": {
                     "Line": 8,
-                    "Column": 37,
-                    "Byte": 161
+                    "Column": 26,
+                    "Byte": 150
                 }
             },
             "Context": null,
@@ -451,32 +474,9 @@
             "Subject": {
                 "Filename": "invalid-interpolations",
                 "Start": {
-                    "Line": 8,
-                    "Column": 7,
-                    "Byte": 131
-                },
-                "End": {
-                    "Line": 8,
-                    "Column": 37,
-                    "Byte": 161
-                }
-            },
-            "Context": null,
-            "Expression": null,
-            "EvalContext": null,
-            "Extra": null,
-            "Path": "values.interpolations[5]"
-        },
-        {
-            "Severity": 1,
-            "Summary": "key subscript is missing closing quote '\"'",
-            "Detail": "",
-            "Subject": {
-                "Filename": "invalid-interpolations",
-                "Start": {
                     "Line": 9,
-                    "Column": 7,
-                    "Byte": 168
+                    "Column": 24,
+                    "Byte": 185
                 },
                 "End": {
                     "Line": 9,
@@ -492,14 +492,14 @@
         },
         {
             "Severity": 1,
-            "Summary": "subscript is missing closing bracket ']'",
+            "Summary": "key subscript is missing closing quote '\"'",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-interpolations",
                 "Start": {
                     "Line": 9,
-                    "Column": 7,
-                    "Byte": 168
+                    "Column": 25,
+                    "Byte": 186
                 },
                 "End": {
                     "Line": 9,
@@ -521,8 +521,8 @@
                 "Filename": "invalid-interpolations",
                 "Start": {
                     "Line": 9,
-                    "Column": 7,
-                    "Byte": 168
+                    "Column": 31,
+                    "Byte": 192
                 },
                 "End": {
                     "Line": 9,
@@ -544,13 +544,13 @@
                 "Filename": "invalid-interpolations",
                 "Start": {
                     "Line": 10,
-                    "Column": 7,
-                    "Byte": 199
+                    "Column": 25,
+                    "Byte": 217
                 },
                 "End": {
                     "Line": 10,
-                    "Column": 36,
-                    "Byte": 228
+                    "Column": 34,
+                    "Byte": 226
                 }
             },
             "Context": null,

--- a/eval/testdata/eval/invalid-access-load/expected.json
+++ b/eval/testdata/eval/invalid-access-load/expected.json
@@ -8,8 +8,8 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 3,
-                    "Column": 7,
-                    "Byte": 36
+                    "Column": 9,
+                    "Byte": 38
                 },
                 "End": {
                     "Line": 3,
@@ -31,13 +31,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 4,
-                    "Column": 7,
-                    "Byte": 45
+                    "Column": 13,
+                    "Byte": 51
                 },
                 "End": {
                     "Line": 4,
-                    "Column": 20,
-                    "Byte": 58
+                    "Column": 19,
+                    "Byte": 57
                 }
             },
             "Context": null,
@@ -48,14 +48,14 @@
         },
         {
             "Severity": 1,
-            "Summary": "key subscript is missing closing quote '\"'",
+            "Summary": "subscript is missing closing bracket ']'",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 5,
-                    "Column": 7,
-                    "Byte": 65
+                    "Column": 13,
+                    "Byte": 71
                 },
                 "End": {
                     "Line": 5,
@@ -71,14 +71,14 @@
         },
         {
             "Severity": 1,
-            "Summary": "subscript is missing closing bracket ']'",
+            "Summary": "key subscript is missing closing quote '\"'",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 5,
-                    "Column": 7,
-                    "Byte": 65
+                    "Column": 14,
+                    "Byte": 72
                 },
                 "End": {
                     "Line": 5,
@@ -100,8 +100,8 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 5,
-                    "Column": 7,
-                    "Byte": 65
+                    "Column": 20,
+                    "Byte": 78
                 },
                 "End": {
                     "Line": 5,
@@ -123,8 +123,8 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 6,
-                    "Column": 7,
-                    "Byte": 85
+                    "Column": 20,
+                    "Byte": 98
                 },
                 "End": {
                     "Line": 6,
@@ -146,13 +146,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 7,
-                    "Column": 7,
-                    "Byte": 105
+                    "Column": 14,
+                    "Byte": 112
                 },
                 "End": {
                     "Line": 7,
-                    "Column": 17,
-                    "Byte": 115
+                    "Column": 16,
+                    "Byte": 114
                 }
             },
             "Context": null,
@@ -169,13 +169,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 8,
-                    "Column": 7,
-                    "Byte": 122
+                    "Column": 15,
+                    "Byte": 130
                 },
                 "End": {
                     "Line": 8,
-                    "Column": 27,
-                    "Byte": 142
+                    "Column": 25,
+                    "Byte": 140
                 }
             },
             "Context": null,
@@ -192,13 +192,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 10,
-                    "Column": 7,
-                    "Byte": 159
+                    "Column": 9,
+                    "Byte": 161
                 },
                 "End": {
                     "Line": 10,
-                    "Column": 13,
-                    "Byte": 165
+                    "Column": 11,
+                    "Byte": 163
                 }
             },
             "Context": null,
@@ -215,13 +215,13 @@
                 "Filename": "invalid-access-load",
                 "Start": {
                     "Line": 11,
-                    "Column": 7,
-                    "Byte": 172
+                    "Column": 10,
+                    "Byte": 175
                 },
                 "End": {
                     "Line": 11,
-                    "Column": 19,
-                    "Byte": 184
+                    "Column": 11,
+                    "Byte": 176
                 }
             },
             "Context": null,


### PR DESCRIPTION
These changes refine the ranges for errors encountered when parsing properties. When possible, errors will now be associated with the erroneous accessor rather than the parent string.