### PR TITLE
cli: add a `-f` flag to `env edit`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,6 +15,9 @@
 - Finalize command tree for version management.
   [#304](https://github.com/pulumi/esc/pull/304)
 
+- Add support to `esc env edit` for reading the edited environment definition from a file.
+  [#308](https://github.com/pulumi/esc/pull/308)
+
 ### Bug Fixes
 
 - Ensure that redacted output is flushed in `esc run`

--- a/cmd/esc/cli/testdata/env-edit-file.yaml
+++ b/cmd/esc/cli/testdata/env-edit-file.yaml
@@ -1,0 +1,46 @@
+run: |
+  echo '{"values":{"foo":"baz"}}' | esc env edit test -f=-
+  esc env get test
+  echo '{"values":{"foo":"qux"}}' >def.yaml
+  esc env edit test -f=def.yaml
+  esc env get test
+environments:
+  test-user/test:
+    values:
+      foo: bar
+stdout: |+
+  > esc env edit test -f=-
+  Environment updated.
+  > esc env get test
+  # Value
+  ```json
+  {
+    "foo": "baz"
+  }
+  ```
+  # Definition
+  ```yaml
+  {"values": {"foo": "baz"}}
+
+  ```
+
+  > esc env edit test -f=def.yaml
+  Environment updated.
+  > esc env get test
+  # Value
+  ```json
+  {
+    "foo": "qux"
+  }
+  ```
+  # Definition
+  ```yaml
+  {"values": {"foo": "qux"}}
+
+  ```
+
+stderr: |
+  > esc env edit test -f=-
+  > esc env get test
+  > esc env edit test -f=def.yaml
+  > esc env get test


### PR DESCRIPTION
This flag allows the user to provide a file from which to read the new environment definition. The flag has the same behavior as the `-f` flag for `env init`.