### PR TITLE
cli: add a command for diffing revisions

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,6 +9,9 @@
 - Add support for managing version tags.
   [#283](https://github.com/pulumi/esc/pull/283)
 
+- Add support for displaying changed between environment revisions.
+  [#295](https://github.com/pulumi/esc/pull/295)
+
 ### Bug Fixes
 
 - Ensure that redacted output is flushed in `esc run`

--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -52,6 +52,7 @@ func newEnvCmd(esc *escCommand) *cobra.Command {
 	cmd.AddCommand(newEnvInitCmd(env))
 	cmd.AddCommand(newEnvEditCmd(env))
 	cmd.AddCommand(newEnvGetCmd(env))
+	cmd.AddCommand(newEnvDiffCmd(env))
 	cmd.AddCommand(newEnvSetCmd(env))
 	cmd.AddCommand(newEnvLogCmd(env))
 	cmd.AddCommand(newEnvVersionCmd(env))

--- a/cmd/esc/cli/env_diff.go
+++ b/cmd/esc/cli/env_diff.go
@@ -1,0 +1,137 @@
+// Copyright 2023, Pulumi Corporation.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/charmbracelet/glamour"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/esc/cmd/esc/cli/style"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+func newEnvDiffCmd(env *envCommand) *cobra.Command {
+	var format string
+	var showSecrets bool
+	var pathString string
+
+	diff := &envGetCommand{env: env}
+
+	cmd := &cobra.Command{
+		Use:   "diff [<org-name>/]<environment-name>[:<revision-or-tag>] [<revision-or-tag>]",
+		Args:  cobra.RangeArgs(1, 2),
+		Short: "Show changes between revisions.",
+		Long: "Show changes between revisions\n" +
+			"\n" +
+			"This command fetches the current definition for the named environment and gets a\n" +
+			"value within it. The path to the value to set is a Pulumi property path. The value\n" +
+			"is printed to stdout as YAML.\n",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			if err := env.esc.getCachedClient(ctx); err != nil {
+				return err
+			}
+
+			orgName, envName, revisionOrTag, args, err := env.getEnvName(args)
+			if err != nil {
+				return err
+			}
+			baseRevisionOrTag := revisionOrTag
+			if baseRevisionOrTag == "" {
+				baseRevisionOrTag = "latest"
+			}
+
+			tipRevisionOrTag := "latest"
+			if len(args) != 0 {
+				tipRevisionOrTag = args[0]
+			}
+
+			var path resource.PropertyPath
+			if pathString != "" {
+				path, err = resource.ParsePropertyPath(pathString)
+				if err != nil {
+					return fmt.Errorf("invalid path: %w", err)
+				}
+			}
+
+			switch format {
+			case "":
+				// OK
+			case "detailed", "json", "string":
+				return diff.diffValue(ctx, orgName, envName, baseRevisionOrTag, tipRevisionOrTag, path, format, showSecrets)
+			case "dotenv":
+				if len(path) != 0 {
+					return fmt.Errorf("output format '%s' may not be used with a property path", format)
+				}
+				return diff.diffValue(ctx, orgName, envName, baseRevisionOrTag, tipRevisionOrTag, path, format, showSecrets)
+			case "shell":
+				if len(path) != 0 {
+					return fmt.Errorf("output format '%s' may not be used with a property path", format)
+				}
+				return diff.diffValue(ctx, orgName, envName, baseRevisionOrTag, tipRevisionOrTag, path, format, showSecrets)
+			default:
+				return fmt.Errorf("unknown output format %q", format)
+			}
+
+			baseData, err := diff.getEnvironment(ctx, orgName, envName, baseRevisionOrTag, path, showSecrets)
+			if err != nil {
+				return err
+			}
+			if baseData == nil {
+				baseData = &envGetTemplateData{}
+			}
+
+			tipData, err := diff.getEnvironment(ctx, orgName, envName, tipRevisionOrTag, path, showSecrets)
+			if err != nil {
+				return err
+			}
+			if tipData == nil {
+				tipData = &envGetTemplateData{}
+			}
+
+			baseRef := fmt.Sprintf("%s:%s", envName, baseRevisionOrTag)
+			tipRef := fmt.Sprintf("%s:%s", envName, tipRevisionOrTag)
+			data := diff.diff(baseRef, baseData, tipRef, tipData)
+
+			var markdown bytes.Buffer
+			if err := envDiffTemplate.Execute(&markdown, data); err != nil {
+				return fmt.Errorf("internal error: rendering: %w", err)
+			}
+
+			if !cmdutil.InteractiveTerminal() {
+				fmt.Fprint(diff.env.esc.stdout, markdown.String())
+				return nil
+			}
+
+			renderer, err := style.Glamour(diff.env.esc.stdout, glamour.WithWordWrap(0))
+			if err != nil {
+				return fmt.Errorf("internal error: creating renderer: %w", err)
+			}
+			rendered, err := renderer.Render(markdown.String())
+			if err != nil {
+				rendered = markdown.String()
+			}
+			fmt.Fprint(diff.env.esc.stdout, rendered)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(
+		&format, "format", "f", "",
+		"the output format to use. May be 'dotenv', 'json', 'yaml', 'detailed', or 'shell'")
+	cmd.Flags().BoolVar(
+		&showSecrets, "show-secrets", false,
+		"Show static secrets in plaintext rather than ciphertext")
+	cmd.Flags().StringVar(
+		&pathString, "path", "",
+		"Show the diff for a specific path")
+
+	return cmd
+}

--- a/cmd/esc/cli/style/chroma.go
+++ b/cmd/esc/cli/style/chroma.go
@@ -1,0 +1,76 @@
+package style
+
+import (
+	"github.com/alecthomas/chroma/v2"
+	"github.com/charmbracelet/glamour/ansi"
+)
+
+func Chroma(theme string, rules ansi.StyleCodeBlock) *chroma.Style {
+	return chroma.MustNewStyle(theme, chroma.StyleEntries{
+		chroma.Text:                chromaStyle(rules.Chroma.Text),
+		chroma.Error:               chromaStyle(rules.Chroma.Error),
+		chroma.Comment:             chromaStyle(rules.Chroma.Comment),
+		chroma.CommentPreproc:      chromaStyle(rules.Chroma.CommentPreproc),
+		chroma.Keyword:             chromaStyle(rules.Chroma.Keyword),
+		chroma.KeywordReserved:     chromaStyle(rules.Chroma.KeywordReserved),
+		chroma.KeywordNamespace:    chromaStyle(rules.Chroma.KeywordNamespace),
+		chroma.KeywordType:         chromaStyle(rules.Chroma.KeywordType),
+		chroma.Operator:            chromaStyle(rules.Chroma.Operator),
+		chroma.Punctuation:         chromaStyle(rules.Chroma.Punctuation),
+		chroma.Name:                chromaStyle(rules.Chroma.Name),
+		chroma.NameBuiltin:         chromaStyle(rules.Chroma.NameBuiltin),
+		chroma.NameTag:             chromaStyle(rules.Chroma.NameTag),
+		chroma.NameAttribute:       chromaStyle(rules.Chroma.NameAttribute),
+		chroma.NameClass:           chromaStyle(rules.Chroma.NameClass),
+		chroma.NameConstant:        chromaStyle(rules.Chroma.NameConstant),
+		chroma.NameDecorator:       chromaStyle(rules.Chroma.NameDecorator),
+		chroma.NameException:       chromaStyle(rules.Chroma.NameException),
+		chroma.NameFunction:        chromaStyle(rules.Chroma.NameFunction),
+		chroma.NameOther:           chromaStyle(rules.Chroma.NameOther),
+		chroma.Literal:             chromaStyle(rules.Chroma.Literal),
+		chroma.LiteralNumber:       chromaStyle(rules.Chroma.LiteralNumber),
+		chroma.LiteralDate:         chromaStyle(rules.Chroma.LiteralDate),
+		chroma.LiteralString:       chromaStyle(rules.Chroma.LiteralString),
+		chroma.LiteralStringEscape: chromaStyle(rules.Chroma.LiteralStringEscape),
+		chroma.GenericDeleted:      chromaStyle(rules.Chroma.GenericDeleted),
+		chroma.GenericEmph:         chromaStyle(rules.Chroma.GenericEmph),
+		chroma.GenericInserted:     chromaStyle(rules.Chroma.GenericInserted),
+		chroma.GenericStrong:       chromaStyle(rules.Chroma.GenericStrong),
+		chroma.GenericSubheading:   chromaStyle(rules.Chroma.GenericSubheading),
+		chroma.Background:          chromaStyle(rules.Chroma.Background),
+	})
+}
+
+func chromaStyle(style ansi.StylePrimitive) string {
+	var s string
+
+	if style.Color != nil {
+		s = *style.Color
+	}
+	if style.BackgroundColor != nil {
+		if s != "" {
+			s += " "
+		}
+		s += "bg:" + *style.BackgroundColor
+	}
+	if style.Italic != nil && *style.Italic {
+		if s != "" {
+			s += " "
+		}
+		s += "italic"
+	}
+	if style.Bold != nil && *style.Bold {
+		if s != "" {
+			s += " "
+		}
+		s += "bold"
+	}
+	if style.Underline != nil && *style.Underline {
+		if s != "" {
+			s += " "
+		}
+		s += "underline"
+	}
+
+	return s
+}

--- a/cmd/esc/cli/style/chroma.go
+++ b/cmd/esc/cli/style/chroma.go
@@ -1,3 +1,5 @@
+// Copyright 2024, Pulumi Corporation.
+
 package style
 
 import (

--- a/cmd/esc/cli/templates.go
+++ b/cmd/esc/cli/templates.go
@@ -12,7 +12,8 @@ import (
 var templatesFS embed.FS
 
 var (
-	envGetTemplate *template.Template
+	envGetTemplate  *template.Template
+	envDiffTemplate *template.Template
 )
 
 func init() {
@@ -28,4 +29,5 @@ func init() {
 
 	templates := template.Must(root.ParseFS(templatesFS, "templates/*.tmpl"))
 	envGetTemplate = mustLookup(templates, "env-get.tmpl")
+	envDiffTemplate = mustLookup(templates, "env-diff.tmpl")
 }

--- a/cmd/esc/cli/templates/env-diff.tmpl
+++ b/cmd/esc/cli/templates/env-diff.tmpl
@@ -1,0 +1,9 @@
+{{ if .Value }}# Value
+```diff
+{{.Value}}
+```
+{{ end -}}{{ if .Definition }}# Definition
+```diff
+{{.Definition}}
+```
+{{ end -}}

--- a/cmd/esc/cli/testdata/env-diff.yaml
+++ b/cmd/esc/cli/testdata/env-diff.yaml
@@ -1,0 +1,300 @@
+run: |
+  esc env diff test
+  esc env diff test:latest
+  esc env diff test:stable
+  esc env diff test:1
+  esc env diff test:2
+  esc env diff test:3
+  esc env diff test:1 2
+  esc env diff test:stable --format json
+  esc env diff test:stable --format string
+  esc env diff test:stable --format dotenv
+  esc env diff test:stable --format shell
+environments:
+  test-user/a: {}
+  test-user/b: {}
+  test-user/test:
+    revisions:
+      - yaml:
+          values:
+            string: hello, world!
+            environmentVariables:
+              FOO: bar
+        tag: stable
+      - yaml:
+          imports:
+            - a
+            - b
+          values:
+            # comment
+            "null": null
+            boolean: true
+            number: 42
+            string: esc
+            array: [hello, world]
+            object: {hello: world}
+            open:
+              fn::open::test: echo
+            secret:
+              fn::secret:
+                ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+            environmentVariables:
+              FOO: baz
+              BAR: qux
+stdout: |
+  > esc env diff test
+  > esc env diff test:latest
+  > esc env diff test:stable
+  # Value
+  ```diff
+  --- test:stable
+  +++ test:latest
+  @@ -1,6 +1,19 @@
+   {
+  +  "array": [
+  +    "hello",
+  +    "world"
+  +  ],
+  +  "boolean": true,
+     "environmentVariables": {
+  -    "FOO": "bar"
+  +    "BAR": "qux",
+  +    "FOO": "baz"
+     },
+  -  "string": "hello, world!"
+  +  "null": null,
+  +  "number": 42,
+  +  "object": {
+  +    "hello": "world"
+  +  },
+  +  "open": "[unknown]",
+  +  "secret": "[secret]",
+  +  "string": "esc"
+   }
+  \ No newline at end of file
+
+  ```
+  # Definition
+  ```diff
+  --- test:stable
+  +++ test:latest
+  @@ -1,4 +1,19 @@
+  +imports:
+  +  - a
+  +  - b
+   values:
+  -  string: hello, world!
+  +  # comment
+  +  "null": null
+  +  boolean: true
+  +  number: 42
+  +  string: esc
+  +  array: [hello, world]
+  +  object: {hello: world}
+  +  open:
+  +    fn::open::test: echo
+  +  secret:
+  +    fn::secret:
+  +      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+     environmentVariables:
+  -    FOO: bar
+  +    FOO: baz
+  +    BAR: qux
+
+  ```
+  > esc env diff test:1
+  # Value
+  ```diff
+  --- test:1
+  +++ test:latest
+  @@ -1 +1,19 @@
+  +{
+  +  "array": [
+  +    "hello",
+  +    "world"
+  +  ],
+  +  "boolean": true,
+  +  "environmentVariables": {
+  +    "BAR": "qux",
+  +    "FOO": "baz"
+  +  },
+  +  "null": null,
+  +  "number": 42,
+  +  "object": {
+  +    "hello": "world"
+  +  },
+  +  "open": "[unknown]",
+  +  "secret": "[secret]",
+  +  "string": "esc"
+  +}
+  \ No newline at end of file
+
+  ```
+  # Definition
+  ```diff
+  --- test:1
+  +++ test:latest
+  @@ -1 +1,19 @@
+  +imports:
+  +  - a
+  +  - b
+  +values:
+  +  # comment
+  +  "null": null
+  +  boolean: true
+  +  number: 42
+  +  string: esc
+  +  array: [hello, world]
+  +  object: {hello: world}
+  +  open:
+  +    fn::open::test: echo
+  +  secret:
+  +    fn::secret:
+  +      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+  +  environmentVariables:
+  +    FOO: baz
+  +    BAR: qux
+
+  ```
+  > esc env diff test:2
+  # Value
+  ```diff
+  --- test:2
+  +++ test:latest
+  @@ -1,6 +1,19 @@
+   {
+  +  "array": [
+  +    "hello",
+  +    "world"
+  +  ],
+  +  "boolean": true,
+     "environmentVariables": {
+  -    "FOO": "bar"
+  +    "BAR": "qux",
+  +    "FOO": "baz"
+     },
+  -  "string": "hello, world!"
+  +  "null": null,
+  +  "number": 42,
+  +  "object": {
+  +    "hello": "world"
+  +  },
+  +  "open": "[unknown]",
+  +  "secret": "[secret]",
+  +  "string": "esc"
+   }
+  \ No newline at end of file
+
+  ```
+  # Definition
+  ```diff
+  --- test:2
+  +++ test:latest
+  @@ -1,4 +1,19 @@
+  +imports:
+  +  - a
+  +  - b
+   values:
+  -  string: hello, world!
+  +  # comment
+  +  "null": null
+  +  boolean: true
+  +  number: 42
+  +  string: esc
+  +  array: [hello, world]
+  +  object: {hello: world}
+  +  open:
+  +    fn::open::test: echo
+  +  secret:
+  +    fn::secret:
+  +      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+     environmentVariables:
+  -    FOO: bar
+  +    FOO: baz
+  +    BAR: qux
+
+  ```
+  > esc env diff test:3
+  > esc env diff test:1 2
+  # Value
+  ```diff
+  --- test:1
+  +++ test:2
+  @@ -1 +1,6 @@
+  +{
+  +  "environmentVariables": {
+  +    "FOO": "bar"
+  +  },
+  +  "string": "hello, world!"
+  +}
+  \ No newline at end of file
+
+  ```
+  # Definition
+  ```diff
+  --- test:1
+  +++ test:2
+  @@ -1 +1,4 @@
+  +values:
+  +  string: hello, world!
+  +  environmentVariables:
+  +    FOO: bar
+
+  ```
+  > esc env diff test:stable --format json
+  --- test:stable
+  +++ test:latest
+  @@ -1,6 +1,19 @@
+   {
+  +  "array": [
+  +    "hello",
+  +    "world"
+  +  ],
+  +  "boolean": true,
+     "environmentVariables": {
+  -    "FOO": "bar"
+  +    "BAR": "qux",
+  +    "FOO": "baz"
+     },
+  -  "string": "hello, world!"
+  +  "null": null,
+  +  "number": 42,
+  +  "object": {
+  +    "hello": "world"
+  +  },
+  +  "open": "[unknown]",
+  +  "secret": "[secret]",
+  +  "string": "esc"
+   }
+  > esc env diff test:stable --format string
+  --- test:stable
+  +++ test:latest
+  @@ -1 +1 @@
+  -"environmentVariables"="\"FOO\"=\"bar\"","string"="hello, world!"
+  +"array"="\"hello\",\"world\"","boolean"="true","environmentVariables"="\"BAR\"=\"qux\",\"FOO\"=\"baz\"","null"="","number"="42","object"="\"hello\"=\"world\"","open"="[unknown]","secret"="[secret]","string"="esc"
+  > esc env diff test:stable --format dotenv
+  --- test:stable
+  +++ test:latest
+  @@ -1 +1,2 @@
+  -FOO="bar"
+  +BAR="qux"
+  +FOO="baz"
+  > esc env diff test:stable --format shell
+  --- test:stable
+  +++ test:latest
+  @@ -1 +1,2 @@
+  -export FOO="bar"
+  +export BAR="qux"
+  +export FOO="baz"
+stderr: |
+  > esc env diff test
+  > esc env diff test:latest
+  > esc env diff test:stable
+  > esc env diff test:1
+  > esc env diff test:2
+  > esc env diff test:3
+  > esc env diff test:1 2
+  > esc env diff test:stable --format json
+  > esc env diff test:stable --format string
+  > esc env diff test:stable --format dotenv
+  > esc env diff test:stable --format shell

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
+	github.com/alecthomas/chroma/v2 v2.13.0
 	github.com/ccojocar/zxcvbn-go v1.0.1
 	github.com/charmbracelet/bubbles v0.16.1
 	github.com/charmbracelet/bubbletea v0.25.0
@@ -14,6 +15,7 @@ require (
 	github.com/google/go-querystring v1.1.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/hcl/v2 v2.17.0
+	github.com/hexops/gotextdiff v1.0.3
 	github.com/muesli/termenv v0.15.2
 	github.com/petar-dambovaliev/aho-corasick v0.0.0-20230725210150-fb29fc3c913e
 	github.com/pgavlin/fx v0.1.6
@@ -100,7 +102,7 @@ require (
 	github.com/deckarep/golang-set/v2 v2.5.0 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/djherbis/times v1.5.0 // indirect
-	github.com/dlclark/regexp2 v1.4.0 // indirect
+	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
@@ -143,7 +145,6 @@ require (
 	github.com/hashicorp/vault/api v1.8.2 // indirect
 	github.com/hashicorp/vault/sdk v0.6.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
-	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,12 @@ github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSi
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/alecthomas/assert/v2 v2.6.0 h1:o3WJwILtexrEUk3cUVal3oiQY2tfgr/FHWiz/v2n4FU=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
+github.com/alecthomas/chroma/v2 v2.13.0 h1:VP72+99Fb2zEcYM0MeaWJmV+xQvz5v5cxRHd+ooU1lI=
+github.com/alecthomas/chroma/v2 v2.13.0/go.mod h1:BUGjjsD+ndS6eX37YgTchSEG+Jg9Jv1GiZs9sqPqztk=
+github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -556,8 +560,9 @@ github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
 github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
-github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=


### PR DESCRIPTION
These changes add a command, `esc env diff`, for displaying the differences between environment revisions. By default, the output includes both value and definition diffs. Diffs between the value as rendered in different formats (e.g. `shell`, `json`, etc.) can also be displayed.