### PR TITLE
Add support for execution context data for interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,6 @@
 CHANGELOG
 =========
 
-## 0.8.0
-
-### Bug Fixes
-
-- Add support for execution context interpolation.
-  [#239](https://github.com/pulumi/esc/pull/239)
-
 ## 0.7.0
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+## 0.8.0
+
+### Bug Fixes
+
+- Add support for execution context interpolation.
+  [#239](https://github.com/pulumi/esc/pull/239)
+
 ## 0.7.0
 
 ### Bug Fixes

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,4 +15,7 @@
 - Provide more accurate accessor diagnostic positions.
   [#238](https://github.com/pulumi/esc/pull/238)
 
+- Add support for execution context interpolation.
+  [#239](https://github.com/pulumi/esc/pull/239)
+
 ### Bug Fixes

--- a/analysis/describe_test.go
+++ b/analysis/describe_test.go
@@ -31,7 +31,7 @@ func TestDescribe(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, diags)
 
-	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, esc.NewValue(map[string]esc.Value{}))
+	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, map[string]esc.Value{})
 	require.Empty(t, diags)
 
 	analysis := New(*env, map[string]*schema.Schema{"test": testProviderSchema})
@@ -102,7 +102,7 @@ func TestDescribeOpen(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, diags)
 
-	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, esc.NewValue(map[string]esc.Value{}))
+	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, map[string]esc.Value{})
 	require.Empty(t, diags)
 
 	analysis := New(*env, map[string]*schema.Schema{"test": testProviderSchema})

--- a/analysis/describe_test.go
+++ b/analysis/describe_test.go
@@ -31,7 +31,7 @@ func TestDescribe(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, diags)
 
-	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{})
+	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, esc.NewValue(map[string]esc.Value{}))
 	require.Empty(t, diags)
 
 	analysis := New(*env, map[string]*schema.Schema{"test": testProviderSchema})
@@ -102,7 +102,7 @@ func TestDescribeOpen(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, diags)
 
-	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{})
+	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, esc.NewValue(map[string]esc.Value{}))
 	require.Empty(t, diags)
 
 	analysis := New(*env, map[string]*schema.Schema{"test": testProviderSchema})

--- a/analysis/traversal_test.go
+++ b/analysis/traversal_test.go
@@ -30,7 +30,7 @@ func TestExpressionAt(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, diags)
 
-	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, esc.NewValue(map[string]esc.Value{}))
+	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, map[string]esc.Value{})
 	require.Empty(t, diags)
 
 	analysis := New(*env, map[string]*schema.Schema{"test": testProviderSchema})

--- a/analysis/traversal_test.go
+++ b/analysis/traversal_test.go
@@ -30,7 +30,7 @@ func TestExpressionAt(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, diags)
 
-	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{})
+	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, esc.NewValue(map[string]esc.Value{}))
 	require.Empty(t, diags)
 
 	analysis := New(*env, map[string]*schema.Schema{"test": testProviderSchema})

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -339,7 +339,7 @@ func (c *testPulumiClient) checkEnvironment(ctx context.Context, orgName, envNam
 	providers := &testProviders{}
 	envLoader := &testEnvironments{orgName: orgName, environments: c.environments}
 
-	checked, checkDiags := eval.CheckEnvironment(ctx, envName, environment, providers, envLoader, esc.NewValue(map[string]esc.Value{}))
+	checked, checkDiags := eval.CheckEnvironment(ctx, envName, environment, providers, envLoader, map[string]esc.Value{})
 	diags.Extend(checkDiags...)
 	return checked, mapDiags(diags), nil
 }
