### PR TITLE
cli: make `env log` prettier

### DIFF
--- a/cmd/esc/cli/env_get.go
+++ b/cmd/esc/cli/env_get.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/pulumi/esc"
+	"github.com/pulumi/esc/cmd/esc/cli/style"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
@@ -104,7 +105,7 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 				return nil
 			}
 
-			renderer, err := glamour.NewTermRenderer(glamour.WithAutoStyle(), glamour.WithWordWrap(0))
+			renderer, err := style.Glamour(get.env.esc.stdout, glamour.WithWordWrap(0))
 			if err != nil {
 				return fmt.Errorf("internal error: creating renderer: %w", err)
 			}

--- a/cmd/esc/cli/env_log.go
+++ b/cmd/esc/cli/env_log.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/esc/cmd/esc/cli/client"
+	"github.com/pulumi/esc/cmd/esc/cli/style"
 )
 
 func newEnvLogCmd(env *envCommand) *cobra.Command {
@@ -48,6 +49,9 @@ func newEnvLogCmd(env *envCommand) *cobra.Command {
 				before = rev + 1
 			}
 
+			// NOTE: we use the color profile from the user-visible stdout rather than the color profile from the pager's stdout.
+			rules := style.Default()
+			st := style.NewStylist(style.Profile(env.esc.stdout))
 			return env.esc.pager.Run(pagerFlag, env.esc.stdout, env.esc.stderr, func(ctx context.Context, stdout io.Writer) error {
 				count := 500
 				for {
@@ -65,14 +69,14 @@ func newEnvLogCmd(env *envCommand) *cobra.Command {
 					before = revisions[len(revisions)-1].Number
 
 					for _, r := range revisions {
-						fmt.Fprintf(stdout, "revision %v", r.Number)
+						st.Fprintf(stdout, rules.H1.StylePrimitive, "revision %v", r.Number)
 						switch len(r.Tags) {
 						case 0:
 							// OK
 						case 1:
-							fmt.Fprintf(stdout, " (tag: %v)", r.Tags[0])
+							st.Fprintf(stdout, rules.LinkText, " (tag: %v)", r.Tags[0])
 						default:
-							fmt.Fprintf(stdout, " (tags: %v)", strings.Join(r.Tags, ", "))
+							st.Fprintf(stdout, rules.LinkText, " (tags: %v)", strings.Join(r.Tags, ", "))
 						}
 						fmt.Fprintln(stdout, "")
 

--- a/cmd/esc/cli/pager/system.go
+++ b/cmd/esc/cli/pager/system.go
@@ -9,11 +9,12 @@ import (
 	"os/exec"
 )
 
-func runSystemPager(pager string, stdout, stderr io.Writer, f func(context.Context, io.Writer) error) error {
+func runSystemPager(pager []string, stdout, stderr io.Writer, f func(context.Context, io.Writer) error) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cmd := exec.Command(pager)
+	//nolint:gosec
+	cmd := exec.Command(pager[0], pager[1:]...)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	stdin, err := cmd.StdinPipe()

--- a/cmd/esc/cli/style/dark_style.go
+++ b/cmd/esc/cli/style/dark_style.go
@@ -1,0 +1,220 @@
+// Copyright 2024, Pulumi Corporation.
+
+package style
+
+import (
+	"github.com/charmbracelet/glamour/ansi"
+)
+
+// Dark is the default dark style.
+var Dark = ansi.StyleConfig{
+	Document: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			BlockPrefix: "\n",
+			BlockSuffix: "\n",
+			Color:       some("252"),
+		},
+		Margin: some(uint(2)),
+	},
+	BlockQuote: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{},
+		Indent:         some(uint(1)),
+		IndentToken:    some("│ "),
+	},
+	List: ansi.StyleList{
+		LevelIndent: 2,
+	},
+	Heading: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			BlockSuffix: "\n",
+			Color:       some("39"),
+			Bold:        some(true),
+		},
+	},
+	H1: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix:          " ",
+			Suffix:          " ",
+			Color:           some("228"),
+			BackgroundColor: some("63"),
+			Bold:            some(true),
+		},
+	},
+	H2: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "## ",
+		},
+	},
+	H3: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "### ",
+		},
+	},
+	H4: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "#### ",
+		},
+	},
+	H5: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "##### ",
+		},
+	},
+	H6: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "###### ",
+			Color:  some("35"),
+			Bold:   some(false),
+		},
+	},
+	Strikethrough: ansi.StylePrimitive{
+		CrossedOut: some(true),
+	},
+	Emph: ansi.StylePrimitive{
+		Italic: some(true),
+	},
+	Strong: ansi.StylePrimitive{
+		Bold: some(true),
+	},
+	HorizontalRule: ansi.StylePrimitive{
+		Color:  some("240"),
+		Format: "\n--------\n",
+	},
+	Item: ansi.StylePrimitive{
+		BlockPrefix: "• ",
+	},
+	Enumeration: ansi.StylePrimitive{
+		BlockPrefix: ". ",
+	},
+	Task: ansi.StyleTask{
+		StylePrimitive: ansi.StylePrimitive{},
+		Ticked:         "[✓] ",
+		Unticked:       "[ ] ",
+	},
+	Link: ansi.StylePrimitive{
+		Color:     some("30"),
+		Underline: some(true),
+	},
+	LinkText: ansi.StylePrimitive{
+		Color: some("35"),
+		Bold:  some(true),
+	},
+	Image: ansi.StylePrimitive{
+		Color:     some("212"),
+		Underline: some(true),
+	},
+	ImageText: ansi.StylePrimitive{
+		Color:  some("243"),
+		Format: "Image: {{.text}} →",
+	},
+	Code: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix:          " ",
+			Suffix:          " ",
+			Color:           some("203"),
+			BackgroundColor: some("236"),
+		},
+	},
+	CodeBlock: ansi.StyleCodeBlock{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color: some("244"),
+			},
+			Margin: some(uint(2)),
+		},
+		Chroma: &ansi.Chroma{
+			Text: ansi.StylePrimitive{
+				Color: some("#C4C4C4"),
+			},
+			Error: ansi.StylePrimitive{
+				Color:           some("#F1F1F1"),
+				BackgroundColor: some("#F05B5B"),
+			},
+			Comment: ansi.StylePrimitive{
+				Color: some("#676767"),
+			},
+			CommentPreproc: ansi.StylePrimitive{
+				Color: some("#FF875F"),
+			},
+			Keyword: ansi.StylePrimitive{
+				Color: some("#00AAFF"),
+			},
+			KeywordReserved: ansi.StylePrimitive{
+				Color: some("#FF5FD2"),
+			},
+			KeywordNamespace: ansi.StylePrimitive{
+				Color: some("#FF5F87"),
+			},
+			KeywordType: ansi.StylePrimitive{
+				Color: some("#6E6ED8"),
+			},
+			Operator: ansi.StylePrimitive{
+				Color: some("#EF8080"),
+			},
+			Punctuation: ansi.StylePrimitive{
+				Color: some("#E8E8A8"),
+			},
+			Name: ansi.StylePrimitive{
+				Color: some("#C4C4C4"),
+			},
+			NameBuiltin: ansi.StylePrimitive{
+				Color: some("#FF8EC7"),
+			},
+			NameTag: ansi.StylePrimitive{
+				Color: some("#B083EA"),
+			},
+			NameAttribute: ansi.StylePrimitive{
+				Color: some("#7A7AE6"),
+			},
+			NameClass: ansi.StylePrimitive{
+				Color:     some("#F1F1F1"),
+				Underline: some(true),
+				Bold:      some(true),
+			},
+			NameDecorator: ansi.StylePrimitive{
+				Color: some("#FFFF87"),
+			},
+			NameFunction: ansi.StylePrimitive{
+				Color: some("#00D787"),
+			},
+			LiteralNumber: ansi.StylePrimitive{
+				Color: some("#6EEFC0"),
+			},
+			LiteralString: ansi.StylePrimitive{
+				Color: some("#C69669"),
+			},
+			LiteralStringEscape: ansi.StylePrimitive{
+				Color: some("#AFFFD7"),
+			},
+			GenericDeleted: ansi.StylePrimitive{
+				Color: some("#FD5B5B"),
+			},
+			GenericEmph: ansi.StylePrimitive{
+				Italic: some(true),
+			},
+			GenericInserted: ansi.StylePrimitive{
+				Color: some("#00D787"),
+			},
+			GenericStrong: ansi.StylePrimitive{
+				Bold: some(true),
+			},
+			GenericSubheading: ansi.StylePrimitive{
+				Color: some("#777777"),
+			},
+			Background: ansi.StylePrimitive{
+				BackgroundColor: some("#373737"),
+			},
+		},
+	},
+	Table: ansi.StyleTable{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{},
+		},
+		CenterSeparator: some("┼"),
+		ColumnSeparator: some("│"),
+		RowSeparator:    some("─"),
+	},
+	DefinitionDescription: ansi.StylePrimitive{
+		BlockPrefix: "\n🠶 ",
+	},
+}

