### PR TITLE
cli: add revision/tag support to get and open

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,5 +2,8 @@
 
 
 
+- Add support for getting or opening environments at specific revisions/tags.
+  [#275](https://github.com/pulumi/esc/pull/275)
+
 ### Bug Fixes
 

--- a/cmd/esc/cli/client/apitype.go
+++ b/cmd/esc/cli/client/apitype.go
@@ -17,6 +17,7 @@ package client
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pulumi/esc"
 )
@@ -58,6 +59,34 @@ func diagsErrorString(envDiags []EnvironmentDiagnostic) string {
 	return diags.String()
 }
 
+type EnvironmentRevision struct {
+	Number       int       `json:"number"`
+	Created      time.Time `json:"created"`
+	CreatorLogin string    `json:"creatorLogin"`
+	CreatorName  string    `json:"creatorName"`
+}
+
+type CreateEnvironmentRevisionTagRequest struct {
+	Revision *int `json:"revision,omitempty"`
+}
+
+type UpdateEnvironmentRevisionTagRequest struct {
+	Revision *int `json:"revision,omitempty"`
+}
+
+type EnvironmentRevisionTag struct {
+	Name        string    `json:"name"`
+	Revision    int       `json:"revision"`
+	Created     time.Time `json:"created"`
+	Modified    time.Time `json:"modified"`
+	EditorLogin string    `json:"editorLogin"`
+	EditorName  string    `json:"editorName"`
+}
+
+type ListEnvironmentRevisionTagsResponse struct {
+	Tags      []EnvironmentRevisionTag `json:"tags"`
+	NextToken string                   `json:"nextToken"`
+}
 type OrgEnvironment struct {
 	Organization string `json:"organization,omitempty"`
 	Name         string `json:"name,omitempty"`

--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -61,10 +61,10 @@ func newEnvCmd(esc *escCommand) *cobra.Command {
 	return cmd
 }
 
-func (cmd *envCommand) getEnvName(args []string) (org, env string, rest []string, err error) {
+func (cmd *envCommand) getEnvName(args []string) (org, env, revisionOrTag string, rest []string, err error) {
 	if cmd.envNameFlag == "" {
 		if len(args) == 0 {
-			return "", "", nil, fmt.Errorf("no environment name specified")
+			return "", "", "", nil, fmt.Errorf("no environment name specified")
 		}
 		cmd.envNameFlag, args = args[0], args[1:]
 	}
@@ -73,7 +73,10 @@ func (cmd *envCommand) getEnvName(args []string) (org, env string, rest []string
 	if !hasOrgName {
 		orgName, envName = cmd.esc.account.DefaultOrg, orgName
 	}
-	return orgName, envName, args, nil
+
+	envName, revisionOrTag, _ = strings.Cut(envName, ":")
+
+	return orgName, envName, revisionOrTag, args, nil
 }
 
 func sortEnvironmentDiagnostics(diags []client.EnvironmentDiagnostic) {

--- a/cmd/esc/cli/env_edit.go
+++ b/cmd/esc/cli/env_edit.go
@@ -57,13 +57,16 @@ func newEnvEditCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, args, err := edit.env.getEnvName(args)
+			orgName, envName, revisionOrTag, args, err := edit.env.getEnvName(args)
 			if err != nil {
 				return err
 			}
+			if revisionOrTag != "" {
+				return fmt.Errorf("the edit command does not accept revisions or tags")
+			}
 			_ = args
 
-			yaml, tag, err := edit.env.esc.client.GetEnvironment(ctx, orgName, envName, showSecrets)
+			yaml, tag, err := edit.env.esc.client.GetEnvironment(ctx, orgName, envName, "", showSecrets)
 			if err != nil {
 				return fmt.Errorf("getting environment definition: %w", err)
 			}

--- a/cmd/esc/cli/env_get.go
+++ b/cmd/esc/cli/env_get.go
@@ -28,7 +28,7 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 	get := &envGetCommand{env: env}
 
 	cmd := &cobra.Command{
-		Use:   "get [<org-name>/]<environment-name> <path>",
+		Use:   "get [<org-name>/]<environment-name>[:<revision-or-tag>] <path>",
 		Args:  cobra.RangeArgs(1, 2),
 		Short: "Get a value within an environment.",
 		Long: "Get a value within an environment\n" +
@@ -44,7 +44,7 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, args, err := env.getEnvName(args)
+			orgName, envName, revisionOrTag, args, err := env.getEnvName(args)
 			if err != nil {
 				return err
 			}
@@ -61,22 +61,22 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 			case "":
 				// OK
 			case "detailed", "json", "string":
-				return get.showValue(ctx, orgName, envName, path, value, showSecrets)
+				return get.showValue(ctx, orgName, envName, revisionOrTag, path, value, showSecrets)
 			case "dotenv":
 				if len(path) != 0 {
 					return fmt.Errorf("output format '%s' may not be used with a property path", value)
 				}
-				return get.showValue(ctx, orgName, envName, path, value, showSecrets)
+				return get.showValue(ctx, orgName, envName, revisionOrTag, path, value, showSecrets)
 			case "shell":
 				if len(path) != 0 {
 					return fmt.Errorf("output format '%s' may not be used with a property path", value)
 				}
-				return get.showValue(ctx, orgName, envName, path, value, showSecrets)
+				return get.showValue(ctx, orgName, envName, revisionOrTag, path, value, showSecrets)
 			default:
 				return fmt.Errorf("unknown output format %q", value)
 			}
 
-			def, _, err := get.env.esc.client.GetEnvironment(ctx, orgName, envName, showSecrets)
+			def, _, err := get.env.esc.client.GetEnvironment(ctx, orgName, envName, revisionOrTag, showSecrets)
 			if err != nil {
 				return fmt.Errorf("getting environment definition: %w", err)
 			}
@@ -141,11 +141,12 @@ func (get *envGetCommand) showValue(
 	ctx context.Context,
 	orgName string,
 	envName string,
+	revisionOrTag string,
 	path resource.PropertyPath,
 	format string,
 	showSecrets bool,
 ) error {
-	def, _, err := get.env.esc.client.GetEnvironment(ctx, orgName, envName, showSecrets)
+	def, _, err := get.env.esc.client.GetEnvironment(ctx, orgName, envName, revisionOrTag, showSecrets)
 	if err != nil {
 		return fmt.Errorf("getting environment definition: %w", err)
 	}

--- a/cmd/esc/cli/env_init.go
+++ b/cmd/esc/cli/env_init.go
@@ -34,9 +34,12 @@ func newEnvInitCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, args, err := env.getEnvName(args)
+			orgName, envName, revisionOrTag, args, err := env.getEnvName(args)
 			if err != nil {
 				return err
+			}
+			if revisionOrTag != "" {
+				return fmt.Errorf("the init command does not accept revisions or tags")
 			}
 			_ = args
 

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -21,7 +21,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 	var format string
 
 	cmd := &cobra.Command{
-		Use:   "open [<org-name>/]<environment-name> [property path]",
+		Use:   "open [<org-name>/]<environment-name>[:<revision-or-tag>] [property path]",
 		Args:  cobra.MaximumNArgs(2),
 		Short: "Open the environment with the given name.",
 		Long: "Open the environment with the given name and return the result\n" +
@@ -36,7 +36,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, args, err := envcmd.getEnvName(args)
+			orgName, envName, revisionOrTag, args, err := envcmd.getEnvName(args)
 			if err != nil {
 				return err
 			}
@@ -62,7 +62,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 				return fmt.Errorf("unknown output format %q", format)
 			}
 
-			env, diags, err := envcmd.openEnvironment(ctx, orgName, envName, duration)
+			env, diags, err := envcmd.openEnvironment(ctx, orgName, envName, revisionOrTag, duration)
 			if err != nil {
 				return err
 			}
@@ -163,9 +163,10 @@ func (env *envCommand) openEnvironment(
 	ctx context.Context,
 	orgName string,
 	envName string,
+	revisionOrTag string,
 	duration time.Duration,
 ) (*esc.Environment, []client.EnvironmentDiagnostic, error) {
-	envID, diags, err := env.esc.client.OpenEnvironment(ctx, orgName, envName, duration)
+	envID, diags, err := env.esc.client.OpenEnvironment(ctx, orgName, envName, revisionOrTag, duration)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/esc/cli/env_rm.go
+++ b/cmd/esc/cli/env_rm.go
@@ -38,9 +38,12 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, args, err := env.getEnvName(args)
+			orgName, envName, revisionOrTag, args, err := env.getEnvName(args)
 			if err != nil {
 				return err
+			}
+			if revisionOrTag != "" {
+				return fmt.Errorf("the rm command does not accept revisions or tags")
 			}
 
 			// Are we removing the entire environment?
@@ -69,7 +72,7 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 				return fmt.Errorf("invalid path: %w", err)
 			}
 
-			def, tag, err := env.esc.client.GetEnvironment(ctx, orgName, envName, false)
+			def, tag, err := env.esc.client.GetEnvironment(ctx, orgName, envName, "", false)
 			if err != nil {
 				return fmt.Errorf("getting environment definition: %w", err)
 			}

--- a/cmd/esc/cli/env_run.go
+++ b/cmd/esc/cli/env_run.go
@@ -126,7 +126,7 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, args, err := envcmd.getEnvName(args)
+			orgName, envName, revisionOrTag, args, err := envcmd.getEnvName(args)
 			if err != nil {
 				return err
 			}
@@ -140,7 +140,7 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 			}
 			args = args[1:]
 
-			env, diags, err := envcmd.openEnvironment(ctx, orgName, envName, duration)
+			env, diags, err := envcmd.openEnvironment(ctx, orgName, envName, revisionOrTag, duration)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -36,9 +36,12 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, args, err := env.getEnvName(args)
+			orgName, envName, revisionOrTag, args, err := env.getEnvName(args)
 			if err != nil {
 				return err
+			}
+			if revisionOrTag != "" {
+				return fmt.Errorf("the set command does not accept revisions or tags")
 			}
 			if len(args) < 2 {
 				return fmt.Errorf("expected a path and a value")
@@ -78,7 +81,7 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 				yamlValue = *yamlValue.Content[0]
 			}
 
-			def, tag, err := env.esc.client.GetEnvironment(ctx, orgName, envName, false)
+			def, tag, err := env.esc.client.GetEnvironment(ctx, orgName, envName, "", false)
 			if err != nil {
 				return fmt.Errorf("getting environment definition: %w", err)
 			}

--- a/cmd/esc/cli/testdata/env-edit-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-edit-revision-or-tag.yaml
@@ -1,0 +1,20 @@
+run: |
+  (esc env edit test:1 --editor my-editor || exit 0)
+  esc env edit test:foo --editor my-editor
+error: exit status 1
+process:
+  commands:
+    my-editor: |
+      echo -e "\n" >$1
+environments:
+  test-user/test:
+    values:
+      foo: bar
+stdout: |
+  > esc env edit test:1 --editor my-editor
+  > esc env edit test:foo --editor my-editor
+stderr: |
+  > esc env edit test:1 --editor my-editor
+  Error: the edit command does not accept revisions or tags
+  > esc env edit test:foo --editor my-editor
+  Error: the edit command does not accept revisions or tags

--- a/cmd/esc/cli/testdata/env-get-all.yaml
+++ b/cmd/esc/cli/testdata/env-get-all.yaml
@@ -1,24 +1,36 @@
-run: esc env get test
+run: |
+  esc env get test
+  esc env get test:latest
+  esc env get test:stable
+  esc env get test:0
+  esc env get test:1
+  esc env get test:2
 environments:
   test-user/a: {}
   test-user/b: {}
   test-user/test:
-    imports:
-      - a
-      - b
-    values:
-      # comment
-      "null": null
-      boolean: true
-      number: 42
-      string: esc
-      array: [hello, world]
-      object: {hello: world}
-      open:
-        fn::open::test: echo
-      secret:
-        fn::secret:
-          ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+    revisions:
+      - yaml:
+          values:
+            string: hello, world!
+        tag: stable
+      - yaml:
+          imports:
+            - a
+            - b
+          values:
+            # comment
+            "null": null
+            boolean: true
+            number: 42
+            string: esc
+            array: [hello, world]
+            object: {hello: world}
+            open:
+              fn::open::test: echo
+            secret:
+              fn::secret:
+                ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
 stdout: |+
   > esc env get test
   # Value
@@ -60,5 +72,119 @@ stdout: |+
 
   ```
 
+  > esc env get test:latest
+  # Value
+  ```json
+  {
+    "array": [
+      "hello",
+      "world"
+    ],
+    "boolean": true,
+    "null": null,
+    "number": 42,
+    "object": {
+      "hello": "world"
+    },
+    "open": "[unknown]",
+    "secret": "[secret]",
+    "string": "esc"
+  }
+  ```
+  # Definition
+  ```yaml
+  imports:
+    - a
+    - b
+  values:
+    # comment
+    "null": null
+    boolean: true
+    number: 42
+    string: esc
+    array: [hello, world]
+    object: {hello: world}
+    open:
+      fn::open::test: echo
+    secret:
+      fn::secret:
+        ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+
+  ```
+
+  > esc env get test:stable
+  # Value
+  ```json
+  {
+    "string": "hello, world!"
+  }
+  ```
+  # Definition
+  ```yaml
+  values:
+    string: hello, world!
+
+  ```
+
+  > esc env get test:0
+  > esc env get test:1
+  # Value
+  ```json
+  {
+    "string": "hello, world!"
+  }
+  ```
+  # Definition
+  ```yaml
+  values:
+    string: hello, world!
+
+  ```
+
+  > esc env get test:2
+  # Value
+  ```json
+  {
+    "array": [
+      "hello",
+      "world"
+    ],
+    "boolean": true,
+    "null": null,
+    "number": 42,
+    "object": {
+      "hello": "world"
+    },
+    "open": "[unknown]",
+    "secret": "[secret]",
+    "string": "esc"
+  }
+  ```
+  # Definition
+  ```yaml
+  imports:
+    - a
+    - b
+  values:
+    # comment
+    "null": null
+    boolean: true
+    number: 42
+    string: esc
+    array: [hello, world]
+    object: {hello: world}
+    open:
+      fn::open::test: echo
+    secret:
+      fn::secret:
+        ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+
+  ```
+
 stderr: |
   > esc env get test
+  > esc env get test:latest
+  > esc env get test:stable
+  > esc env get test:0
+  > esc env get test:1
+  > esc env get test:2

--- a/cmd/esc/cli/testdata/env-init-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-init-revision-or-tag.yaml
@@ -1,0 +1,12 @@
+run: |
+  (esc env init test-env:1 || exit 0)
+  esc env init test-env:foo
+error: exit status 1
+stdout: |
+  > esc env init test-env:1
+  > esc env init test-env:foo
+stderr: |
+  > esc env init test-env:1
+  Error: the init command does not accept revisions or tags
+  > esc env init test-env:foo
+  Error: the init command does not accept revisions or tags

--- a/cmd/esc/cli/testdata/env-rm-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-rm-revision-or-tag.yaml
@@ -1,0 +1,12 @@
+run: |
+  (esc env rm dup:1 -y || exit 0)
+  esc env rm dup:foo -y
+error: exit status 1
+stdout: |
+  > esc env rm dup:1 -y
+  > esc env rm dup:foo -y
+stderr: |
+  > esc env rm dup:1 -y
+  Error: the rm command does not accept revisions or tags
+  > esc env rm dup:foo -y
+  Error: the rm command does not accept revisions or tags

--- a/cmd/esc/cli/testdata/env-set-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-set-revision-or-tag.yaml
@@ -1,0 +1,12 @@
+run: |
+  (esc env set test:1 string foo || exit 0)
+  esc env set test:foo string foo
+error: exit status 1
+stdout: |
+  > esc env set test:1 string foo
+  > esc env set test:foo string foo
+stderr: |
+  > esc env set test:1 string foo
+  Error: the set command does not accept revisions or tags
+  > esc env set test:foo string foo
+  Error: the set command does not accept revisions or tags

--- a/cmd/esc/cli/testdata/open-json.yaml
+++ b/cmd/esc/cli/testdata/open-json.yaml
@@ -1,10 +1,22 @@
-run: esc open test --format json
+run: |
+  esc open test --format json
+  esc open test:stable
+  esc open test:latest
+  esc open test:0
+  esc open test:1
+  esc open test:2
 environments:
   test-user/test:
-    imports:
-      - test-2
-    values:
-      foo: bar
+    revisions:
+      - yaml:
+          values:
+            foo: bar
+        tag: stable
+      - yaml:
+          imports:
+            - test-2
+          values:
+            foo: bar
   test-user/test-2:
     values:
       foo: baz
@@ -15,5 +27,29 @@ stdout: |
     "foo": "bar",
     "hello": "world"
   }
+  > esc open test:stable
+  {
+    "foo": "bar"
+  }
+  > esc open test:latest
+  {
+    "foo": "bar",
+    "hello": "world"
+  }
+  > esc open test:0
+  > esc open test:1
+  {
+    "foo": "bar"
+  }
+  > esc open test:2
+  {
+    "foo": "bar",
+    "hello": "world"
+  }
 stderr: |
   > esc open test --format json
+  > esc open test:stable
+  > esc open test:latest
+  > esc open test:0
+  > esc open test:1
+  > esc open test:2


### PR DESCRIPTION
These changes add support to the CLI for getting or opening environments at specific revisions or tags using the familiar `name:revision-or-tag` syntax.