### PR TITLE
cli: add tags to `env log` output

### DIFF
--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -624,11 +624,17 @@ func (c *testPulumiClient) ListEnvironmentRevisions(
 
 	var resp []client.EnvironmentRevision
 	for i := before - 1; i > 0; i-- {
+		var tags []string
+		if tag := env.revisions[i-1].tag; tag != "" {
+			tags = []string{tag}
+		}
+
 		resp = append(resp, client.EnvironmentRevision{
 			Number:       i,
 			Created:      time.Unix(0, 0).Add(time.Duration(i) * time.Hour),
 			CreatorLogin: "Test Tester",
 			CreatorName:  "test-tester",
+			Tags:         tags,
 		})
 	}
 
@@ -850,6 +856,7 @@ func loadTestcase(path string) (*cliTestcaseYAML, *cliTestcase, error) {
 					return nil, nil, fmt.Errorf("duplicate tag %q", rev.Tag)
 				}
 				tags[rev.Tag] = revisionNumber
+				envRevisions[revisionNumber-1].tag = rev.Tag
 			}
 		}
 		tags["latest"] = len(envRevisions)

--- a/cmd/esc/cli/client/apitype.go
+++ b/cmd/esc/cli/client/apitype.go
@@ -64,6 +64,7 @@ type EnvironmentRevision struct {
 	Created      time.Time `json:"created"`
 	CreatorLogin string    `json:"creatorLogin"`
 	CreatorName  string    `json:"creatorName"`
+	Tags         []string  `json:"tags"`
 }
 
 type CreateEnvironmentRevisionTagRequest struct {

--- a/cmd/esc/cli/env_log.go
+++ b/cmd/esc/cli/env_log.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -64,7 +65,17 @@ func newEnvLogCmd(env *envCommand) *cobra.Command {
 					before = revisions[len(revisions)-1].Number
 
 					for _, r := range revisions {
-						fmt.Fprintf(stdout, "revision %v\n", r.Number)
+						fmt.Fprintf(stdout, "revision %v", r.Number)
+						switch len(r.Tags) {
+						case 0:
+							// OK
+						case 1:
+							fmt.Fprintf(stdout, " (tag: %v)", r.Tags[0])
+						default:
+							fmt.Fprintf(stdout, " (tags: %v)", strings.Join(r.Tags, ", "))
+						}
+						fmt.Fprintln(stdout, "")
+
 						if r.CreatorLogin == "" {
 							fmt.Fprintf(stdout, "Author: <unknown>\n")
 						} else {

--- a/cmd/esc/cli/testdata/env-log.yaml
+++ b/cmd/esc/cli/testdata/env-log.yaml
@@ -40,7 +40,7 @@ stdout: |+
   Author: test-tester <Test Tester>
   Date:   1970-01-01 04:00:00 +0000 UTC
 
-  revision 3
+  revision 3 (tag: stable)
   Author: test-tester <Test Tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
@@ -57,7 +57,7 @@ stdout: |+
   Author: test-tester <Test Tester>
   Date:   1970-01-01 04:00:00 +0000 UTC
 
-  revision 3
+  revision 3 (tag: stable)
   Author: test-tester <Test Tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
@@ -70,7 +70,7 @@ stdout: |+
   Date:   1970-01-01 01:00:00 +0000 UTC
 
   > esc env log test:stable --utc
-  revision 3
+  revision 3 (tag: stable)
   Author: test-tester <Test Tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
@@ -97,7 +97,7 @@ stdout: |+
   Date:   1970-01-01 01:00:00 +0000 UTC
 
   > esc env log test:3 --utc
-  revision 3
+  revision 3 (tag: stable)
   Author: test-tester <Test Tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
@@ -114,7 +114,7 @@ stdout: |+
   Author: test-tester <Test Tester>
   Date:   1970-01-01 04:00:00 +0000 UTC
 
-  revision 3
+  revision 3 (tag: stable)
   Author: test-tester <Test Tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 


### PR DESCRIPTION
If a revision has tags, display them after the revision number ala `git log`.