### PR TITLE
cli: prefer '@version' when env name is implied

### DIFF
--- a/cmd/esc/cli/env_diff.go
+++ b/cmd/esc/cli/env_diff.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/glamour"
 	"github.com/spf13/cobra"
@@ -23,7 +24,7 @@ func newEnvDiffCmd(env *envCommand) *cobra.Command {
 	diff := &envGetCommand{env: env}
 
 	cmd := &cobra.Command{
-		Use:   "diff [<org-name>/]<environment-name>[@<version>] [<version>]",
+		Use:   "diff [<org-name>/]<environment-name>[@<version>] [@<version>]",
 		Args:  cobra.RangeArgs(1, 2),
 		Short: "Show changes between versions.",
 		Long: "Show changes between versions\n" +
@@ -51,7 +52,7 @@ func newEnvDiffCmd(env *envCommand) *cobra.Command {
 
 			compareVersion := "latest"
 			if len(args) != 0 {
-				compareVersion = args[0]
+				compareVersion, _ = strings.CutPrefix(args[0], "@")
 			}
 
 			var path resource.PropertyPath


### PR DESCRIPTION
`env diff` and `env version tag` both accept arguments that imply an environment name. In the case of `env diff`, this is the version to use for comparison; for `env version tag` it is the version to target with the tag. In both cases, document that the syntax for these arguments is `@version` (but continue to accept a bare version).