### PR TITLE
cli: add commands for managing version tags

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,6 +6,9 @@
 - Add support for listing the revisions to an environment.
   [#277](https://github.com/pulumi/esc/pull/277)
 
+- Add support for managing version tags.
+  [#283](https://github.com/pulumi/esc/pull/283)
+
 ### Bug Fixes
 
 - Ensure that redacted output is flushed in `esc run`

--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -54,6 +54,7 @@ func newEnvCmd(esc *escCommand) *cobra.Command {
 	cmd.AddCommand(newEnvGetCmd(env))
 	cmd.AddCommand(newEnvSetCmd(env))
 	cmd.AddCommand(newEnvLogCmd(env))
+	cmd.AddCommand(newEnvVersionCmd(env))
 	cmd.AddCommand(newEnvLsCmd(env))
 	cmd.AddCommand(newEnvRmCmd(env))
 	cmd.AddCommand(newEnvOpenCmd(env))

--- a/cmd/esc/cli/env_version.go
+++ b/cmd/esc/cli/env_version.go
@@ -1,0 +1,28 @@
+// Copyright 2023, Pulumi Corporation.
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newEnvVersionCmd(env *envCommand) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Manage version tags",
+		Long: "Manage version tags\n" +
+			"\n" +
+			"This command creates, inspects, updates, deletes, and lists version tags.\n" +
+			"A version tag is a name that refers to a specific revision of an environment.\n" +
+			"Once created, version tags can be updated to refer to new reversions\n" +
+			"of an environment. Version tags can be used to refer to a particular logical\n" +
+			"version of an environment rather than a specific revision.\n",
+		SilenceUsage: true,
+	}
+
+	cmd.AddCommand(newEnvVersionTagCmd(env))
+	cmd.AddCommand(newEnvVersionRmCmd(env))
+	cmd.AddCommand(newEnvVersionLsCmd(env))
+
+	return cmd
+}

--- a/cmd/esc/cli/env_version_ls.go
+++ b/cmd/esc/cli/env_version_ls.go
@@ -1,0 +1,77 @@
+// Copyright 2023, Pulumi Corporation.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/esc/cmd/esc/cli/client"
+	"github.com/pulumi/esc/cmd/esc/cli/style"
+)
+
+func newEnvVersionLsCmd(env *envCommand) *cobra.Command {
+	var pagerFlag string
+	var utc bool
+
+	cmd := &cobra.Command{
+		Use:   "ls [<org-name>/]<environment-name>",
+		Short: "List version tags.",
+		Long: "List version tags\n" +
+			"\n" +
+			"This command lists the version tags for an environment.\n",
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			if err := env.esc.getCachedClient(ctx); err != nil {
+				return err
+			}
+
+			orgName, envName, revisionOrTag, args, err := env.getEnvName(args)
+			if err != nil {
+				return err
+			}
+			if revisionOrTag != "" {
+				return fmt.Errorf("the ls command does not accept revisions or tags")
+			}
+			_ = args
+
+			st := style.NewStylist(style.Profile(env.esc.stdout))
+
+			after := ""
+			return env.esc.pager.Run(pagerFlag, env.esc.stdout, env.esc.stderr, func(ctx context.Context, stdout io.Writer) error {
+				count := 500
+				for {
+					options := client.ListEnvironmentRevisionTagsOptions{
+						After: after,
+						Count: &count,
+					}
+					tags, err := env.esc.client.ListEnvironmentRevisionTags(ctx, orgName, envName, options)
+					if err != nil {
+						return err
+					}
+					if len(tags) == 0 {
+						break
+					}
+					after = tags[len(tags)-1].Name
+
+					for _, t := range tags {
+						printRevisionTag(stdout, st, t, utc)
+						fmt.Fprintf(stdout, "\n")
+					}
+				}
+				return nil
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&pagerFlag, "pager", "", "the command to use to page through the environment's version tags")
+	cmd.Flags().BoolVar(&utc, "utc", false, "display times in UTC")
+
+	return cmd
+}

--- a/cmd/esc/cli/env_version_rm.go
+++ b/cmd/esc/cli/env_version_rm.go
@@ -1,0 +1,49 @@
+// Copyright 2023, Pulumi Corporation.
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+func newEnvVersionRmCmd(env *envCommand) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rm [<org-name>/]<environment-name>:<tag>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Remove a version tag.",
+		Long: "Remove a version tag\n" +
+			"\n" +
+			"This command removes the version tag with the given name to refer to the\n" +
+			"indicated revision.\n",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			if err := env.esc.getCachedClient(ctx); err != nil {
+				return err
+			}
+
+			orgName, envName, revisionOrTag, args, err := env.getEnvName(args)
+			if err != nil {
+				return err
+			}
+			if revisionOrTag == "" || isRevisionNumber(revisionOrTag) {
+				return errors.New("please specify a tag name to remove")
+			}
+			_ = args
+
+			return env.esc.client.DeleteEnvironmentRevisionTag(ctx, orgName, envName, revisionOrTag)
+		},
+	}
+
+	return cmd
+}
+
+func isRevisionNumber(revisionOrTag string) bool {
+	_, err := strconv.ParseInt(revisionOrTag, 10, 0)
+	return err == nil
+}

