### PR TITLE
cli: allow comparing different envs

### DIFF
--- a/cmd/esc/cli/env_diff.go
+++ b/cmd/esc/cli/env_diff.go
@@ -33,7 +33,7 @@ func newEnvDiffCmd(env *envCommand) *cobra.Command {
 			"\n" +
 			"The first argument is the base environment for the diff and the second argument\n" +
 			"is the comparison environment. If the environment name portion of the second\n" +
-			"argument, the name of the base environment is used. If the version portion of\n" +
+			"argument is omitted, the name of the base environment is used. If the version portion of\n" +
 			"the second argument is omitted, the 'latest' tag is used.",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/esc/cli/env_init.go
+++ b/cmd/esc/cli/env_init.go
@@ -34,11 +34,11 @@ func newEnvInitCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, version, args, err := env.getEnvName(args)
+			ref, args, err := env.getEnvRef(args)
 			if err != nil {
 				return err
 			}
-			if version != "" {
+			if ref.version != "" {
 				return fmt.Errorf("the init command does not accept versions")
 			}
 			_ = args
@@ -56,17 +56,17 @@ func newEnvInitCmd(env *envCommand) *cobra.Command {
 				return fmt.Errorf("reading environment definition: %w", err)
 			}
 
-			if err := env.esc.client.CreateEnvironment(ctx, orgName, envName); err != nil {
+			if err := env.esc.client.CreateEnvironment(ctx, ref.orgName, ref.envName); err != nil {
 				return fmt.Errorf("creating environment: %w", err)
 			}
 			fmt.Fprintln(env.esc.stdout, "Environment created.")
 			if len(yaml) != 0 {
-				diags, err := env.esc.client.UpdateEnvironment(ctx, orgName, envName, yaml, "")
+				diags, err := env.esc.client.UpdateEnvironment(ctx, ref.orgName, ref.envName, yaml, "")
 				if err != nil {
 					return fmt.Errorf("updating environment definition: %w", err)
 				}
 				if len(diags) != 0 {
-					err = env.writeYAMLEnvironmentDiagnostics(env.esc.stderr, envName, yaml, diags)
+					err = env.writeYAMLEnvironmentDiagnostics(env.esc.stderr, ref.envName, yaml, diags)
 					contract.IgnoreError(err)
 
 					return fmt.Errorf("updating environment definition: too many errors")

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -36,7 +36,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, version, args, err := envcmd.getEnvName(args)
+			ref, args, err := envcmd.getEnvRef(args)
 			if err != nil {
 				return err
 			}
@@ -62,7 +62,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 				return fmt.Errorf("unknown output format %q", format)
 			}
 
-			env, diags, err := envcmd.openEnvironment(ctx, orgName, envName, version, duration)
+			env, diags, err := envcmd.openEnvironment(ctx, ref, duration)
 			if err != nil {
 				return err
 			}
@@ -161,18 +161,16 @@ func (env *envCommand) removeTemporaryFiles(paths []string) {
 
 func (env *envCommand) openEnvironment(
 	ctx context.Context,
-	orgName string,
-	envName string,
-	version string,
+	ref environmentRef,
 	duration time.Duration,
 ) (*esc.Environment, []client.EnvironmentDiagnostic, error) {
-	envID, diags, err := env.esc.client.OpenEnvironment(ctx, orgName, envName, version, duration)
+	envID, diags, err := env.esc.client.OpenEnvironment(ctx, ref.orgName, ref.envName, ref.version, duration)
 	if err != nil {
 		return nil, nil, err
 	}
 	if len(diags) != 0 {
 		return nil, diags, err
 	}
-	open, err := env.esc.client.GetOpenEnvironment(ctx, orgName, envName, envID)
+	open, err := env.esc.client.GetOpenEnvironment(ctx, ref.orgName, ref.envName, envID)
 	return open, nil, err
 }

--- a/cmd/esc/cli/env_rm.go
+++ b/cmd/esc/cli/env_rm.go
@@ -38,17 +38,17 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, version, args, err := env.getEnvName(args)
+			ref, args, err := env.getEnvRef(args)
 			if err != nil {
 				return err
 			}
-			if version != "" {
+			if ref.version != "" {
 				return fmt.Errorf("the rm command does not accept versions")
 			}
 
 			// Are we removing the entire environment?
 			if len(args) == 0 {
-				envSlug := fmt.Sprintf("%v/%v", orgName, envName)
+				envSlug := fmt.Sprintf("%v/%v", ref.orgName, ref.envName)
 
 				// Ensure the user really wants to do this.
 				prompt := fmt.Sprintf("This will permanently remove the %q environment!", envSlug)
@@ -56,7 +56,7 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 					return errors.New("confirmation declined")
 				}
 
-				err = env.esc.client.DeleteEnvironment(ctx, orgName, envName)
+				err = env.esc.client.DeleteEnvironment(ctx, ref.orgName, ref.envName)
 				if err != nil {
 					return err
 				}
@@ -72,7 +72,7 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 				return fmt.Errorf("invalid path: %w", err)
 			}
 
-			def, tag, err := env.esc.client.GetEnvironment(ctx, orgName, envName, "", false)
+			def, tag, err := env.esc.client.GetEnvironment(ctx, ref.orgName, ref.envName, "", false)
 			if err != nil {
 				return fmt.Errorf("getting environment definition: %w", err)
 			}
@@ -98,7 +98,7 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 				return fmt.Errorf("marshaling definition: %w", err)
 			}
 
-			diags, err := env.esc.client.UpdateEnvironment(ctx, orgName, envName, newYAML, tag)
+			diags, err := env.esc.client.UpdateEnvironment(ctx, ref.orgName, ref.envName, newYAML, tag)
 			if err != nil {
 				return fmt.Errorf("updating environment definition: %w", err)
 			}

--- a/cmd/esc/cli/env_run.go
+++ b/cmd/esc/cli/env_run.go
@@ -130,7 +130,7 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, version, args, err := envcmd.getEnvName(args)
+			ref, args, err := envcmd.getEnvRef(args)
 			if err != nil {
 				return err
 			}
@@ -144,7 +144,7 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 			}
 			args = args[1:]
 
-			env, diags, err := envcmd.openEnvironment(ctx, orgName, envName, version, duration)
+			env, diags, err := envcmd.openEnvironment(ctx, ref, duration)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -36,11 +36,11 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, version, args, err := env.getEnvName(args)
+			ref, args, err := env.getEnvRef(args)
 			if err != nil {
 				return err
 			}
-			if version != "" {
+			if ref.version != "" {
 				return fmt.Errorf("the set command does not accept versions")
 			}
 			if len(args) < 2 {
@@ -81,7 +81,7 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 				yamlValue = *yamlValue.Content[0]
 			}
 
-			def, tag, err := env.esc.client.GetEnvironment(ctx, orgName, envName, "", false)
+			def, tag, err := env.esc.client.GetEnvironment(ctx, ref.orgName, ref.envName, "", false)
 			if err != nil {
 				return fmt.Errorf("getting environment definition: %w", err)
 			}
@@ -120,7 +120,7 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 				return fmt.Errorf("marshaling definition: %w", err)
 			}
 
-			diags, err := env.esc.client.UpdateEnvironment(ctx, orgName, envName, newYAML, tag)
+			diags, err := env.esc.client.UpdateEnvironment(ctx, ref.orgName, ref.envName, newYAML, tag)
 			if err != nil {
 				return fmt.Errorf("updating environment definition: %w", err)
 			}

--- a/cmd/esc/cli/env_version.go
+++ b/cmd/esc/cli/env_version.go
@@ -36,28 +36,28 @@ func newEnvVersionCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, version, args, err := env.getEnvName(args)
+			ref, args, err := env.getEnvRef(args)
 			if err != nil {
 				return err
 			}
-			if version == "" {
+			if ref.version == "" {
 				return errors.New("please specify a version")
 			}
 			_ = args
 
 			st := style.NewStylist(style.Profile(env.esc.stdout))
-			if isRevisionNumber(version) {
-				revisionNumber, err := strconv.ParseInt(version, 10, 0)
+			if isRevisionNumber(ref.version) {
+				revisionNumber, err := strconv.ParseInt(ref.version, 10, 0)
 				if err != nil {
 					return err
 				}
-				rev, err := env.esc.client.GetEnvironmentRevision(ctx, orgName, envName, int(revisionNumber))
+				rev, err := env.esc.client.GetEnvironmentRevision(ctx, ref.orgName, ref.envName, int(revisionNumber))
 				if err != nil {
 					return err
 				}
 				printRevision(env.esc.stdout, st, *rev, utc)
 			} else {
-				tag, err := env.esc.client.GetEnvironmentRevisionTag(ctx, orgName, envName, version)
+				tag, err := env.esc.client.GetEnvironmentRevisionTag(ctx, ref.orgName, ref.envName, ref.version)
 				if err != nil {
 					return err
 				}

--- a/cmd/esc/cli/env_version_history.go
+++ b/cmd/esc/cli/env_version_history.go
@@ -33,15 +33,15 @@ func newEnvVersionHistoryCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, version, args, err := env.getEnvName(args)
+			ref, args, err := env.getEnvRef(args)
 			if err != nil {
 				return err
 			}
 			_ = args
 
 			before := 0
-			if version != "" {
-				rev, err := env.esc.client.GetRevisionNumber(ctx, orgName, envName, version)
+			if ref.version != "" {
+				rev, err := env.esc.client.GetRevisionNumber(ctx, ref.orgName, ref.envName, ref.version)
 				if err != nil {
 					return err
 				}
@@ -57,7 +57,7 @@ func newEnvVersionHistoryCmd(env *envCommand) *cobra.Command {
 						Before: &before,
 						Count:  &count,
 					}
-					revisions, err := env.esc.client.ListEnvironmentRevisions(ctx, orgName, envName, options)
+					revisions, err := env.esc.client.ListEnvironmentRevisions(ctx, ref.orgName, ref.envName, options)
 					if err != nil {
 						return err
 					}

--- a/cmd/esc/cli/env_version_tag.go
+++ b/cmd/esc/cli/env_version_tag.go
@@ -34,37 +34,37 @@ func newEnvVersionTagCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, tagName, args, err := env.getEnvName(args)
+			ref, args, err := env.getEnvRef(args)
 			if err != nil {
 				return err
 			}
-			if tagName == "" || isRevisionNumber(tagName) {
+			if ref.version == "" || isRevisionNumber(ref.version) {
 				return errors.New("please specify a name for the tagged version")
 			}
 
 			var revision int
 			if len(args) == 0 {
-				latest, err := env.esc.client.GetEnvironmentRevisionTag(ctx, orgName, envName, "latest")
+				latest, err := env.esc.client.GetEnvironmentRevisionTag(ctx, ref.orgName, ref.envName, "latest")
 				if err != nil {
 					return err
 				}
 				revision = latest.Revision
 			} else {
 				version, _ := strings.CutPrefix(args[0], "@")
-				revision, err = env.esc.client.GetRevisionNumber(ctx, orgName, envName, version)
+				revision, err = env.esc.client.GetRevisionNumber(ctx, ref.orgName, ref.envName, version)
 				if err != nil {
 					return err
 				}
 			}
 
-			err = env.esc.client.UpdateEnvironmentRevisionTag(ctx, orgName, envName, tagName, &revision)
+			err = env.esc.client.UpdateEnvironmentRevisionTag(ctx, ref.orgName, ref.envName, ref.version, &revision)
 			if err == nil {
 				return err
 			}
 			if !client.IsNotFound(err) {
 				return err
 			}
-			return env.esc.client.CreateEnvironmentRevisionTag(ctx, orgName, envName, tagName, &revision)
+			return env.esc.client.CreateEnvironmentRevisionTag(ctx, ref.orgName, ref.envName, ref.version, &revision)
 		},
 	}
 

--- a/cmd/esc/cli/env_version_tag_ls.go
+++ b/cmd/esc/cli/env_version_tag_ls.go
@@ -32,11 +32,11 @@ func newEnvVersionTagLsCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, version, args, err := env.getEnvName(args)
+			ref, args, err := env.getEnvRef(args)
 			if err != nil {
 				return err
 			}
-			if version != "" {
+			if ref.version != "" {
 				return fmt.Errorf("the ls command does not accept versions")
 			}
 			_ = args
@@ -51,7 +51,7 @@ func newEnvVersionTagLsCmd(env *envCommand) *cobra.Command {
 						After: after,
 						Count: &count,
 					}
-					tags, err := env.esc.client.ListEnvironmentRevisionTags(ctx, orgName, envName, options)
+					tags, err := env.esc.client.ListEnvironmentRevisionTags(ctx, ref.orgName, ref.envName, options)
 					if err != nil {
 						return err
 					}

--- a/cmd/esc/cli/env_version_tag_rm.go
+++ b/cmd/esc/cli/env_version_tag_rm.go
@@ -5,7 +5,6 @@ package cli
 import (
 	"context"
 	"errors"
-	"strconv"
 
 	"github.com/spf13/cobra"
 )
@@ -26,16 +25,16 @@ func newEnvVersionTagRmCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			orgName, envName, version, args, err := env.getEnvName(args)
+			ref, args, err := env.getEnvRef(args)
 			if err != nil {
 				return err
 			}
-			if version == "" || isRevisionNumber(version) {
+			if ref.version == "" || isRevisionNumber(ref.version) {
 				return errors.New("please specify a tagged version to remove")
 			}
 			_ = args
 
-			return env.esc.client.DeleteEnvironmentRevisionTag(ctx, orgName, envName, version)
+			return env.esc.client.DeleteEnvironmentRevisionTag(ctx, ref.orgName, ref.envName, ref.version)
 		},
 	}
 
@@ -43,6 +42,5 @@ func newEnvVersionTagRmCmd(env *envCommand) *cobra.Command {
 }
 
 func isRevisionNumber(version string) bool {
-	_, err := strconv.ParseInt(version, 10, 0)
-	return err == nil
+	return len(version) > 0 && version[0] >= '0' && version[0] <= '9'
 }

--- a/cmd/esc/cli/testdata/env-diff.yaml
+++ b/cmd/esc/cli/testdata/env-diff.yaml
@@ -5,7 +5,10 @@ run: |
   esc env diff test@1
   esc env diff test@2
   esc env diff test@3
-  esc env diff test@1 2
+  esc env diff test@1 @2
+  esc env diff test@1 @stable
+  esc env diff test@stable test-v2@stable
+  esc env diff test test-v2
   esc env diff test@stable --format json
   esc env diff test@stable --format string
   esc env diff test@stable --format dotenv
@@ -41,14 +44,32 @@ environments:
             environmentVariables:
               FOO: baz
               BAR: qux
+  test-user/test-v2:
+    revisions:
+      - yaml:
+          values:
+            string: bonjour, monde!
+            environmentVariables:
+              FOO: bar
+        tag: stable
+      - yaml:
+          imports:
+            - a
+            - b
+          values:
+            # comment
+            string: cse
+            environmentVariables:
+              FOO: bar
+              BAR: qux
 stdout: |
   > esc env diff test
   > esc env diff test@latest
   > esc env diff test@stable
   # Value
   ```diff
-  --- test:stable
-  +++ test:latest
+  --- test-user/test@stable
+  +++ test-user/test@latest
   @@ -1,6 +1,19 @@
    {
   +  "array": [
@@ -76,8 +97,8 @@ stdout: |
   ```
   # Definition
   ```diff
-  --- test:stable
-  +++ test:latest
+  --- test-user/test@stable
+  +++ test-user/test@latest
   @@ -1,4 +1,19 @@
   +imports:
   +  - a
@@ -105,8 +126,8 @@ stdout: |
   > esc env diff test@1
   # Value
   ```diff
-  --- test:1
-  +++ test:latest
+  --- test-user/test@1
+  +++ test-user/test@latest
   @@ -1 +1,19 @@
   +{
   +  "array": [
@@ -132,8 +153,8 @@ stdout: |
   ```
   # Definition
   ```diff
-  --- test:1
-  +++ test:latest
+  --- test-user/test@1
+  +++ test-user/test@latest
   @@ -1 +1,19 @@
   +imports:
   +  - a
@@ -159,8 +180,8 @@ stdout: |
   > esc env diff test@2
   # Value
   ```diff
-  --- test:2
-  +++ test:latest
+  --- test-user/test@2
+  +++ test-user/test@latest
   @@ -1,6 +1,19 @@
    {
   +  "array": [
@@ -188,8 +209,8 @@ stdout: |
   ```
   # Definition
   ```diff
-  --- test:2
-  +++ test:latest
+  --- test-user/test@2
+  +++ test-user/test@latest
   @@ -1,4 +1,19 @@
   +imports:
   +  - a
@@ -215,11 +236,11 @@ stdout: |
 
   ```
   > esc env diff test@3
-  > esc env diff test@1 2
+  > esc env diff test@1 @2
   # Value
   ```diff
-  --- test:1
-  +++ test:2
+  --- test-user/test@1
+  +++ test-user/test@2
   @@ -1 +1,6 @@
   +{
   +  "environmentVariables": {
@@ -232,8 +253,8 @@ stdout: |
   ```
   # Definition
   ```diff
-  --- test:1
-  +++ test:2
+  --- test-user/test@1
+  +++ test-user/test@2
   @@ -1 +1,4 @@
   +values:
   +  string: hello, world!
@@ -241,9 +262,118 @@ stdout: |
   +    FOO: bar
 
   ```
+  > esc env diff test@1 @stable
+  # Value
+  ```diff
+  --- test-user/test@1
+  +++ test-user/test@stable
+  @@ -1 +1,6 @@
+  +{
+  +  "environmentVariables": {
+  +    "FOO": "bar"
+  +  },
+  +  "string": "hello, world!"
+  +}
+  \ No newline at end of file
+
+  ```
+  # Definition
+  ```diff
+  --- test-user/test@1
+  +++ test-user/test@stable
+  @@ -1 +1,4 @@
+  +values:
+  +  string: hello, world!
+  +  environmentVariables:
+  +    FOO: bar
+
+  ```
+  > esc env diff test@stable test-v2@stable
+  # Value
+  ```diff
+  --- test-user/test@stable
+  +++ test-user/test-v2@stable
+  @@ -2,5 +2,5 @@
+     "environmentVariables": {
+       "FOO": "bar"
+     },
+  -  "string": "hello, world!"
+  +  "string": "bonjour, monde!"
+   }
+  \ No newline at end of file
+
+  ```
+  # Definition
+  ```diff
+  --- test-user/test@stable
+  +++ test-user/test-v2@stable
+  @@ -1,4 +1,4 @@
+   values:
+  -  string: hello, world!
+  +  string: bonjour, monde!
+     environmentVariables:
+       FOO: bar
+
+  ```
+  > esc env diff test test-v2
+  # Value
+  ```diff
+  --- test-user/test@latest
+  +++ test-user/test-v2
+  @@ -1,19 +1,7 @@
+   {
+  -  "array": [
+  -    "hello",
+  -    "world"
+  -  ],
+  -  "boolean": true,
+     "environmentVariables": {
+       "BAR": "qux",
+  -    "FOO": "baz"
+  +    "FOO": "bar"
+     },
+  -  "null": null,
+  -  "number": 42,
+  -  "object": {
+  -    "hello": "world"
+  -  },
+  -  "open": "[unknown]",
+  -  "secret": "[secret]",
+  -  "string": "esc"
+  +  "string": "cse"
+   }
+  \ No newline at end of file
+
+  ```
+  # Definition
+  ```diff
+  --- test-user/test@latest
+  +++ test-user/test-v2
+  @@ -3,17 +3,7 @@
+     - b
+   values:
+     # comment
+  -  "null": null
+  -  boolean: true
+  -  number: 42
+  -  string: esc
+  -  array: [hello, world]
+  -  object: {hello: world}
+  -  open:
+  -    fn::open::test: echo
+  -  secret:
+  -    fn::secret:
+  -      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+  +  string: cse
+     environmentVariables:
+  -    FOO: baz
+  +    FOO: bar
+       BAR: qux
+
+  ```
   > esc env diff test@stable --format json
-  --- test:stable
-  +++ test:latest
+  --- test-user/test@stable
+  +++ test-user/test@latest
   @@ -1,6 +1,19 @@
    {
   +  "array": [
@@ -267,21 +397,21 @@ stdout: |
   +  "string": "esc"
    }
   > esc env diff test@stable --format string
-  --- test:stable
-  +++ test:latest
+  --- test-user/test@stable
+  +++ test-user/test@latest
   @@ -1 +1 @@
   -"environmentVariables"="\"FOO\"=\"bar\"","string"="hello, world!"
   +"array"="\"hello\",\"world\"","boolean"="true","environmentVariables"="\"BAR\"=\"qux\",\"FOO\"=\"baz\"","null"="","number"="42","object"="\"hello\"=\"world\"","open"="[unknown]","secret"="[secret]","string"="esc"
   > esc env diff test@stable --format dotenv
-  --- test:stable
-  +++ test:latest
+  --- test-user/test@stable
+  +++ test-user/test@latest
   @@ -1 +1,2 @@
   -FOO="bar"
   +BAR="qux"
   +FOO="baz"
   > esc env diff test@stable --format shell
-  --- test:stable
-  +++ test:latest
+  --- test-user/test@stable
+  +++ test-user/test@latest
   @@ -1 +1,2 @@
   -export FOO="bar"
   +export BAR="qux"
@@ -293,7 +423,10 @@ stderr: |
   > esc env diff test@1
   > esc env diff test@2
   > esc env diff test@3
-  > esc env diff test@1 2
+  > esc env diff test@1 @2
+  > esc env diff test@1 @stable
+  > esc env diff test@stable test-v2@stable
+  > esc env diff test test-v2
   > esc env diff test@stable --format json
   > esc env diff test@stable --format string
   > esc env diff test@stable --format dotenv


### PR DESCRIPTION
Instead of only allowing `esc env diff` to compare different versions of the same environment, allow it to compare different environments altogether.

Most of the delta here is some rather mechanical refactoring to encapsulate the (org, env, version) tuple that identifies an environment in a type.