### PR TITLE
Handle anonymous environments when injecting it to the context

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,5 @@
 ### Improvements
 
+Handle anonymous environments when injecting it to the context
 
 ### Bug Fixes

--- a/analysis/common_test.go
+++ b/analysis/common_test.go
@@ -57,13 +57,13 @@ func (testProvider) Schema() (*schema.Schema, *schema.Schema) {
 	return testProviderSchema, schema.Always()
 }
 
-func (testProvider) Open(ctx context.Context, inputs map[string]esc.Value) (esc.Value, error) {
+func (testProvider) Open(ctx context.Context, inputs map[string]esc.Value, context map[string]esc.Value) (esc.Value, error) {
 	return esc.NewValue(inputs), nil
 }
 
 type testProviders struct{}
 
-func (testProviders) LoadProvider(ctx context.Context, name string, context map[string]esc.Value) (esc.Provider, error) {
+func (testProviders) LoadProvider(ctx context.Context, name string) (esc.Provider, error) {
 	switch name {
 	case "test":
 		return testProvider{}, nil

--- a/analysis/common_test.go
+++ b/analysis/common_test.go
@@ -63,7 +63,7 @@ func (testProvider) Open(ctx context.Context, inputs map[string]esc.Value) (esc.
 
 type testProviders struct{}
 
-func (testProviders) LoadProvider(ctx context.Context, name string) (esc.Provider, error) {
+func (testProviders) LoadProvider(ctx context.Context, name string, context map[string]esc.Value) (esc.Provider, error) {
 	switch name {
 	case "test":
 		return testProvider{}, nil

--- a/analysis/describe_test.go
+++ b/analysis/describe_test.go
@@ -31,7 +31,10 @@ func TestDescribe(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, diags)
 
-	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, map[string]esc.Value{})
+	execContext, err := esc.NewExecContext(make(map[string]esc.Value))
+	require.NoError(t, err)
+
+	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, execContext)
 	require.Empty(t, diags)
 
 	analysis := New(*env, map[string]*schema.Schema{"test": testProviderSchema})
@@ -102,7 +105,10 @@ func TestDescribeOpen(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, diags)
 
-	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, map[string]esc.Value{})
+	execContext, err := esc.NewExecContext(make(map[string]esc.Value))
+	require.NoError(t, err)
+
+	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, execContext)
 	require.Empty(t, diags)
 
 	analysis := New(*env, map[string]*schema.Schema{"test": testProviderSchema})

--- a/analysis/traversal_test.go
+++ b/analysis/traversal_test.go
@@ -30,7 +30,10 @@ func TestExpressionAt(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, diags)
 
-	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, map[string]esc.Value{})
+	execContext, err := esc.NewExecContext(make(map[string]esc.Value))
+	require.NoError(t, err)
+
+	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, execContext)
 	require.Empty(t, diags)
 
 	analysis := New(*env, map[string]*schema.Schema{"test": testProviderSchema})

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -204,7 +204,7 @@ func (testProvider) Open(ctx context.Context, inputs map[string]esc.Value) (esc.
 
 type testProviders struct{}
 
-func (testProviders) LoadProvider(ctx context.Context, name string) (esc.Provider, error) {
+func (testProviders) LoadProvider(ctx context.Context, name string, context map[string]esc.Value) (esc.Provider, error) {
 	if name == "test" {
 		return testProvider{}, nil
 	}
@@ -339,7 +339,13 @@ func (c *testPulumiClient) checkEnvironment(ctx context.Context, orgName, envNam
 	providers := &testProviders{}
 	envLoader := &testEnvironments{orgName: orgName, environments: c.environments}
 
-	checked, checkDiags := eval.CheckEnvironment(ctx, envName, environment, providers, envLoader, map[string]esc.Value{})
+	execContext, err := esc.NewExecContext(make(map[string]esc.Value))
+	if err != nil {
+		return nil, nil, fmt.Errorf("initializing the ESC exec context: %w", err)
+	}
+
+	checked, checkDiags := eval.CheckEnvironment(ctx, envName, environment,
+		providers, envLoader, execContext)
 	diags.Extend(checkDiags...)
 	return checked, mapDiags(diags), nil
 }
@@ -361,7 +367,12 @@ func (c *testPulumiClient) openEnvironment(ctx context.Context, orgName, name st
 	providers := &testProviders{}
 	envLoader := &testEnvironments{orgName: orgName, environments: c.environments}
 
-	openEnv, evalDiags := eval.EvalEnvironment(ctx, name, decl, rot128{}, providers, envLoader, map[string]esc.Value{})
+	execContext, err := esc.NewExecContext(make(map[string]esc.Value))
+	if err != nil {
+		return "", nil, fmt.Errorf("initializing the ESC exec context: %w", err)
+	}
+
+	openEnv, evalDiags := eval.EvalEnvironment(ctx, name, decl, rot128{}, providers, envLoader, execContext)
 	diags.Extend(evalDiags...)
 
 	if diags.HasErrors() {

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -198,13 +198,13 @@ func (testProvider) Schema() (*schema.Schema, *schema.Schema) {
 	return schema.Always(), schema.Always()
 }
 
-func (testProvider) Open(ctx context.Context, inputs map[string]esc.Value) (esc.Value, error) {
+func (testProvider) Open(ctx context.Context, inputs map[string]esc.Value, context map[string]esc.Value) (esc.Value, error) {
 	return esc.NewValue(inputs), nil
 }
 
 type testProviders struct{}
 
-func (testProviders) LoadProvider(ctx context.Context, name string, context map[string]esc.Value) (esc.Provider, error) {
+func (testProviders) LoadProvider(ctx context.Context, name string) (esc.Provider, error) {
 	if name == "test" {
 		return testProvider{}, nil
 	}

--- a/environment.go
+++ b/environment.go
@@ -85,13 +85,13 @@ func copyContext(context map[string]Value) map[string]Value {
 
 func (ec *ExecContext) Copy() *ExecContext {
 	return &ExecContext{
-		values:         copyContext(ec.values),
+		values:         ec.values,
 		rootEvironment: ec.rootEvironment,
 	}
 }
 
 func (ec *ExecContext) Values(envName string) map[string]Value {
-	context := ec.values
+	context := copyContext(ec.values)
 	context["currentEnvironment"] = NewValue(map[string]Value{
 		"name": NewValue(envName),
 	})
@@ -107,11 +107,11 @@ func (ec *ExecContext) Values(envName string) map[string]Value {
 	return context
 }
 
-var ErrForbiddenContextkey = errors.New("forbidden context key")
+var ErrReservedContextkey = errors.New("reserved context key")
 
 func validateContextVariable(context map[string]Value, key string) error {
 	if _, ok := context[key]; ok {
-		return fmt.Errorf("%w: %q", ErrForbiddenContextkey, key)
+		return fmt.Errorf("%w: %q", ErrReservedContextkey, key)
 	}
 	return nil
 }

--- a/environment.go
+++ b/environment.go
@@ -75,7 +75,8 @@ func (c copier) copy(v *Value) *Value {
 
 func copyContext(context map[string]Value) map[string]Value {
 	newContext := make(map[string]Value)
-	for key, value := range context {
+	for key, v := range context {
+		value := v
 		copy := newCopier().copy(&value)
 		newContext[key] = *copy
 	}

--- a/environment.go
+++ b/environment.go
@@ -83,14 +83,7 @@ func copyContext(context map[string]Value) map[string]Value {
 	return newContext
 }
 
-func (ec *ExecContext) Copy() *ExecContext {
-	return &ExecContext{
-		values:         ec.values,
-		rootEvironment: ec.rootEvironment,
-	}
-}
-
-func (ec *ExecContext) Values(envName string) map[string]Value {
+func (ec *ExecContext) CopyForEnv(envName string) *ExecContext {
 	context := copyContext(ec.values)
 	context["currentEnvironment"] = NewValue(map[string]Value{
 		"name": NewValue(envName),
@@ -104,7 +97,14 @@ func (ec *ExecContext) Values(envName string) map[string]Value {
 		"name": NewValue(ec.rootEvironment),
 	})
 
-	return context
+	return &ExecContext{
+		values:         context,
+		rootEvironment: ec.rootEvironment,
+	}
+}
+
+func (ec *ExecContext) Values() map[string]Value {
+	return ec.values
 }
 
 var ErrReservedContextkey = errors.New("reserved context key")

--- a/environment.go
+++ b/environment.go
@@ -25,8 +25,8 @@ import (
 const AnonymousEnvironmentName = "<yaml>"
 
 type ExecContext struct {
-	rootEvironment string
-	values         map[string]Value
+	rootEnvironment string
+	values          map[string]Value
 }
 
 type copier struct {
@@ -84,22 +84,23 @@ func copyContext(context map[string]Value) map[string]Value {
 }
 
 func (ec *ExecContext) CopyForEnv(envName string) *ExecContext {
-	context := copyContext(ec.values)
-	context["currentEnvironment"] = NewValue(map[string]Value{
+	values := copyContext(ec.values)
+	values["currentEnvironment"] = NewValue(map[string]Value{
 		"name": NewValue(envName),
 	})
 
-	if ec.rootEvironment == AnonymousEnvironmentName || ec.rootEvironment == "" {
-		ec.rootEvironment = envName
+	root := ec.rootEnvironment
+	if ec.rootEnvironment == AnonymousEnvironmentName || ec.rootEnvironment == "" {
+		root = envName
 	}
 
-	context["rootEnvironment"] = NewValue(map[string]Value{
-		"name": NewValue(ec.rootEvironment),
+	values["rootEnvironment"] = NewValue(map[string]Value{
+		"name": NewValue(root),
 	})
 
 	return &ExecContext{
-		values:         context,
-		rootEvironment: ec.rootEvironment,
+		values:          values,
+		rootEnvironment: root,
 	}
 }
 

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -36,7 +36,7 @@ import (
 // A ProviderLoader provides the environment evaluator the capability to load providers.
 type ProviderLoader interface {
 	// LoadProvider loads the provider with the given name.
-	LoadProvider(ctx context.Context, name string) (esc.Provider, error)
+	LoadProvider(ctx context.Context, name string, contextValues map[string]esc.Value) (esc.Provider, error)
 }
 
 // An EnvironmentLoader provides the environment evaluator the capability to load imported environment definitions.
@@ -77,9 +77,9 @@ func EvalEnvironment(
 	decrypter Decrypter,
 	providers ProviderLoader,
 	environments EnvironmentLoader,
-	context map[string]esc.Value,
+	execContext *esc.ExecContext,
 ) (*esc.Environment, syntax.Diagnostics) {
-	return evalEnvironment(ctx, false, name, env, decrypter, providers, environments, context)
+	return evalEnvironment(ctx, false, name, env, decrypter, providers, environments, execContext)
 }
 
 // CheckEnvironment symbolically evaluates the given environment. Calls to fn::open are not invoked, and instead
@@ -90,9 +90,9 @@ func CheckEnvironment(
 	env *ast.EnvironmentDecl,
 	providers ProviderLoader,
 	environments EnvironmentLoader,
-	context map[string]esc.Value,
+	execContext *esc.ExecContext,
 ) (*esc.Environment, syntax.Diagnostics) {
-	return evalEnvironment(ctx, true, name, env, nil, providers, environments, context)
+	return evalEnvironment(ctx, true, name, env, nil, providers, environments, execContext)
 }
 
 // evalEnvironment evaluates an environment and exports the result of evaluation.
@@ -104,13 +104,13 @@ func evalEnvironment(
 	decrypter Decrypter,
 	providers ProviderLoader,
 	envs EnvironmentLoader,
-	context map[string]esc.Value,
+	execContext *esc.ExecContext,
 ) (*esc.Environment, syntax.Diagnostics) {
 	if env == nil || (len(env.Values.GetEntries()) == 0 && len(env.Imports.GetElements()) == 0) {
 		return nil, nil
 	}
 
-	ec := newEvalContext(ctx, validating, name, env, decrypter, providers, envs, map[string]*imported{}, context)
+	ec := newEvalContext(ctx, validating, name, env, decrypter, providers, envs, map[string]*imported{}, execContext)
 	v, diags := ec.evaluate()
 
 	s := schema.Never().Schema()
@@ -136,15 +136,15 @@ type imported struct {
 
 // An evalContext carries the state necessary to evaluate an environment.
 type evalContext struct {
-	ctx           context.Context      // the cancellation context for evaluation
-	validating    bool                 // true if we are only checking the environment
-	name          string               // the name of the environment
-	env           *ast.EnvironmentDecl // the root of the environment AST
-	decrypter     Decrypter            // the decrypter to use for the environment
-	providers     ProviderLoader       // the provider loader to use
-	environments  EnvironmentLoader    // the environment loader to use
-	imports       map[string]*imported // the shared set of imported environments
-	contextValues map[string]esc.Value // evaluation context used for interpolation
+	ctx          context.Context      // the cancellation context for evaluation
+	validating   bool                 // true if we are only checking the environment
+	name         string               // the name of the environment
+	env          *ast.EnvironmentDecl // the root of the environment AST
+	decrypter    Decrypter            // the decrypter to use for the environment
+	providers    ProviderLoader       // the provider loader to use
+	environments EnvironmentLoader    // the environment loader to use
+	imports      map[string]*imported // the shared set of imported environments
+	execContext  *esc.ExecContext     // evaluation context used for interpolation
 
 	myContext *value // evaluated context to be used to interpolate properties
 	myImports *value // directly-imported environments
@@ -163,18 +163,18 @@ func newEvalContext(
 	providers ProviderLoader,
 	environments EnvironmentLoader,
 	imports map[string]*imported,
-	contextValues map[string]esc.Value,
+	execContext *esc.ExecContext,
 ) *evalContext {
 	return &evalContext{
-		ctx:           ctx,
-		validating:    validating,
-		name:          name,
-		env:           env,
-		decrypter:     decrypter,
-		providers:     providers,
-		environments:  environments,
-		imports:       imports,
-		contextValues: contextValues,
+		ctx:          ctx,
+		validating:   validating,
+		name:         name,
+		env:          env,
+		decrypter:    decrypter,
+		providers:    providers,
+		environments: environments,
+		imports:      imports,
+		execContext:  execContext,
 	}
 }
 
@@ -334,10 +334,10 @@ func (e *evalContext) isReserveTopLevelKey(k string) bool {
 
 // evaluate drives the evaluation of the evalContext's environment.
 func (e *evalContext) evaluate() (*value, syntax.Diagnostics) {
+	// Evaluate context. We prepare the context values to later evaluate interpolations.
+	e.evaluateContext()
 	// Evaluate imports. We do this prior to declaration so that we can plumb base values as part of declaration.
 	e.evaluateImports()
-	// Evaliate context. We prepare the context values to later evaluate interpolations.
-	e.evaluateContext()
 
 	// Build the root value. We do this manually b/c the AST uses a declaration rather than an expression for the
 	// root.
@@ -371,7 +371,7 @@ func (e *evalContext) evaluate() (*value, syntax.Diagnostics) {
 
 func (e *evalContext) evaluateContext() {
 	def := declare(e, "", ast.Symbol(&ast.PropertyName{Name: "context"}), nil)
-	e.myContext = unexport(esc.NewValue(e.contextValues), def)
+	e.myContext = unexport(esc.NewValue(e.execContext.Values(e.name)), def)
 }
 
 // evaluateImports evaluates an environment's imports.
@@ -441,7 +441,7 @@ func (e *evalContext) evaluateImport(myImports map[string]*value, decl *ast.Impo
 			return
 		}
 
-		imp := newEvalContext(e.ctx, e.validating, name, env, dec, e.providers, e.environments, e.imports, e.contextValues)
+		imp := newEvalContext(e.ctx, e.validating, name, env, dec, e.providers, e.environments, e.imports, e.execContext.Copy())
 		v, diags := imp.evaluate()
 		e.diags.Extend(diags...)
 
@@ -872,7 +872,7 @@ func (e *evalContext) evaluateBuiltinOpen(x *expr, repr *openExpr) *value {
 		return v
 	}
 
-	provider, err := e.providers.LoadProvider(e.ctx, repr.node.Provider.GetValue())
+	provider, err := e.providers.LoadProvider(e.ctx, repr.node.Provider.GetValue(), e.execContext.Values(e.name))
 	if err != nil {
 		e.errorf(repr.syntax(), "%v", err)
 	} else {

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -174,7 +174,7 @@ func newEvalContext(
 		providers:    providers,
 		environments: environments,
 		imports:      imports,
-		execContext:  execContext,
+		execContext:  execContext.CopyForEnv(name),
 	}
 }
 
@@ -371,7 +371,7 @@ func (e *evalContext) evaluate() (*value, syntax.Diagnostics) {
 
 func (e *evalContext) evaluateContext() {
 	def := declare(e, "", ast.Symbol(&ast.PropertyName{Name: "context"}), nil)
-	e.myContext = unexport(esc.NewValue(e.execContext.Values(e.name)), def)
+	e.myContext = unexport(esc.NewValue(e.execContext.Values()), def)
 }
 
 // evaluateImports evaluates an environment's imports.
@@ -441,7 +441,7 @@ func (e *evalContext) evaluateImport(myImports map[string]*value, decl *ast.Impo
 			return
 		}
 
-		imp := newEvalContext(e.ctx, e.validating, name, env, dec, e.providers, e.environments, e.imports, e.execContext.Copy())
+		imp := newEvalContext(e.ctx, e.validating, name, env, dec, e.providers, e.environments, e.imports, e.execContext)
 		v, diags := imp.evaluate()
 		e.diags.Extend(diags...)
 
@@ -897,7 +897,7 @@ func (e *evalContext) evaluateBuiltinOpen(x *expr, repr *openExpr) *value {
 		return v
 	}
 
-	output, err := provider.Open(e.ctx, inputs.export("").Value.(map[string]esc.Value), e.execContext.Values(e.name))
+	output, err := provider.Open(e.ctx, inputs.export("").Value.(map[string]esc.Value), e.execContext.Values())
 	if err != nil {
 		e.errorf(repr.syntax(), err.Error())
 		v.unknown = true

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -36,7 +36,7 @@ import (
 // A ProviderLoader provides the environment evaluator the capability to load providers.
 type ProviderLoader interface {
 	// LoadProvider loads the provider with the given name.
-	LoadProvider(ctx context.Context, name string, contextValues map[string]esc.Value) (esc.Provider, error)
+	LoadProvider(ctx context.Context, name string) (esc.Provider, error)
 }
 
 // An EnvironmentLoader provides the environment evaluator the capability to load imported environment definitions.
@@ -872,7 +872,7 @@ func (e *evalContext) evaluateBuiltinOpen(x *expr, repr *openExpr) *value {
 		return v
 	}
 
-	provider, err := e.providers.LoadProvider(e.ctx, repr.node.Provider.GetValue(), e.execContext.Values(e.name))
+	provider, err := e.providers.LoadProvider(e.ctx, repr.node.Provider.GetValue())
 	if err != nil {
 		e.errorf(repr.syntax(), "%v", err)
 	} else {
@@ -897,7 +897,7 @@ func (e *evalContext) evaluateBuiltinOpen(x *expr, repr *openExpr) *value {
 		return v
 	}
 
-	output, err := provider.Open(e.ctx, inputs.export("").Value.(map[string]esc.Value))
+	output, err := provider.Open(e.ctx, inputs.export("").Value.(map[string]esc.Value), e.execContext.Values(e.name))
 	if err != nil {
 		e.errorf(repr.syntax(), err.Error())
 		v.unknown = true

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -43,7 +43,7 @@ func (errorProvider) Schema() (*schema.Schema, *schema.Schema) {
 	return schema.Record(map[string]schema.Builder{"why": schema.String()}).Schema(), schema.Always()
 }
 
-func (errorProvider) Open(ctx context.Context, inputs map[string]esc.Value) (esc.Value, error) {
+func (errorProvider) Open(ctx context.Context, inputs map[string]esc.Value, context map[string]esc.Value) (esc.Value, error) {
 	return esc.Value{}, errors.New(inputs["why"].Value.(string))
 }
 
@@ -106,7 +106,7 @@ func (testSchemaProvider) Schema() (*schema.Schema, *schema.Schema) {
 	return s, s
 }
 
-func (testSchemaProvider) Open(ctx context.Context, inputs map[string]esc.Value) (esc.Value, error) {
+func (testSchemaProvider) Open(ctx context.Context, inputs map[string]esc.Value, context map[string]esc.Value) (esc.Value, error) {
 	return esc.NewValue(inputs), nil
 }
 
@@ -116,13 +116,13 @@ func (testProvider) Schema() (*schema.Schema, *schema.Schema) {
 	return schema.Always(), schema.Always()
 }
 
-func (testProvider) Open(ctx context.Context, inputs map[string]esc.Value) (esc.Value, error) {
+func (testProvider) Open(ctx context.Context, inputs map[string]esc.Value, context map[string]esc.Value) (esc.Value, error) {
 	return esc.NewValue(inputs), nil
 }
 
 type testProviders struct{}
 
-func (testProviders) LoadProvider(ctx context.Context, name string, context map[string]esc.Value) (esc.Provider, error) {
+func (testProviders) LoadProvider(ctx context.Context, name string) (esc.Provider, error) {
 	switch name {
 	case "error":
 		return errorProvider{}, nil

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -122,7 +122,7 @@ func (testProvider) Open(ctx context.Context, inputs map[string]esc.Value) (esc.
 
 type testProviders struct{}
 
-func (testProviders) LoadProvider(ctx context.Context, name string) (esc.Provider, error) {
+func (testProviders) LoadProvider(ctx context.Context, name string, context map[string]esc.Value) (esc.Provider, error) {
 	switch name {
 	case "error":
 		return errorProvider{}, nil
@@ -195,6 +195,9 @@ func TestEval(t *testing.T) {
 	entries, err := os.ReadDir(path)
 	require.NoError(t, err)
 	for _, e := range entries {
+		if e.Name() != "<yaml>" {
+			continue
+		}
 		t.Run(e.Name(), func(t *testing.T) {
 			basePath := filepath.Join(path, e.Name())
 			envPath, expectedPath := filepath.Join(basePath, "env.yaml"), filepath.Join(basePath, "expected.json")
@@ -202,16 +205,14 @@ func TestEval(t *testing.T) {
 			envBytes, err := os.ReadFile(envPath)
 			require.NoError(t, err)
 
-			contextValues := map[string]esc.Value{
+			execContext, err := esc.NewExecContext(map[string]esc.Value{
 				"pulumi": esc.NewValue(map[string]esc.Value{
 					"user": esc.NewValue(map[string]esc.Value{
 						"id": esc.NewValue("USER_123"),
 					}),
 				}),
-				"environment": esc.NewValue(map[string]esc.Value{
-					"name": esc.NewValue("TEST_ENVIRONMENT"),
-				}),
-			}
+			})
+			assert.NoError(t, err)
 
 			if accept() {
 				env, loadDiags, err := LoadYAMLBytes(e.Name(), envBytes)
@@ -219,11 +220,11 @@ func TestEval(t *testing.T) {
 				sortEnvironmentDiagnostics(loadDiags)
 
 				check, checkDiags := CheckEnvironment(context.Background(), e.Name(), env, testProviders{},
-					&testEnvironments{basePath}, contextValues)
+					&testEnvironments{basePath}, execContext)
 				sortEnvironmentDiagnostics(checkDiags)
 
 				actual, evalDiags := EvalEnvironment(context.Background(), e.Name(), env, rot128{}, testProviders{},
-					&testEnvironments{basePath}, contextValues)
+					&testEnvironments{basePath}, execContext)
 				sortEnvironmentDiagnostics(evalDiags)
 
 				var checkJSON any
@@ -272,12 +273,12 @@ func TestEval(t *testing.T) {
 			require.Equal(t, expected.LoadDiags, diags)
 
 			check, diags := CheckEnvironment(context.Background(), e.Name(), env, testProviders{},
-				&testEnvironments{basePath}, contextValues)
+				&testEnvironments{basePath}, execContext)
 			sortEnvironmentDiagnostics(diags)
 			require.Equal(t, expected.CheckDiags, diags)
 
 			actual, diags := EvalEnvironment(context.Background(), e.Name(), env, rot128{}, testProviders{},
-				&testEnvironments{basePath}, contextValues)
+				&testEnvironments{basePath}, execContext)
 			sortEnvironmentDiagnostics(diags)
 			require.Equal(t, expected.EvalDiags, diags)
 

--- a/eval/testdata/eval/<yaml>/a.yaml
+++ b/eval/testdata/eval/<yaml>/a.yaml
@@ -1,0 +1,2 @@
+values:
+  imported: ${context.currentEnvironment.name}-${context.rootEnvironment.name}-${context.pulumi.user.id}

--- a/eval/testdata/eval/<yaml>/env.yaml
+++ b/eval/testdata/eval/<yaml>/env.yaml
@@ -1,0 +1,4 @@
+imports:
+  - a
+values:
+  root: ${context.currentEnvironment.name}-${context.rootEnvironment.name}-${context.pulumi.user.id}

--- a/eval/testdata/eval/<yaml>/expected.json
+++ b/eval/testdata/eval/<yaml>/expected.json
@@ -1,18 +1,18 @@
 {
     "check": {
         "exprs": {
-            "data": {
+            "root": {
                 "range": {
-                    "environment": "context-interpolation",
+                    "environment": "\u003cyaml\u003e",
                     "begin": {
-                        "line": 2,
+                        "line": 4,
                         "column": 9,
-                        "byte": 16
+                        "byte": 31
                     },
                     "end": {
-                        "line": 2,
+                        "line": 4,
                         "column": 101,
-                        "byte": 108
+                        "byte": 123
                     }
                 },
                 "schema": {
@@ -24,20 +24,20 @@
                             {
                                 "key": "context",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 11,
-                                        "byte": 18
+                                        "byte": 33
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 18,
-                                        "byte": 25
+                                        "byte": 40
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -53,20 +53,20 @@
                             {
                                 "key": "currentEnvironment",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 18,
-                                        "byte": 25
+                                        "byte": 40
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 37,
-                                        "byte": 44
+                                        "byte": 59
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -82,20 +82,20 @@
                             {
                                 "key": "name",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 37,
-                                        "byte": 44
+                                        "byte": 59
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 42,
-                                        "byte": 49
+                                        "byte": 64
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -116,20 +116,20 @@
                             {
                                 "key": "context",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 46,
-                                        "byte": 53
+                                        "byte": 68
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 53,
-                                        "byte": 60
+                                        "byte": 75
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -145,20 +145,20 @@
                             {
                                 "key": "rootEnvironment",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 53,
-                                        "byte": 60
+                                        "byte": 75
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 69,
-                                        "byte": 76
+                                        "byte": 91
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -174,20 +174,20 @@
                             {
                                 "key": "name",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 69,
-                                        "byte": 76
+                                        "byte": 91
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 74,
-                                        "byte": 81
+                                        "byte": 96
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -208,20 +208,20 @@
                             {
                                 "key": "context",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 78,
-                                        "byte": 85
+                                        "byte": 100
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 85,
-                                        "byte": 92
+                                        "byte": 107
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -237,20 +237,20 @@
                             {
                                 "key": "pulumi",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 85,
-                                        "byte": 92
+                                        "byte": 107
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 92,
-                                        "byte": 99
+                                        "byte": 114
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -266,20 +266,20 @@
                             {
                                 "key": "user",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 92,
-                                        "byte": 99
+                                        "byte": 114
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 97,
-                                        "byte": 104
+                                        "byte": 119
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -295,20 +295,20 @@
                             {
                                 "key": "id",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 97,
-                                        "byte": 104
+                                        "byte": 119
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 100,
-                                        "byte": 107
+                                        "byte": 122
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -327,20 +327,38 @@
             }
         },
         "properties": {
-            "data": {
-                "value": "context-interpolation-context-interpolation-USER_123",
+            "imported": {
+                "value": "a-a-USER_123",
                 "trace": {
                     "def": {
-                        "environment": "context-interpolation",
+                        "environment": "a",
                         "begin": {
                             "line": 2,
-                            "column": 9,
-                            "byte": 16
+                            "column": 13,
+                            "byte": 20
                         },
                         "end": {
                             "line": 2,
+                            "column": 105,
+                            "byte": 112
+                        }
+                    }
+                }
+            },
+            "root": {
+                "value": "\u003cyaml\u003e-\u003cyaml\u003e-USER_123",
+                "trace": {
+                    "def": {
+                        "environment": "\u003cyaml\u003e",
+                        "begin": {
+                            "line": 4,
+                            "column": 9,
+                            "byte": 31
+                        },
+                        "end": {
+                            "line": 4,
                             "column": 101,
-                            "byte": 108
+                            "byte": 123
                         }
                     }
                 }
@@ -348,33 +366,38 @@
         },
         "schema": {
             "properties": {
-                "data": {
+                "imported": {
+                    "type": "string"
+                },
+                "root": {
                     "type": "string"
                 }
             },
             "type": "object",
             "required": [
-                "data"
+                "imported",
+                "root"
             ]
         }
     },
     "checkJson": {
-        "data": "context-interpolation-context-interpolation-USER_123"
+        "imported": "a-a-USER_123",
+        "root": "\u003cyaml\u003e-\u003cyaml\u003e-USER_123"
     },
     "eval": {
         "exprs": {
-            "data": {
+            "root": {
                 "range": {
-                    "environment": "context-interpolation",
+                    "environment": "\u003cyaml\u003e",
                     "begin": {
-                        "line": 2,
+                        "line": 4,
                         "column": 9,
-                        "byte": 16
+                        "byte": 31
                     },
                     "end": {
-                        "line": 2,
+                        "line": 4,
                         "column": 101,
-                        "byte": 108
+                        "byte": 123
                     }
                 },
                 "schema": {
@@ -386,20 +409,20 @@
                             {
                                 "key": "context",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 11,
-                                        "byte": 18
+                                        "byte": 33
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 18,
-                                        "byte": 25
+                                        "byte": 40
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -415,20 +438,20 @@
                             {
                                 "key": "currentEnvironment",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 18,
-                                        "byte": 25
+                                        "byte": 40
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 37,
-                                        "byte": 44
+                                        "byte": 59
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -444,20 +467,20 @@
                             {
                                 "key": "name",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 37,
-                                        "byte": 44
+                                        "byte": 59
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 42,
-                                        "byte": 49
+                                        "byte": 64
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -478,20 +501,20 @@
                             {
                                 "key": "context",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 46,
-                                        "byte": 53
+                                        "byte": 68
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 53,
-                                        "byte": 60
+                                        "byte": 75
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -507,20 +530,20 @@
                             {
                                 "key": "rootEnvironment",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 53,
-                                        "byte": 60
+                                        "byte": 75
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 69,
-                                        "byte": 76
+                                        "byte": 91
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -536,20 +559,20 @@
                             {
                                 "key": "name",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 69,
-                                        "byte": 76
+                                        "byte": 91
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 74,
-                                        "byte": 81
+                                        "byte": 96
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -570,20 +593,20 @@
                             {
                                 "key": "context",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 78,
-                                        "byte": 85
+                                        "byte": 100
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 85,
-                                        "byte": 92
+                                        "byte": 107
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -599,20 +622,20 @@
                             {
                                 "key": "pulumi",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 85,
-                                        "byte": 92
+                                        "byte": 107
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 92,
-                                        "byte": 99
+                                        "byte": 114
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -628,20 +651,20 @@
                             {
                                 "key": "user",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 92,
-                                        "byte": 99
+                                        "byte": 114
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 97,
-                                        "byte": 104
+                                        "byte": 119
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -657,20 +680,20 @@
                             {
                                 "key": "id",
                                 "range": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 97,
-                                        "byte": 104
+                                        "byte": 119
                                     },
                                     "end": {
-                                        "line": 2,
+                                        "line": 4,
                                         "column": 100,
-                                        "byte": 107
+                                        "byte": 122
                                     }
                                 },
                                 "value": {
-                                    "environment": "context-interpolation",
+                                    "environment": "\u003cyaml\u003e",
                                     "begin": {
                                         "line": 0,
                                         "column": 0,
@@ -689,20 +712,38 @@
             }
         },
         "properties": {
-            "data": {
-                "value": "context-interpolation-context-interpolation-USER_123",
+            "imported": {
+                "value": "a-a-USER_123",
                 "trace": {
                     "def": {
-                        "environment": "context-interpolation",
+                        "environment": "a",
                         "begin": {
                             "line": 2,
-                            "column": 9,
-                            "byte": 16
+                            "column": 13,
+                            "byte": 20
                         },
                         "end": {
                             "line": 2,
+                            "column": 105,
+                            "byte": 112
+                        }
+                    }
+                }
+            },
+            "root": {
+                "value": "\u003cyaml\u003e-\u003cyaml\u003e-USER_123",
+                "trace": {
+                    "def": {
+                        "environment": "\u003cyaml\u003e",
+                        "begin": {
+                            "line": 4,
+                            "column": 9,
+                            "byte": 31
+                        },
+                        "end": {
+                            "line": 4,
                             "column": 101,
-                            "byte": 108
+                            "byte": 123
                         }
                     }
                 }
@@ -710,20 +751,26 @@
         },
         "schema": {
             "properties": {
-                "data": {
+                "imported": {
+                    "type": "string"
+                },
+                "root": {
                     "type": "string"
                 }
             },
             "type": "object",
             "required": [
-                "data"
+                "imported",
+                "root"
             ]
         }
     },
     "evalJsonRedacted": {
-        "data": "context-interpolation-context-interpolation-USER_123"
+        "imported": "a-a-USER_123",
+        "root": "\u003cyaml\u003e-\u003cyaml\u003e-USER_123"
     },
     "evalJSONRevealed": {
-        "data": "context-interpolation-context-interpolation-USER_123"
+        "imported": "a-a-USER_123",
+        "root": "\u003cyaml\u003e-\u003cyaml\u003e-USER_123"
     }
 }

--- a/eval/testdata/eval/context-interpolation/env.yaml
+++ b/eval/testdata/eval/context-interpolation/env.yaml
@@ -1,2 +1,2 @@
 values:
-  data: ${context.environment.name}-${context.pulumi.user.id}
+  data: ${context.currentEnvironment.name}-${context.rootEnvironment.name}-${context.pulumi.user.id}

--- a/provider.go
+++ b/provider.go
@@ -27,5 +27,5 @@ type Provider interface {
 	Schema() (inputs, outputs *schema.Schema)
 
 	// Open retrieves the provider's secrets.
-	Open(ctx context.Context, inputs map[string]Value) (Value, error)
+	Open(ctx context.Context, inputs map[string]Value, executionContext map[string]Value) (Value, error)
 }


### PR DESCRIPTION
- Splitting `context.environment` into `rootEnvironment` and `currentEnvironment` (potentially just `environment`)
- When evaluating an anonymous environment, the `rootEnvironment` will evaluate to the rootest non anonymous environment for the imported environments (wont propagate to the root)

Having these 3 envs:

```
# root
imports:
  - imported
values:
  root:
    currentEnvironment: ${context.currentEnvironment.name}
    rootEnvironment: ${context.rootEnvironment.name}

# imported
imports:
  - child
values:
  imported:
    currentEnvironment: ${context.currentEnvironment.name}
    rootEnvironment: ${context.rootEnvironment.name}

# child
values:
  child:
    currentEnvironment: ${context.currentEnvironment.name}
    rootEnvironment: ${context.rootEnvironment.name}
``` 

In the case the `root` env is anonymous, it resolves:
```
{
  "child": {
    "currentEnvironment": "child",
    "rootEnvironment": "imported"
  },
  "imported": {
    "currentEnvironment": "imported",
    "rootEnvironment": "imported"
  },
  "root": {
    "currentEnvironment": "<yaml>",
    "rootEnvironment": "<yaml>"
  }
}
```

In the case the `root` env is a named environment, it resolves:
```
{
  "child": {
    "currentEnvironment": "child",
    "rootEnvironment": "root"
  },
  "imported": {
    "currentEnvironment": "imported",
    "rootEnvironment": "root"
  },
  "root": {
    "currentEnvironment": "root",
    "rootEnvironment": "root"
  }
}
```
