### PR TITLE
cli: env version show + replace ':' with '@'

### DIFF
--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -64,7 +64,7 @@ func newEnvCmd(esc *escCommand) *cobra.Command {
 	return cmd
 }
 
-func (cmd *envCommand) getEnvName(args []string) (org, env, revisionOrTag string, rest []string, err error) {
+func (cmd *envCommand) getEnvName(args []string) (org, env, version string, rest []string, err error) {
 	if cmd.envNameFlag == "" {
 		if len(args) == 0 {
 			return "", "", "", nil, fmt.Errorf("no environment name specified")
@@ -72,14 +72,17 @@ func (cmd *envCommand) getEnvName(args []string) (org, env, revisionOrTag string
 		cmd.envNameFlag, args = args[0], args[1:]
 	}
 
-	orgName, envName, hasOrgName := strings.Cut(cmd.envNameFlag, "/")
+	orgName, envNameAndVersion, hasOrgName := strings.Cut(cmd.envNameFlag, "/")
 	if !hasOrgName {
-		orgName, envName = cmd.esc.account.DefaultOrg, orgName
+		orgName, envNameAndVersion = cmd.esc.account.DefaultOrg, orgName
 	}
 
-	envName, revisionOrTag, _ = strings.Cut(envName, ":")
+	envName, version, hasSep := strings.Cut(envNameAndVersion, "@")
+	if !hasSep {
+		envName, version, _ = strings.Cut(envNameAndVersion, ":")
+	}
 
-	return orgName, envName, revisionOrTag, args, nil
+	return orgName, envName, version, args, nil
 }
 
 func sortEnvironmentDiagnostics(diags []client.EnvironmentDiagnostic) {

--- a/cmd/esc/cli/env_edit.go
+++ b/cmd/esc/cli/env_edit.go
@@ -57,11 +57,11 @@ func newEnvEditCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, revisionOrTag, args, err := edit.env.getEnvName(args)
+			orgName, envName, version, args, err := edit.env.getEnvName(args)
 			if err != nil {
 				return err
 			}
-			if revisionOrTag != "" {
+			if version != "" {
 				return fmt.Errorf("the edit command does not accept revisions or tags")
 			}
 			_ = args

--- a/cmd/esc/cli/env_get.go
+++ b/cmd/esc/cli/env_get.go
@@ -36,7 +36,7 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 	get := &envGetCommand{env: env}
 
 	cmd := &cobra.Command{
-		Use:   "get [<org-name>/]<environment-name>[:<revision-or-tag>] <path>",
+		Use:   "get [<org-name>/]<environment-name>[@<version>] <path>",
 		Args:  cobra.RangeArgs(1, 2),
 		Short: "Get a value within an environment.",
 		Long: "Get a value within an environment\n" +
@@ -52,7 +52,7 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, revisionOrTag, args, err := env.getEnvName(args)
+			orgName, envName, version, args, err := env.getEnvName(args)
 			if err != nil {
 				return err
 			}
@@ -69,22 +69,22 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 			case "":
 				// OK
 			case "detailed", "json", "string":
-				return get.showValue(ctx, orgName, envName, revisionOrTag, path, value, showSecrets)
+				return get.showValue(ctx, orgName, envName, version, path, value, showSecrets)
 			case "dotenv":
 				if len(path) != 0 {
 					return fmt.Errorf("output format '%s' may not be used with a property path", value)
 				}
-				return get.showValue(ctx, orgName, envName, revisionOrTag, path, value, showSecrets)
+				return get.showValue(ctx, orgName, envName, version, path, value, showSecrets)
 			case "shell":
 				if len(path) != 0 {
 					return fmt.Errorf("output format '%s' may not be used with a property path", value)
 				}
-				return get.showValue(ctx, orgName, envName, revisionOrTag, path, value, showSecrets)
+				return get.showValue(ctx, orgName, envName, version, path, value, showSecrets)
 			default:
 				return fmt.Errorf("unknown output format %q", value)
 			}
 
-			data, err := get.getEnvironment(ctx, orgName, envName, revisionOrTag, path, showSecrets)
+			data, err := get.getEnvironment(ctx, orgName, envName, version, path, showSecrets)
 			if err != nil {
 				return err
 			}
@@ -140,12 +140,12 @@ func (get *envGetCommand) writeValue(
 	out io.Writer,
 	orgName string,
 	envName string,
-	revisionOrTag string,
+	version string,
 	path resource.PropertyPath,
 	format string,
 	showSecrets bool,
 ) error {
-	def, _, err := get.env.esc.client.GetEnvironment(ctx, orgName, envName, revisionOrTag, showSecrets)
+	def, _, err := get.env.esc.client.GetEnvironment(ctx, orgName, envName, version, showSecrets)
 	if err != nil {
 		return fmt.Errorf("getting environment definition: %w", err)
 	}

--- a/cmd/esc/cli/env_init.go
+++ b/cmd/esc/cli/env_init.go
@@ -34,11 +34,11 @@ func newEnvInitCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, revisionOrTag, args, err := env.getEnvName(args)
+			orgName, envName, version, args, err := env.getEnvName(args)
 			if err != nil {
 				return err
 			}
-			if revisionOrTag != "" {
+			if version != "" {
 				return fmt.Errorf("the init command does not accept revisions or tags")
 			}
 			_ = args

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -21,7 +21,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 	var format string
 
 	cmd := &cobra.Command{
-		Use:   "open [<org-name>/]<environment-name>[:<revision-or-tag>] [property path]",
+		Use:   "open [<org-name>/]<environment-name>[@<version>] [property path]",
 		Args:  cobra.MaximumNArgs(2),
 		Short: "Open the environment with the given name.",
 		Long: "Open the environment with the given name and return the result\n" +
@@ -36,7 +36,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, revisionOrTag, args, err := envcmd.getEnvName(args)
+			orgName, envName, version, args, err := envcmd.getEnvName(args)
 			if err != nil {
 				return err
 			}
@@ -62,7 +62,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 				return fmt.Errorf("unknown output format %q", format)
 			}
 
-			env, diags, err := envcmd.openEnvironment(ctx, orgName, envName, revisionOrTag, duration)
+			env, diags, err := envcmd.openEnvironment(ctx, orgName, envName, version, duration)
 			if err != nil {
 				return err
 			}
@@ -163,10 +163,10 @@ func (env *envCommand) openEnvironment(
 	ctx context.Context,
 	orgName string,
 	envName string,
-	revisionOrTag string,
+	version string,
 	duration time.Duration,
 ) (*esc.Environment, []client.EnvironmentDiagnostic, error) {
-	envID, diags, err := env.esc.client.OpenEnvironment(ctx, orgName, envName, revisionOrTag, duration)
+	envID, diags, err := env.esc.client.OpenEnvironment(ctx, orgName, envName, version, duration)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/esc/cli/env_rm.go
+++ b/cmd/esc/cli/env_rm.go
@@ -38,11 +38,11 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, revisionOrTag, args, err := env.getEnvName(args)
+			orgName, envName, version, args, err := env.getEnvName(args)
 			if err != nil {
 				return err
 			}
-			if revisionOrTag != "" {
+			if version != "" {
 				return fmt.Errorf("the rm command does not accept revisions or tags")
 			}
 

--- a/cmd/esc/cli/env_run.go
+++ b/cmd/esc/cli/env_run.go
@@ -130,7 +130,7 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, revisionOrTag, args, err := envcmd.getEnvName(args)
+			orgName, envName, version, args, err := envcmd.getEnvName(args)
 			if err != nil {
 				return err
 			}
@@ -144,7 +144,7 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 			}
 			args = args[1:]
 
-			env, diags, err := envcmd.openEnvironment(ctx, orgName, envName, revisionOrTag, duration)
+			env, diags, err := envcmd.openEnvironment(ctx, orgName, envName, version, duration)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -36,11 +36,11 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, revisionOrTag, args, err := env.getEnvName(args)
+			orgName, envName, version, args, err := env.getEnvName(args)
 			if err != nil {
 				return err
 			}
-			if revisionOrTag != "" {
+			if version != "" {
 				return fmt.Errorf("the set command does not accept revisions or tags")
 			}
 			if len(args) < 2 {

--- a/cmd/esc/cli/env_version.go
+++ b/cmd/esc/cli/env_version.go
@@ -20,6 +20,7 @@ func newEnvVersionCmd(env *envCommand) *cobra.Command {
 		SilenceUsage: true,
 	}
 
+	cmd.AddCommand(newEnvVersionShowCmd(env))
 	cmd.AddCommand(newEnvVersionTagCmd(env))
 	cmd.AddCommand(newEnvVersionRmCmd(env))
 	cmd.AddCommand(newEnvVersionLsCmd(env))

--- a/cmd/esc/cli/env_version_ls.go
+++ b/cmd/esc/cli/env_version_ls.go
@@ -32,11 +32,11 @@ func newEnvVersionLsCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, revisionOrTag, args, err := env.getEnvName(args)
+			orgName, envName, version, args, err := env.getEnvName(args)
 			if err != nil {
 				return err
 			}
-			if revisionOrTag != "" {
+			if version != "" {
 				return fmt.Errorf("the ls command does not accept revisions or tags")
 			}
 			_ = args

--- a/cmd/esc/cli/env_version_rm.go
+++ b/cmd/esc/cli/env_version_rm.go
@@ -12,13 +12,12 @@ import (
 
 func newEnvVersionRmCmd(env *envCommand) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rm [<org-name>/]<environment-name>:<tag>",
+		Use:   "rm [<org-name>/]<environment-name>@<tag>",
 		Args:  cobra.ExactArgs(1),
-		Short: "Remove a version tag.",
-		Long: "Remove a version tag\n" +
+		Short: "Remove a tagged version.",
+		Long: "Remove a tagged version\n" +
 			"\n" +
-			"This command removes the version tag with the given name to refer to the\n" +
-			"indicated revision.\n",
+			"This command removes the tagged version with the given name",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -27,23 +26,23 @@ func newEnvVersionRmCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, revisionOrTag, args, err := env.getEnvName(args)
+			orgName, envName, version, args, err := env.getEnvName(args)
 			if err != nil {
 				return err
 			}
-			if revisionOrTag == "" || isRevisionNumber(revisionOrTag) {
-				return errors.New("please specify a tag name to remove")
+			if version == "" || isRevisionNumber(version) {
+				return errors.New("please specify a tagged version to remove")
 			}
 			_ = args
 
-			return env.esc.client.DeleteEnvironmentRevisionTag(ctx, orgName, envName, revisionOrTag)
+			return env.esc.client.DeleteEnvironmentRevisionTag(ctx, orgName, envName, version)
 		},
 	}
 
 	return cmd
 }
 
-func isRevisionNumber(revisionOrTag string) bool {
-	_, err := strconv.ParseInt(revisionOrTag, 10, 0)
+func isRevisionNumber(version string) bool {
+	_, err := strconv.ParseInt(version, 10, 0)
 	return err == nil
 }

--- a/cmd/esc/cli/env_version_show.go
+++ b/cmd/esc/cli/env_version_show.go
@@ -40,6 +40,7 @@ func newEnvVersionShowCmd(env *envCommand) *cobra.Command {
 			if version == "" {
 				version = "latest"
 			}
+			_ = args
 
 			st := style.NewStylist(style.Profile(env.esc.stdout))
 			if isRevisionNumber(version) {

--- a/cmd/esc/cli/env_version_show.go
+++ b/cmd/esc/cli/env_version_show.go
@@ -1,0 +1,121 @@
+// Copyright 2023, Pulumi Corporation.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/pulumi/esc/cmd/esc/cli/client"
+	"github.com/pulumi/esc/cmd/esc/cli/style"
+	"github.com/spf13/cobra"
+)
+
+func newEnvVersionShowCmd(env *envCommand) *cobra.Command {
+	var utc bool
+
+	cmd := &cobra.Command{
+		Use:   "show [<org-name>/]<environment-name>[@<version>]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Describe a version tag or revision.",
+		Long: "Describe a version tag or revision\n" +
+			"\n" +
+			"This command describes the referenced. If no version is present,\n" +
+			"the 'latest' version is shown.",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			if err := env.esc.getCachedClient(ctx); err != nil {
+				return err
+			}
+
+			orgName, envName, version, args, err := env.getEnvName(args)
+			if err != nil {
+				return err
+			}
+			if version == "" {
+				version = "latest"
+			}
+
+			st := style.NewStylist(style.Profile(env.esc.stdout))
+			if isRevisionNumber(version) {
+				revisionNumber, err := strconv.ParseInt(version, 10, 0)
+				if err != nil {
+					return err
+				}
+				rev, err := env.esc.client.GetEnvironmentRevision(ctx, orgName, envName, int(revisionNumber))
+				if err != nil {
+					return err
+				}
+				printRevision(env.esc.stdout, st, *rev, utc)
+			} else {
+				tag, err := env.esc.client.GetEnvironmentRevisionTag(ctx, orgName, envName, version)
+				if err != nil {
+					return err
+				}
+				printRevisionTag(env.esc.stdout, st, *tag, utc)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&utc, "utc", false, "display times in UTC")
+
+	return cmd
+}
+
+func printRevision(stdout io.Writer, st *style.Stylist, r client.EnvironmentRevision, utc bool) {
+	rules := style.Default()
+
+	st.Fprintf(stdout, rules.H1.StylePrimitive, "revision %v", r.Number)
+	switch len(r.Tags) {
+	case 0:
+		// OK
+	case 1:
+		st.Fprintf(stdout, rules.LinkText, " (tag: %v)", r.Tags[0])
+	default:
+		st.Fprintf(stdout, rules.LinkText, " (tags: %v)", strings.Join(r.Tags, ", "))
+	}
+	fmt.Fprintln(stdout, "")
+
+	if r.CreatorLogin == "" {
+		fmt.Fprintf(stdout, "Author: <unknown>\n")
+	} else {
+		fmt.Fprintf(stdout, "Author: %v <%v>\n", r.CreatorName, r.CreatorLogin)
+	}
+
+	stamp := r.Created
+	if utc {
+		stamp = stamp.UTC()
+	} else {
+		stamp = stamp.Local()
+	}
+
+	fmt.Fprintf(stdout, "Date:   %v\n", stamp)
+}
+
+func printRevisionTag(stdout io.Writer, st *style.Stylist, tag client.EnvironmentRevisionTag, utc bool) {
+	rules := style.Default()
+
+	st.Fprintf(stdout, rules.LinkText, "%v\n", tag.Name)
+	fmt.Fprintf(stdout, "Revision %v\n", tag.Revision)
+
+	stamp := tag.Modified
+	if utc {
+		stamp = stamp.UTC()
+	} else {
+		stamp = stamp.Local()
+	}
+
+	fmt.Fprintf(stdout, "Last updated at %v by ", stamp)
+	if tag.EditorLogin == "" {
+		fmt.Fprintf(stdout, "<unknown>")
+	} else {
+		fmt.Fprintf(stdout, "%v <%v>", tag.EditorName, tag.EditorLogin)
+	}
+	fmt.Fprintln(stdout)
+}

--- a/cmd/esc/cli/pager/pager.go
+++ b/cmd/esc/cli/pager/pager.go
@@ -15,7 +15,7 @@ func Run(pager string, stdout, stderr io.Writer, f func(context.Context, io.Writ
 	if pager == "" {
 		pager = os.Getenv("PAGER")
 		if pager == "" {
-			pager = "less -R"
+			pager = "less -R -F"
 		}
 	}
 

--- a/cmd/esc/cli/testdata/env-edit-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-edit-revision-or-tag.yaml
@@ -1,6 +1,6 @@
 run: |
-  (esc env edit test:1 --editor my-editor || exit 0)
-  esc env edit test:foo --editor my-editor
+  (esc env edit test@1 --editor my-editor || exit 0)
+  esc env edit test@foo --editor my-editor
 error: exit status 1
 process:
   commands:
@@ -11,10 +11,10 @@ environments:
     values:
       foo: bar
 stdout: |
-  > esc env edit test:1 --editor my-editor
-  > esc env edit test:foo --editor my-editor
+  > esc env edit test@1 --editor my-editor
+  > esc env edit test@foo --editor my-editor
 stderr: |
-  > esc env edit test:1 --editor my-editor
+  > esc env edit test@1 --editor my-editor
   Error: the edit command does not accept revisions or tags
-  > esc env edit test:foo --editor my-editor
+  > esc env edit test@foo --editor my-editor
   Error: the edit command does not accept revisions or tags

--- a/cmd/esc/cli/testdata/env-get-all.yaml
+++ b/cmd/esc/cli/testdata/env-get-all.yaml
@@ -1,10 +1,10 @@
 run: |
   esc env get test
-  esc env get test:latest
-  esc env get test:stable
-  esc env get test:1
-  esc env get test:2
-  esc env get test:3
+  esc env get test@latest
+  esc env get test@stable
+  esc env get test@1
+  esc env get test@2
+  esc env get test@3
 environments:
   test-user/a: {}
   test-user/b: {}
@@ -72,7 +72,7 @@ stdout: |+
 
   ```
 
-  > esc env get test:latest
+  > esc env get test@latest
   # Value
   ```json
   {
@@ -112,7 +112,7 @@ stdout: |+
 
   ```
 
-  > esc env get test:stable
+  > esc env get test@stable
   # Value
   ```json
   {
@@ -126,8 +126,8 @@ stdout: |+
 
   ```
 
-  > esc env get test:1
-  > esc env get test:2
+  > esc env get test@1
+  > esc env get test@2
   # Value
   ```json
   {
@@ -141,7 +141,7 @@ stdout: |+
 
   ```
 
-  > esc env get test:3
+  > esc env get test@3
   # Value
   ```json
   {
@@ -183,8 +183,8 @@ stdout: |+
 
 stderr: |
   > esc env get test
-  > esc env get test:latest
-  > esc env get test:stable
-  > esc env get test:1
-  > esc env get test:2
-  > esc env get test:3
+  > esc env get test@latest
+  > esc env get test@stable
+  > esc env get test@1
+  > esc env get test@2
+  > esc env get test@3

--- a/cmd/esc/cli/testdata/env-init-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-init-revision-or-tag.yaml
@@ -1,12 +1,12 @@
 run: |
-  (esc env init test-env:1 || exit 0)
-  esc env init test-env:foo
+  (esc env init test-env@1 || exit 0)
+  esc env init test-env@foo
 error: exit status 1
 stdout: |
-  > esc env init test-env:1
-  > esc env init test-env:foo
+  > esc env init test-env@1
+  > esc env init test-env@foo
 stderr: |
-  > esc env init test-env:1
+  > esc env init test-env@1
   Error: the init command does not accept revisions or tags
-  > esc env init test-env:foo
+  > esc env init test-env@foo
   Error: the init command does not accept revisions or tags

--- a/cmd/esc/cli/testdata/env-rm-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-rm-revision-or-tag.yaml
@@ -1,12 +1,12 @@
 run: |
-  (esc env rm dup:1 -y || exit 0)
-  esc env rm dup:foo -y
+  (esc env rm dup@1 -y || exit 0)
+  esc env rm dup@foo -y
 error: exit status 1
 stdout: |
-  > esc env rm dup:1 -y
-  > esc env rm dup:foo -y
+  > esc env rm dup@1 -y
+  > esc env rm dup@foo -y
 stderr: |
-  > esc env rm dup:1 -y
+  > esc env rm dup@1 -y
   Error: the rm command does not accept revisions or tags
-  > esc env rm dup:foo -y
+  > esc env rm dup@foo -y
   Error: the rm command does not accept revisions or tags

--- a/cmd/esc/cli/testdata/env-set-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-set-revision-or-tag.yaml
@@ -1,12 +1,12 @@
 run: |
-  (esc env set test:1 string foo || exit 0)
-  esc env set test:foo string foo
+  (esc env set test@1 string foo || exit 0)
+  esc env set test@foo string foo
 error: exit status 1
 stdout: |
-  > esc env set test:1 string foo
-  > esc env set test:foo string foo
+  > esc env set test@1 string foo
+  > esc env set test@foo string foo
 stderr: |
-  > esc env set test:1 string foo
+  > esc env set test@1 string foo
   Error: the set command does not accept revisions or tags
-  > esc env set test:foo string foo
+  > esc env set test@foo string foo
   Error: the set command does not accept revisions or tags

--- a/cmd/esc/cli/testdata/env-version-tag.yaml
+++ b/cmd/esc/cli/testdata/env-version-tag.yaml
@@ -1,13 +1,15 @@
 run: |
-  esc env version tag test:stable 2
-  esc env version tag test:stable --utc
-  esc env version tag test:stable 3
-  esc env version tag test:stable --utc
-  esc env version tag test:latest --utc
+  esc env version tag test@stable 2
+  esc env version show test@stable --utc
+  esc env version tag test@stable 3
+  esc env version show test@stable --utc
+  esc env version tag test@stable
+  esc env version show test@stable --utc
+  esc env version show test@latest --utc
   esc env version ls test --utc
-  esc env version tag test:initial 1
+  esc env version tag test@initial 1
   esc env version ls test --utc
-  esc env version rm test:initial
+  esc env version rm test@initial
   esc env version ls test --utc
 environments:
   test-user/a: {}
@@ -37,17 +39,22 @@ environments:
               fn::secret:
                 ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
 stdout: |+
-  > esc env version tag test:stable 2
-  > esc env version tag test:stable --utc
+  > esc env version tag test@stable 2
+  > esc env version show test@stable --utc
   stable
   Revision 2
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
-  > esc env version tag test:stable 3
-  > esc env version tag test:stable --utc
+  > esc env version tag test@stable 3
+  > esc env version show test@stable --utc
   stable
   Revision 3
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
-  > esc env version tag test:latest --utc
+  > esc env version tag test@stable
+  > esc env version show test@stable --utc
+  stable
+  Revision 4
+  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+  > esc env version show test@latest --utc
   latest
   Revision 4
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
@@ -57,10 +64,10 @@ stdout: |+
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
   stable
-  Revision 3
+  Revision 4
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
-  > esc env version tag test:initial 1
+  > esc env version tag test@initial 1
   > esc env version ls test --utc
   initial
   Revision 1
@@ -71,27 +78,29 @@ stdout: |+
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
   stable
-  Revision 3
+  Revision 4
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
-  > esc env version rm test:initial
+  > esc env version rm test@initial
   > esc env version ls test --utc
   latest
   Revision 4
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
   stable
-  Revision 3
+  Revision 4
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
 stderr: |
-  > esc env version tag test:stable 2
-  > esc env version tag test:stable --utc
-  > esc env version tag test:stable 3
-  > esc env version tag test:stable --utc
-  > esc env version tag test:latest --utc
+  > esc env version tag test@stable 2
+  > esc env version show test@stable --utc
+  > esc env version tag test@stable 3
+  > esc env version show test@stable --utc
+  > esc env version tag test@stable
+  > esc env version show test@stable --utc
+  > esc env version show test@latest --utc
   > esc env version ls test --utc
-  > esc env version tag test:initial 1
+  > esc env version tag test@initial 1
   > esc env version ls test --utc
-  > esc env version rm test:initial
+  > esc env version rm test@initial
   > esc env version ls test --utc

--- a/cmd/esc/cli/testdata/open-json.yaml
+++ b/cmd/esc/cli/testdata/open-json.yaml
@@ -1,10 +1,10 @@
 run: |
   esc open test --format json
-  esc open test:stable
-  esc open test:latest
-  esc open test:1
-  esc open test:2
-  esc open test:3
+  esc open test@stable
+  esc open test@latest
+  esc open test@1
+  esc open test@2
+  esc open test@3
 environments:
   test-user/test:
     revisions:
@@ -27,29 +27,29 @@ stdout: |
     "foo": "bar",
     "hello": "world"
   }
-  > esc open test:stable
+  > esc open test@stable
   {
     "foo": "bar"
   }
-  > esc open test:latest
+  > esc open test@latest
   {
     "foo": "bar",
     "hello": "world"
   }
-  > esc open test:1
-  > esc open test:2
+  > esc open test@1
+  > esc open test@2
   {
     "foo": "bar"
   }
-  > esc open test:3
+  > esc open test@3
   {
     "foo": "bar",
     "hello": "world"
   }
 stderr: |
   > esc open test --format json
-  > esc open test:stable
-  > esc open test:latest
-  > esc open test:1
-  > esc open test:2
-  > esc open test:3
+  > esc open test@stable
+  > esc open test@latest
+  > esc open test@1
+  > esc open test@2
+  > esc open test@3


### PR DESCRIPTION
These changes add an `env version show` command to display a specific version of an environment and replace the `:` name/version separator with `@`.