--- a/cmd/esc/cli/style/light_style.go
+++ b/cmd/esc/cli/style/light_style.go
@@ -1,0 +1,219 @@
+// Copyright 2024, Pulumi Corporation.
+
+package style
+
+import (
+	"github.com/charmbracelet/glamour/ansi"
+)
+
+// Light is the default light style.
+var Light = ansi.StyleConfig{
+	Document: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			BlockPrefix: "\n",
+			BlockSuffix: "\n",
+			Color:       some("234"),
+		},
+		Margin: some(uint(2)),
+	},
+	BlockQuote: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{},
+		Indent:         some(uint(1)),
+		IndentToken:    some("│ "),
+	},
+	List: ansi.StyleList{
+		LevelIndent: 2,
+	},
+	Heading: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			BlockSuffix: "\n",
+			Color:       some("27"),
+			Bold:        some(true),
+		},
+	},
+	H1: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix:          " ",
+			Suffix:          " ",
+			Color:           some("228"),
+			BackgroundColor: some("63"),
+			Bold:            some(true),
+		},
+	},
+	H2: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "## ",
+		},
+	},
+	H3: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "### ",
+		},
+	},
+	H4: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "#### ",
+		},
+	},
+	H5: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "##### ",
+		},
+	},
+	H6: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix: "###### ",
+			Bold:   some(false),
+		},
+	},
+	Strikethrough: ansi.StylePrimitive{
+		CrossedOut: some(true),
+	},
+	Emph: ansi.StylePrimitive{
+		Italic: some(true),
+	},
+	Strong: ansi.StylePrimitive{
+		Bold: some(true),
+	},
+	HorizontalRule: ansi.StylePrimitive{
+		Color:  some("249"),
+		Format: "\n--------\n",
+	},
+	Item: ansi.StylePrimitive{
+		BlockPrefix: "• ",
+	},
+	Enumeration: ansi.StylePrimitive{
+		BlockPrefix: ". ",
+	},
+	Task: ansi.StyleTask{
+		StylePrimitive: ansi.StylePrimitive{},
+		Ticked:         "[✓] ",
+		Unticked:       "[ ] ",
+	},
+	Link: ansi.StylePrimitive{
+		Color:     some("36"),
+		Underline: some(true),
+	},
+	LinkText: ansi.StylePrimitive{
+		Color: some("29"),
+		Bold:  some(true),
+	},
+	Image: ansi.StylePrimitive{
+		Color:     some("205"),
+		Underline: some(true),
+	},
+	ImageText: ansi.StylePrimitive{
+		Color:  some("243"),
+		Format: "Image: {{.text}} →",
+	},
+	Code: ansi.StyleBlock{
+		StylePrimitive: ansi.StylePrimitive{
+			Prefix:          " ",
+			Suffix:          " ",
+			Color:           some("203"),
+			BackgroundColor: some("254"),
+		},
+	},
+	CodeBlock: ansi.StyleCodeBlock{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{
+				Color: some("242"),
+			},
+			Margin: some(uint(2)),
+		},
+		Chroma: &ansi.Chroma{
+			Text: ansi.StylePrimitive{
+				Color: some("#2A2A2A"),
+			},
+			Error: ansi.StylePrimitive{
+				Color:           some("#F1F1F1"),
+				BackgroundColor: some("#FF5555"),
+			},
+			Comment: ansi.StylePrimitive{
+				Color: some("#8D8D8D"),
+			},
+			CommentPreproc: ansi.StylePrimitive{
+				Color: some("#FF875F"),
+			},
+			Keyword: ansi.StylePrimitive{
+				Color: some("#279EFC"),
+			},
+			KeywordReserved: ansi.StylePrimitive{
+				Color: some("#FF5FD2"),
+			},
+			KeywordNamespace: ansi.StylePrimitive{
+				Color: some("#FB406F"),
+			},
+			KeywordType: ansi.StylePrimitive{
+				Color: some("#7049C2"),
+			},
+			Operator: ansi.StylePrimitive{
+				Color: some("#FF2626"),
+			},
+			Punctuation: ansi.StylePrimitive{
+				Color: some("#FA7878"),
+			},
+			NameBuiltin: ansi.StylePrimitive{
+				Color: some("#0A1BB1"),
+			},
+			NameTag: ansi.StylePrimitive{
+				Color: some("#581290"),
+			},
+			NameAttribute: ansi.StylePrimitive{
+				Color: some("#8362CB"),
+			},
+			NameClass: ansi.StylePrimitive{
+				Color:     some("#212121"),
+				Underline: some(true),
+				Bold:      some(true),
+			},
+			NameConstant: ansi.StylePrimitive{
+				Color: some("#581290"),
+			},
+			NameDecorator: ansi.StylePrimitive{
+				Color: some("#A3A322"),
+			},
+			NameFunction: ansi.StylePrimitive{
+				Color: some("#019F57"),
+			},
+			LiteralNumber: ansi.StylePrimitive{
+				Color: some("#22CCAE"),
+			},
+			LiteralString: ansi.StylePrimitive{
+				Color: some("#7E5B38"),
+			},
+			LiteralStringEscape: ansi.StylePrimitive{
+				Color: some("#00AEAE"),
+			},
+			GenericDeleted: ansi.StylePrimitive{
+				Color: some("#FD5B5B"),
+			},
+			GenericEmph: ansi.StylePrimitive{
+				Italic: some(true),
+			},
+			GenericInserted: ansi.StylePrimitive{
+				Color: some("#00D787"),
+			},
+			GenericStrong: ansi.StylePrimitive{
+				Bold: some(true),
+			},
+			GenericSubheading: ansi.StylePrimitive{
+				Color: some("#777777"),
+			},
+			Background: ansi.StylePrimitive{
+				BackgroundColor: some("#373737"),
+			},
+		},
+	},
+	Table: ansi.StyleTable{
+		StyleBlock: ansi.StyleBlock{
+			StylePrimitive: ansi.StylePrimitive{},
+		},
+		CenterSeparator: some("┼"),
+		ColumnSeparator: some("│"),
+		RowSeparator:    some("─"),
+	},
+	DefinitionDescription: ansi.StylePrimitive{
+		BlockPrefix: "\n🠶 ",
+	},
+}