@@ -361,7 +361,7 @@ func (c *testPulumiClient) openEnvironment(ctx context.Context, orgName, name st
 	providers := &testProviders{}
 	envLoader := &testEnvironments{orgName: orgName, environments: c.environments}
 
-	openEnv, evalDiags := eval.EvalEnvironment(ctx, name, decl, rot128{}, providers, envLoader, esc.NewValue(map[string]esc.Value{}))
+	openEnv, evalDiags := eval.EvalEnvironment(ctx, name, decl, rot128{}, providers, envLoader, map[string]esc.Value{})
 	diags.Extend(evalDiags...)
 
 	if diags.HasErrors() {

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -339,7 +339,7 @@ func (c *testPulumiClient) checkEnvironment(ctx context.Context, orgName, envNam
 	providers := &testProviders{}
 	envLoader := &testEnvironments{orgName: orgName, environments: c.environments}
 
-	checked, checkDiags := eval.CheckEnvironment(ctx, envName, environment, providers, envLoader)
+	checked, checkDiags := eval.CheckEnvironment(ctx, envName, environment, providers, envLoader, esc.NewValue(map[string]esc.Value{}))
 	diags.Extend(checkDiags...)
 	return checked, mapDiags(diags), nil
 }
@@ -361,7 +361,7 @@ func (c *testPulumiClient) openEnvironment(ctx context.Context, orgName, name st
 	providers := &testProviders{}
 	envLoader := &testEnvironments{orgName: orgName, environments: c.environments}
 
-	openEnv, evalDiags := eval.EvalEnvironment(ctx, name, decl, rot128{}, providers, envLoader)
+	openEnv, evalDiags := eval.EvalEnvironment(ctx, name, decl, rot128{}, providers, envLoader, esc.NewValue(map[string]esc.Value{}))
 	diags.Extend(evalDiags...)
 
 	if diags.HasErrors() {

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -336,6 +336,7 @@ func (e *evalContext) isReserveTopLevelKey(k string) bool {
 func (e *evalContext) evaluate() (*value, syntax.Diagnostics) {
 	// Evaluate imports. We do this prior to declaration so that we can plumb base values as part of declaration.
 	e.evaluateImports()
+	// Evaliate context. We prepare the context values to later evaluate interpolations.
 	e.evaluateContext()
 
 	// Build the root value. We do this manually b/c the AST uses a declaration rather than an expression for the
@@ -619,6 +620,7 @@ func (e *evalContext) evaluateExprAccess(x *expr, accessors []*propertyAccessor)
 		return e.evaluateValueAccess(x.repr.syntax(), e.myImports, accessors[1:])
 	}
 
+	// Check for context interpolation.
 	if ok && k == "context" {
 		accessors[0].value = e.myContext
 		return e.evaluateValueAccess(x.repr.syntax(), e.myContext, accessors[1:])

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -77,7 +77,7 @@ func EvalEnvironment(
 	decrypter Decrypter,
 	providers ProviderLoader,
 	environments EnvironmentLoader,
-	context esc.Value,
+	context map[string]esc.Value,
 ) (*esc.Environment, syntax.Diagnostics) {
 	return evalEnvironment(ctx, false, name, env, decrypter, providers, environments, context)
 }
@@ -90,7 +90,7 @@ func CheckEnvironment(
 	env *ast.EnvironmentDecl,
 	providers ProviderLoader,
 	environments EnvironmentLoader,
-	context esc.Value,
+	context map[string]esc.Value,
 ) (*esc.Environment, syntax.Diagnostics) {
 	return evalEnvironment(ctx, true, name, env, nil, providers, environments, context)
 }
@@ -104,7 +104,7 @@ func evalEnvironment(
 	decrypter Decrypter,
 	providers ProviderLoader,
 	envs EnvironmentLoader,
-	context esc.Value,
+	context map[string]esc.Value,
 ) (*esc.Environment, syntax.Diagnostics) {
 	if env == nil || (len(env.Values.GetEntries()) == 0 && len(env.Imports.GetElements()) == 0) {
 		return nil, nil
@@ -144,7 +144,7 @@ type evalContext struct {
 	providers     ProviderLoader       // the provider loader to use
 	environments  EnvironmentLoader    // the environment loader to use
 	imports       map[string]*imported // the shared set of imported environments
-	contextValues esc.Value            // evaluation context used for interpolation
+	contextValues map[string]esc.Value // evaluation context used for interpolation
 
 	myContext *value // evaluated context to be used to interpolate properties
 	myImports *value // directly-imported environments
@@ -163,7 +163,7 @@ func newEvalContext(
 	providers ProviderLoader,
 	environments EnvironmentLoader,
 	imports map[string]*imported,
-	contextValues esc.Value,
+	contextValues map[string]esc.Value,
 ) *evalContext {
 	return &evalContext{
 		ctx:           ctx,
@@ -370,7 +370,7 @@ func (e *evalContext) evaluate() (*value, syntax.Diagnostics) {
 
 func (e *evalContext) evaluateContext() {
 	def := declare(e, "", ast.Symbol(&ast.PropertyName{Name: "context"}), nil)
-	e.myContext = unexport(e.contextValues, def)
+	e.myContext = unexport(esc.NewValue(e.contextValues), def)
 }
 
 // evaluateImports evaluates an environment's imports.

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -77,8 +77,9 @@ func EvalEnvironment(
 	decrypter Decrypter,
 	providers ProviderLoader,
 	environments EnvironmentLoader,
+	context esc.Value,
 ) (*esc.Environment, syntax.Diagnostics) {
-	return evalEnvironment(ctx, false, name, env, decrypter, providers, environments)
+	return evalEnvironment(ctx, false, name, env, decrypter, providers, environments, context)
 }
 
 // CheckEnvironment symbolically evaluates the given environment. Calls to fn::open are not invoked, and instead
@@ -89,8 +90,9 @@ func CheckEnvironment(
 	env *ast.EnvironmentDecl,
 	providers ProviderLoader,
 	environments EnvironmentLoader,
+	context esc.Value,
 ) (*esc.Environment, syntax.Diagnostics) {
-	return evalEnvironment(ctx, true, name, env, nil, providers, environments)
+	return evalEnvironment(ctx, true, name, env, nil, providers, environments, context)
 }
 
 // evalEnvironment evaluates an environment and exports the result of evaluation.
@@ -102,12 +104,13 @@ func evalEnvironment(
 	decrypter Decrypter,
 	providers ProviderLoader,
 	envs EnvironmentLoader,
+	context esc.Value,
 ) (*esc.Environment, syntax.Diagnostics) {
 	if env == nil || (len(env.Values.GetEntries()) == 0 && len(env.Imports.GetElements()) == 0) {
 		return nil, nil
 	}
 
-	ec := newEvalContext(ctx, validating, name, env, decrypter, providers, envs, map[string]*imported{})
+	ec := newEvalContext(ctx, validating, name, env, decrypter, providers, envs, map[string]*imported{}, context)
 	v, diags := ec.evaluate()
 
 	s := schema.Never().Schema()
@@ -133,15 +136,17 @@ type imported struct {
 
 // An evalContext carries the state necessary to evaluate an environment.
 type evalContext struct {
-	ctx          context.Context      // the cancellation context for evaluation
-	validating   bool                 // true if we are only checking the environment
-	name         string               // the name of the environment
-	env          *ast.EnvironmentDecl // the root of the environment AST
-	decrypter    Decrypter            // the decrypter to use for the environment
-	providers    ProviderLoader       // the provider loader to use
-	environments EnvironmentLoader    // the environment loader to use
-	imports      map[string]*imported // the shared set of imported environments
+	ctx           context.Context      // the cancellation context for evaluation
+	validating    bool                 // true if we are only checking the environment
+	name          string               // the name of the environment
+	env           *ast.EnvironmentDecl // the root of the environment AST
+	decrypter     Decrypter            // the decrypter to use for the environment
+	providers     ProviderLoader       // the provider loader to use
+	environments  EnvironmentLoader    // the environment loader to use
+	imports       map[string]*imported // the shared set of imported environments
+	contextValues esc.Value            // evaluation context used for interpolation
 
+	myContext *value // evaluated context to be used to interpolate properties
 	myImports *value // directly-imported environments
 	root      *expr  // the root expression
 	base      *value // the base value
@@ -158,16 +163,18 @@ func newEvalContext(
 	providers ProviderLoader,
 	environments EnvironmentLoader,
 	imports map[string]*imported,
+	contextValues esc.Value,
 ) *evalContext {
 	return &evalContext{
-		ctx:          ctx,
-		validating:   validating,
-		name:         name,
-		env:          env,
-		decrypter:    decrypter,
-		providers:    providers,
-		environments: environments,
-		imports:      imports,
+		ctx:           ctx,
+		validating:    validating,
+		name:          name,
+		env:           env,
+		decrypter:     decrypter,
+		providers:     providers,
+		environments:  environments,
+		imports:       imports,
+		contextValues: contextValues,
 	}
 }
 
@@ -329,6 +336,7 @@ func (e *evalContext) isReserveTopLevelKey(k string) bool {
 func (e *evalContext) evaluate() (*value, syntax.Diagnostics) {
 	// Evaluate imports. We do this prior to declaration so that we can plumb base values as part of declaration.
 	e.evaluateImports()
+	e.evaluateContext()
 
 	// Build the root value. We do this manually b/c the AST uses a declaration rather than an expression for the
 	// root.
@@ -358,6 +366,11 @@ func (e *evalContext) evaluate() (*value, syntax.Diagnostics) {
 	// Evaluate the root value and return.
 	v := e.evaluateExpr(e.root)
 	return v, e.diags
+}
+
+func (e *evalContext) evaluateContext() {
+	def := declare(e, "", ast.Symbol(&ast.PropertyName{Name: "context"}), nil)
+	e.myContext = unexport(e.contextValues, def)
 }
 
 // evaluateImports evaluates an environment's imports.
@@ -422,7 +435,7 @@ func (e *evalContext) evaluateImport(myImports map[string]*value, decl *ast.Impo
 			return
 		}
 
-		imp := newEvalContext(e.ctx, e.validating, name, env, dec, e.providers, e.environments, e.imports)
+		imp := newEvalContext(e.ctx, e.validating, name, env, dec, e.providers, e.environments, e.imports, e.contextValues)
 		v, diags := imp.evaluate()
 		e.diags.Extend(diags...)
 
@@ -598,10 +611,17 @@ func (e *evalContext) evaluatePropertyAccess(x *expr, accessors []*propertyAcces
 func (e *evalContext) evaluateExprAccess(x *expr, accessors []*propertyAccessor) *value {
 	receiver := e.root
 
+	k, ok := e.objectKey(x.repr.syntax(), accessors[0].accessor, false)
+
 	// Check for an imports access.
-	if k, ok := e.objectKey(x.repr.syntax(), accessors[0].accessor, false); ok && k == "imports" {
+	if ok && k == "imports" {
 		accessors[0].value = e.myImports
 		return e.evaluateValueAccess(x.repr.syntax(), e.myImports, accessors[1:])
+	}
+
+	if ok && k == "context" {
+		accessors[0].value = e.myContext
+		return e.evaluateValueAccess(x.repr.syntax(), e.myContext, accessors[1:])
 	}
 
 	for len(accessors) > 0 {

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -202,15 +202,28 @@ func TestEval(t *testing.T) {
 			envBytes, err := os.ReadFile(envPath)
 			require.NoError(t, err)
 
+			contextValues := esc.NewValue(map[string]esc.Value{
+				"pulumi": esc.NewValue(map[string]esc.Value{
+					"user": esc.NewValue(map[string]esc.Value{
+						"id": esc.NewValue("USER_123"),
+					}),
+				}),
+				"environment": esc.NewValue(map[string]esc.Value{
+					"name": esc.NewValue("TEST_ENVIRONMENT"),
+				}),
+			})
+
 			if accept() {
 				env, loadDiags, err := LoadYAMLBytes(e.Name(), envBytes)
 				require.NoError(t, err)
 				sortEnvironmentDiagnostics(loadDiags)
 
-				check, checkDiags := CheckEnvironment(context.Background(), e.Name(), env, testProviders{}, &testEnvironments{basePath})
+				check, checkDiags := CheckEnvironment(context.Background(), e.Name(), env, testProviders{},
+					&testEnvironments{basePath}, contextValues)
 				sortEnvironmentDiagnostics(checkDiags)
 
-				actual, evalDiags := EvalEnvironment(context.Background(), e.Name(), env, rot128{}, testProviders{}, &testEnvironments{basePath})
+				actual, evalDiags := EvalEnvironment(context.Background(), e.Name(), env, rot128{}, testProviders{},
+					&testEnvironments{basePath}, contextValues)
 				sortEnvironmentDiagnostics(evalDiags)
 
 				var checkJSON any
@@ -258,11 +271,13 @@ func TestEval(t *testing.T) {
 			sortEnvironmentDiagnostics(diags)
 			require.Equal(t, expected.LoadDiags, diags)
 
-			check, diags := CheckEnvironment(context.Background(), e.Name(), env, testProviders{}, &testEnvironments{basePath})
+			check, diags := CheckEnvironment(context.Background(), e.Name(), env, testProviders{},
+				&testEnvironments{basePath}, contextValues)
 			sortEnvironmentDiagnostics(diags)
 			require.Equal(t, expected.CheckDiags, diags)
 
-			actual, diags := EvalEnvironment(context.Background(), e.Name(), env, rot128{}, testProviders{}, &testEnvironments{basePath})
+			actual, diags := EvalEnvironment(context.Background(), e.Name(), env, rot128{}, testProviders{},
+				&testEnvironments{basePath}, contextValues)
 			sortEnvironmentDiagnostics(diags)
 			require.Equal(t, expected.EvalDiags, diags)
 

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -202,7 +202,7 @@ func TestEval(t *testing.T) {
 			envBytes, err := os.ReadFile(envPath)
 			require.NoError(t, err)
 
-			contextValues := esc.NewValue(map[string]esc.Value{
+			contextValues := map[string]esc.Value{
 				"pulumi": esc.NewValue(map[string]esc.Value{
 					"user": esc.NewValue(map[string]esc.Value{
 						"id": esc.NewValue("USER_123"),
@@ -211,7 +211,7 @@ func TestEval(t *testing.T) {
 				"environment": esc.NewValue(map[string]esc.Value{
 					"name": esc.NewValue("TEST_ENVIRONMENT"),
 				}),
-			})
+			}
 
 			if accept() {
 				env, loadDiags, err := LoadYAMLBytes(e.Name(), envBytes)

--- a/eval/testdata/eval/context-interpolation/env.yaml
+++ b/eval/testdata/eval/context-interpolation/env.yaml
@@ -1,0 +1,2 @@
+values:
+  data: ${context.environment.name}-${context.pulumi.user.id}

--- a/eval/testdata/eval/context-interpolation/expected.json
+++ b/eval/testdata/eval/context-interpolation/expected.json
@@ -1,0 +1,545 @@
+{
+    "check": {
+        "exprs": {
+            "data": {
+                "range": {
+                    "environment": "context-interpolation",
+                    "begin": {
+                        "line": 2,
+                        "column": 9,
+                        "byte": 16
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 62,
+                        "byte": 69
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "interpolate": [
+                    {
+                        "value": [
+                            {
+                                "key": "context",
+                                "range": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 2,
+                                        "column": 11,
+                                        "byte": 18
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 18,
+                                        "byte": 25
+                                    }
+                                },
+                                "value": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            },
+                            {
+                                "key": "environment",
+                                "range": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 2,
+                                        "column": 18,
+                                        "byte": 25
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 30,
+                                        "byte": 37
+                                    }
+                                },
+                                "value": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            },
+                            {
+                                "key": "name",
+                                "range": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 2,
+                                        "column": 30,
+                                        "byte": 37
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 35,
+                                        "byte": 42
+                                    }
+                                },
+                                "value": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "text": "-",
+                        "value": [
+                            {
+                                "key": "context",
+                                "range": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 2,
+                                        "column": 39,
+                                        "byte": 46
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 46,
+                                        "byte": 53
+                                    }
+                                },
+                                "value": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            },
+                            {
+                                "key": "pulumi",
+                                "range": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 2,
+                                        "column": 46,
+                                        "byte": 53
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 53,
+                                        "byte": 60
+                                    }
+                                },
+                                "value": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            },
+                            {
+                                "key": "user",
+                                "range": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 2,
+                                        "column": 53,
+                                        "byte": 60
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 58,
+                                        "byte": 65
+                                    }
+                                },
+                                "value": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            },
+                            {
+                                "key": "id",
+                                "range": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 2,
+                                        "column": 58,
+                                        "byte": 65
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 61,
+                                        "byte": 68
+                                    }
+                                },
+                                "value": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "properties": {
+            "data": {
+                "value": "TEST_ENVIRONMENT-USER_123",
+                "trace": {
+                    "def": {
+                        "environment": "context-interpolation",
+                        "begin": {
+                            "line": 2,
+                            "column": 9,
+                            "byte": 16
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 62,
+                            "byte": 69
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "data": {
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "required": [
+                "data"
+            ]
+        }
+    },
+    "checkJson": {
+        "data": "TEST_ENVIRONMENT-USER_123"
+    },
+    "eval": {
+        "exprs": {
+            "data": {
+                "range": {
+                    "environment": "context-interpolation",
+                    "begin": {
+                        "line": 2,
+                        "column": 9,
+                        "byte": 16
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 62,
+                        "byte": 69
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "interpolate": [
+                    {
+                        "value": [
+                            {
+                                "key": "context",
+                                "range": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 2,
+                                        "column": 11,
+                                        "byte": 18
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 18,
+                                        "byte": 25
+                                    }
+                                },
+                                "value": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            },
+                            {
+                                "key": "environment",
+                                "range": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 2,
+                                        "column": 18,
+                                        "byte": 25
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 30,
+                                        "byte": 37
+                                    }
+                                },
+                                "value": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            },
+                            {
+                                "key": "name",
+                                "range": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 2,
+                                        "column": 30,
+                                        "byte": 37
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 35,
+                                        "byte": 42
+                                    }
+                                },
+                                "value": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "text": "-",
+                        "value": [
+                            {
+                                "key": "context",
+                                "range": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 2,
+                                        "column": 39,
+                                        "byte": 46
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 46,
+                                        "byte": 53
+                                    }
+                                },
+                                "value": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            },
+                            {
+                                "key": "pulumi",
+                                "range": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 2,
+                                        "column": 46,
+                                        "byte": 53
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 53,
+                                        "byte": 60
+                                    }
+                                },
+                                "value": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            },
+                            {
+                                "key": "user",
+                                "range": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 2,
+                                        "column": 53,
+                                        "byte": 60
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 58,
+                                        "byte": 65
+                                    }
+                                },
+                                "value": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            },
+                            {
+                                "key": "id",
+                                "range": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 2,
+                                        "column": 58,
+                                        "byte": 65
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 61,
+                                        "byte": 68
+                                    }
+                                },
+                                "value": {
+                                    "environment": "context-interpolation",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "properties": {
+            "data": {
+                "value": "TEST_ENVIRONMENT-USER_123",
+                "trace": {
+                    "def": {
+                        "environment": "context-interpolation",
+                        "begin": {
+                            "line": 2,
+                            "column": 9,
+                            "byte": 16
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 62,
+                            "byte": 69
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "data": {
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "required": [
+                "data"
+            ]
+        }
+    },
+    "evalJsonRedacted": {
+        "data": "TEST_ENVIRONMENT-USER_123"
+    },
+    "evalJSONRevealed": {
+        "data": "TEST_ENVIRONMENT-USER_123"
+    }
+}


### PR DESCRIPTION
Add support for injecting contextual execution information and enable it to be used to interpolate in the environment attributes.

IE:
```
context = {
     "attr1": { "value": "foo" }, 
     "attr2": "bar"
}
```
can be used as:

```
values:
    sample: ${context.attr1.value}-${context.attr2}
```

would generate:

```
{
    "sample": "foo-bar"
}
```