--- a/cmd/esc/cli/env_version_tag.go
+++ b/cmd/esc/cli/env_version_tag.go
@@ -1,0 +1,98 @@
+// Copyright 2023, Pulumi Corporation.
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/pulumi/esc/cmd/esc/cli/client"
+	"github.com/pulumi/esc/cmd/esc/cli/style"
+	"github.com/spf13/cobra"
+)
+
+func newEnvVersionTagCmd(env *envCommand) *cobra.Command {
+	var utc bool
+
+	cmd := &cobra.Command{
+		Use:   "tag [<org-name>/]<environment-name>:<tag> [revision-or-tag]",
+		Args:  cobra.RangeArgs(1, 2),
+		Short: "Create, describe, or update a version tag.",
+		Long: "Create, describe, or update a version tag\n" +
+			"\n" +
+			"This command creates, describes, or updates the version tag with the given name.\n" +
+			"If a revision or tag is passed as the second argument, then the target tag is\n" +
+			"updated to refer to the indicated revision.\n",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			if err := env.esc.getCachedClient(ctx); err != nil {
+				return err
+			}
+
+			orgName, envName, tagName, args, err := env.getEnvName(args)
+			if err != nil {
+				return err
+			}
+			if tagName == "" || isRevisionNumber(tagName) {
+				return errors.New("please specify a tag name")
+			}
+
+			if len(args) == 0 {
+				tag, err := env.esc.client.GetEnvironmentRevisionTag(ctx, orgName, envName, tagName)
+				if err != nil {
+					return err
+				}
+
+				st := style.NewStylist(style.Profile(env.esc.stdout))
+				printRevisionTag(env.esc.stdout, st, *tag, utc)
+				return nil
+			}
+
+			revision64, err := strconv.ParseInt(args[0], 10, 0)
+			if err != nil {
+				return fmt.Errorf("invalid revision number %q: %w", args[0], err)
+			}
+			revision := int(revision64)
+
+			err = env.esc.client.UpdateEnvironmentRevisionTag(ctx, orgName, envName, tagName, &revision)
+			if err == nil {
+				return err
+			}
+			if !client.IsNotFound(err) {
+				return err
+			}
+			return env.esc.client.CreateEnvironmentRevisionTag(ctx, orgName, envName, tagName, &revision)
+		},
+	}
+
+	cmd.Flags().BoolVar(&utc, "utc", false, "display times in UTC")
+
+	return cmd
+}
+
+func printRevisionTag(stdout io.Writer, st *style.Stylist, tag client.EnvironmentRevisionTag, utc bool) {
+	rules := style.Default()
+
+	st.Fprintf(stdout, rules.LinkText, "%v\n", tag.Name)
+	fmt.Fprintf(stdout, "Revision %v\n", tag.Revision)
+
+	stamp := tag.Modified
+	if utc {
+		stamp = stamp.UTC()
+	} else {
+		stamp = stamp.Local()
+	}
+
+	fmt.Fprintf(stdout, "Last updated at %v by ", stamp)
+	if tag.EditorLogin == "" {
+		fmt.Fprintf(stdout, "<unknown>")
+	} else {
+		fmt.Fprintf(stdout, "%v <%v>", tag.EditorName, tag.EditorLogin)
+	}
+	fmt.Fprintln(stdout)
+}