--- a/cmd/esc/cli/style/style.go
+++ b/cmd/esc/cli/style/style.go
@@ -1,0 +1,35 @@
+// Copyright 2024, Pulumi Corporation.
+
+package style
+
+import (
+	"io"
+
+	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/glamour/ansi"
+	"github.com/muesli/termenv"
+)
+
+func some[T any](v T) *T {
+	return &v
+}
+
+func Glamour(w io.Writer, options ...glamour.TermRendererOption) (*glamour.TermRenderer, error) {
+	opts := []glamour.TermRendererOption{
+		glamour.WithStyles(Default()),
+		glamour.WithColorProfile(Profile(w)),
+	}
+	opts = append(opts, options...)
+	return glamour.NewTermRenderer(opts...)
+}
+
+func Profile(w io.Writer) termenv.Profile {
+	return termenv.NewOutput(w).Profile
+}
+
+func Default() ansi.StyleConfig {
+	if termenv.HasDarkBackground() {
+		return Dark
+	}
+	return Light
+}

--- a/cmd/esc/cli/style/stylist.go
+++ b/cmd/esc/cli/style/stylist.go
@@ -1,0 +1,64 @@
+// Copyright 2024, Pulumi Corporation.
+
+package style
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/glamour/ansi"
+	"github.com/muesli/termenv"
+)
+
+type Stylist struct {
+	profile termenv.Profile
+}
+
+func NewStylist(profile termenv.Profile) *Stylist {
+	return &Stylist{profile: profile}
+}
+
+func (st *Stylist) Sprintf(rules ansi.StylePrimitive, s string, args ...any) string {
+	out := st.profile.String(fmt.Sprintf(s, args...))
+
+	if rules.Upper != nil && *rules.Upper {
+		out = termenv.String(strings.ToUpper(s))
+	}
+	if rules.Lower != nil && *rules.Lower {
+		out = termenv.String(strings.ToLower(s))
+	}
+	if rules.Color != nil {
+		out = out.Foreground(st.profile.Color(*rules.Color))
+	}
+	if rules.BackgroundColor != nil {
+		out = out.Background(st.profile.Color(*rules.BackgroundColor))
+	}
+	if rules.Underline != nil && *rules.Underline {
+		out = out.Underline()
+	}
+	if rules.Bold != nil && *rules.Bold {
+		out = out.Bold()
+	}
+	if rules.Italic != nil && *rules.Italic {
+		out = out.Italic()
+	}
+	if rules.CrossedOut != nil && *rules.CrossedOut {
+		out = out.CrossOut()
+	}
+	if rules.Overlined != nil && *rules.Overlined {
+		out = out.Overline()
+	}
+	if rules.Inverse != nil && *rules.Inverse {
+		out = out.Reverse()
+	}
+	if rules.Blink != nil && *rules.Blink {
+		out = out.Blink()
+	}
+
+	return out.String()
+}
+
+func (st *Stylist) Fprintf(w io.Writer, rules ansi.StylePrimitive, s string, args ...any) (int, error) {
+	return fmt.Fprint(w, st.Sprintf(rules, s, args...))
+}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,9 @@ require (
 	github.com/charmbracelet/x/exp/teatest v0.0.0-20240328150354-ab9afc214dfd
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/google/go-querystring v1.1.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/hcl/v2 v2.17.0
+	github.com/muesli/termenv v0.15.2
 	github.com/petar-dambovaliev/aho-corasick v0.0.0-20230725210150-fb29fc3c913e
 	github.com/pulumi/pulumi/pkg/v3 v3.98.0
 	github.com/pulumi/pulumi/sdk/v3 v3.98.0
@@ -168,7 +170,6 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
-	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/natefinch/atomic v1.0.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -881,6 +881,8 @@ github.com/google/pprof v0.0.0-20220608213341-c488b8fa1db3/go.mod h1:gSuNB+gJaOi
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.4 h1:1kZ/sQM3srePvKs3tXAvQzo66XfcReoqFpIpIccE7Oc=
 github.com/google/s2a-go v0.1.4/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/subcommands v1.0.1/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
Use the same styling as is used for rendering top-level headers in the output of `esc env get`.