### PR TITLE
cli: add a rollback command

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,6 +18,9 @@
 - Add support to `esc env edit` for reading the edited environment definition from a file.
   [#308](https://github.com/pulumi/esc/pull/308)
 
+- Add support for rolling back to a specific version of an environment.
+  [#305](https://github.com/pulumi/esc/pull/305)
+
 ### Bug Fixes
 
 - Ensure that redacted output is flushed in `esc run`

--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -55,6 +55,7 @@ func newEnvCmd(esc *escCommand) *cobra.Command {
 	cmd.AddCommand(newEnvDiffCmd(env))
 	cmd.AddCommand(newEnvSetCmd(env))
 	cmd.AddCommand(newEnvVersionCmd(env))
+	cmd.AddCommand(newEnvRollbackCmd(env))
 	cmd.AddCommand(newEnvLsCmd(env))
 	cmd.AddCommand(newEnvRmCmd(env))
 	cmd.AddCommand(newEnvOpenCmd(env))

--- a/cmd/esc/cli/env_rollback.go
+++ b/cmd/esc/cli/env_rollback.go
@@ -1,0 +1,60 @@
+// Copyright 2023, Pulumi Corporation.
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/spf13/cobra"
+)
+
+func newEnvRollbackCmd(env *envCommand) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rollback [<org-name>/]<environment-name>@<version>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Roll back to a specific version",
+		Long: "Roll back to a specific version\n" +
+			"\n" +
+			"This command rolls an environment's definition back to the specified\n" +
+			"version. The environment's definition will be replaced with the\n" +
+			"definition at that version, creating a new revision.\n",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			if err := env.esc.getCachedClient(ctx); err != nil {
+				return err
+			}
+
+			ref, args, err := env.getEnvRef(args)
+			if err != nil {
+				return err
+			}
+			if ref.version == "" {
+				return errors.New("please specify a version")
+			}
+			_ = args
+
+			yaml, _, err := env.esc.client.GetEnvironment(ctx, ref.orgName, ref.envName, ref.version, false)
+			if err != nil {
+				return err
+			}
+			diags, err := env.esc.client.UpdateEnvironment(ctx, ref.orgName, ref.envName, yaml, "")
+			if err != nil {
+				return err
+			}
+			if len(diags) != 0 {
+				err = env.writeYAMLEnvironmentDiagnostics(env.esc.stderr, ref.envName, yaml, diags)
+				contract.IgnoreError(err)
+				return errors.New("could not roll back: too many errors")
+			}
+			fmt.Fprintln(env.esc.stdout, "Environment updated.")
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/esc/cli/testdata/env-rollback.yaml
+++ b/cmd/esc/cli/testdata/env-rollback.yaml
@@ -1,0 +1,63 @@
+run: |
+  esc env rollback test@stable
+  esc env get test
+  esc env rollback test@2
+error: exit status 1
+environments:
+  test-user/a: {}
+  test-user/b: {}
+  test-user/test:
+    revisions:
+      - yaml:
+          imports:
+            - c
+          values: {}
+      - yaml:
+          values:
+            string: hello, world!
+        tag: stable
+      - yaml:
+          imports:
+            - a
+            - b
+          values:
+            # comment
+            "null": null
+            boolean: true
+            number: 42
+            string: esc
+            array: [hello, world]
+            object: {hello: world}
+            open:
+              fn::open::test: echo
+            secret:
+              fn::secret:
+                ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+stdout: |
+  > esc env rollback test@stable
+  Environment updated.
+  > esc env get test
+  # Value
+  ```json
+  {
+    "string": "hello, world!"
+  }
+  ```
+  # Definition
+  ```yaml
+  values:
+    string: hello, world!
+
+  ```
+
+  > esc env rollback test@2
+stderr: |
+  > esc env rollback test@stable
+  > esc env get test
+  > esc env rollback test@2
+  Error: not found
+
+    on test line 2:
+     2:     - c
+
+  Error: could not roll back: too many errors


### PR DESCRIPTION
`esc env rollback` rolls the environment definition back to a specific version.

Note that this can fail if the target of the rollback imports environments that have changed in incompatible ways. Imports should be versioned in order to prevent this.