--- a/cmd/esc/cli/testdata/env-version-tag.yaml
+++ b/cmd/esc/cli/testdata/env-version-tag.yaml
@@ -1,0 +1,97 @@
+run: |
+  esc env version tag test:stable 2
+  esc env version tag test:stable --utc
+  esc env version tag test:stable 3
+  esc env version tag test:stable --utc
+  esc env version tag test:latest --utc
+  esc env version ls test --utc
+  esc env version tag test:initial 1
+  esc env version ls test --utc
+  esc env version rm test:initial
+  esc env version ls test --utc
+environments:
+  test-user/a: {}
+  test-user/b: {}
+  test-user/test:
+    revisions:
+      - yaml:
+          values: {}
+      - yaml:
+          values:
+            string: hello, world!
+      - yaml:
+          imports:
+            - a
+            - b
+          values:
+            # comment
+            "null": null
+            boolean: true
+            number: 42
+            string: esc
+            array: [hello, world]
+            object: {hello: world}
+            open:
+              fn::open::test: echo
+            secret:
+              fn::secret:
+                ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+stdout: |+
+  > esc env version tag test:stable 2
+  > esc env version tag test:stable --utc
+  stable
+  Revision 2
+  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+  > esc env version tag test:stable 3
+  > esc env version tag test:stable --utc
+  stable
+  Revision 3
+  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+  > esc env version tag test:latest --utc
+  latest
+  Revision 4
+  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+  > esc env version ls test --utc
+  latest
+  Revision 4
+  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+
+  stable
+  Revision 3
+  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+
+  > esc env version tag test:initial 1
+  > esc env version ls test --utc
+  initial
+  Revision 1
+  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+
+  latest
+  Revision 4
+  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+
+  stable
+  Revision 3
+  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+
+  > esc env version rm test:initial
+  > esc env version ls test --utc
+  latest
+  Revision 4
+  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+
+  stable
+  Revision 3
+  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+
+stderr: |
+  > esc env version tag test:stable 2
+  > esc env version tag test:stable --utc
+  > esc env version tag test:stable 3
+  > esc env version tag test:stable --utc
+  > esc env version tag test:latest --utc
+  > esc env version ls test --utc
+  > esc env version tag test:initial 1
+  > esc env version ls test --utc
+  > esc env version rm test:initial
+  > esc env version ls test --utc

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.17.0
 	github.com/muesli/termenv v0.15.2
 	github.com/petar-dambovaliev/aho-corasick v0.0.0-20230725210150-fb29fc3c913e
+	github.com/pgavlin/fx v0.1.6
 	github.com/pulumi/pulumi/pkg/v3 v3.98.0
 	github.com/pulumi/pulumi/sdk/v3 v3.98.0
 	github.com/rivo/uniseg v0.4.4
@@ -176,7 +177,6 @@ require (
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pgavlin/diff v0.0.0-20230503175810-113847418e2e // indirect
-	github.com/pgavlin/fx v0.1.6 // indirect
 	github.com/pgavlin/goldmark v1.1.33-0.20200616210433-b5eb04559386 // indirect
 	github.com/pgavlin/text v0.0.0-20230428184845-84c285f11d2f // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect


### PR DESCRIPTION
These changes add commands for managing version tags:

- `esc env version tag` creates, describes, or updates a version tag
- `esc env version rm` deletes a version tag
- `esc env version ls` lists version tags