### PR TITLE
eval: check for a nil import name

### DIFF
--- a/ast/expr.go
+++ b/ast/expr.go
@@ -53,14 +53,9 @@ func (x *exprNode) Syntax() syntax.Node {
 	return x.syntax
 }
 
-type exprConstraint interface {
-	Expr
-	comparable
-}
-
-func exprPosition[T exprConstraint](expr T) (*hcl.Range, string) {
-	var zero T
-	if expr != zero && !reflect.ValueOf(expr).IsNil() {
+func exprPosition(expr Expr) (*hcl.Range, string) {
+	inner := reflect.ValueOf(expr)
+	if !inner.IsZero() {
 		if syntax := expr.Syntax(); syntax != nil {
 			return syntax.Syntax().Range(), syntax.Syntax().Path()
 		}

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -408,7 +408,12 @@ func (e *evalContext) evaluateImports() {
 //
 // Each environment in the import closure is only evaluated once.
 func (e *evalContext) evaluateImport(myImports map[string]*value, decl *ast.ImportDecl) {
-	name := decl.Environment.GetValue()
+	// If the import does not have a name, there's nothing we can do. This can happen for environments
+	// with parse errors.
+	if decl.Environment == nil {
+		return
+	}
+	name := decl.Environment.Value
 
 	merge := true
 	if decl.Meta != nil && decl.Meta.Merge != nil {
@@ -425,9 +430,7 @@ func (e *evalContext) evaluateImport(myImports map[string]*value, decl *ast.Impo
 	} else {
 		bytes, dec, err := e.environments.LoadEnvironment(e.ctx, name)
 		if err != nil {
-			if decl.Environment != nil {
-				e.errorf(decl.Environment, "%s", err.Error())
-			}
+			e.errorf(decl.Environment, "%s", err.Error())
 			return
 		}
 


### PR DESCRIPTION
If an import declaration has a nil name, we can't process it any further, so we can terminate early.

Also, change the "nil in interface" check in `exprPosition` to use `IsZero` instead of `IsNil`, as the latter may panic if the value in the interface is not a pointer (or other nillish type).