### PR TITLE
cli: add env version retract

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
+- Add a command to retract a specific revision of an environment.
+  [#330](https://github.com/pulumi/esc/pull/330)
+
 ### Bug Fixes
 
 - Buffer output to the system pager in paged commands.

--- a/cmd/esc/cli/client/apitype.go
+++ b/cmd/esc/cli/client/apitype.go
@@ -59,12 +59,22 @@ func diagsErrorString(envDiags []EnvironmentDiagnostic) string {
 	return diags.String()
 }
 
+type EnvironmentRevisionRetracted struct {
+	Replacement int       `json:"replacement"`
+	At          time.Time `json:"at"`
+	ByLogin     string    `json:"byLogin,omitempty"`
+	ByName      string    `json:"byName,omitempty"`
+	Reason      string    `json:"reason,omitempty"`
+}
+
 type EnvironmentRevision struct {
 	Number       int       `json:"number"`
 	Created      time.Time `json:"created"`
 	CreatorLogin string    `json:"creatorLogin"`
 	CreatorName  string    `json:"creatorName"`
 	Tags         []string  `json:"tags"`
+
+	Retracted *EnvironmentRevisionRetracted `json:"retracted,omitempty"`
 }
 
 type CreateEnvironmentRevisionTagRequest struct {
@@ -109,4 +119,9 @@ type CheckEnvironmentResponse struct {
 type OpenEnvironmentResponse struct {
 	ID          string                  `json:"id"`
 	Diagnostics []EnvironmentDiagnostic `json:"diagnostics,omitempty"`
+}
+
+type RetractEnvironmentRevisionRequest struct {
+	Replacement *int   `json:"replacement,omitempty"`
+	Reason      string `json:"reason,omitempty"`
 }

--- a/cmd/esc/cli/env_get.go
+++ b/cmd/esc/cli/env_get.go
@@ -236,7 +236,7 @@ func (get *envGetCommand) getEntireEnvironment(
 		return nil, fmt.Errorf("unmarshaling environment definition: %w", err)
 	}
 	if docNode.Kind != yaml.DocumentNode {
-		return nil, nil
+		return &envGetTemplateData{Definition: string(def)}, nil
 	}
 
 	env, _, err := get.env.esc.client.CheckYAMLEnvironment(ctx, orgName, def)

--- a/cmd/esc/cli/env_version.go
+++ b/cmd/esc/cli/env_version.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/pulumi/esc/cmd/esc/cli/client"
 	"github.com/pulumi/esc/cmd/esc/cli/style"
@@ -55,13 +56,13 @@ func newEnvVersionCmd(env *envCommand) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				printRevision(env.esc.stdout, st, *rev, utc)
+				printRevision(env.esc.stdout, st, *rev, utcFlag(utc))
 			} else {
 				tag, err := env.esc.client.GetEnvironmentRevisionTag(ctx, ref.orgName, ref.envName, ref.version)
 				if err != nil {
 					return err
 				}
-				printRevisionTag(env.esc.stdout, st, *tag, utc)
+				printRevisionTag(env.esc.stdout, st, *tag, utcFlag(utc))
 			}
 			return nil
 		},
@@ -76,7 +77,16 @@ func newEnvVersionCmd(env *envCommand) *cobra.Command {
 	return cmd
 }
 
-func printRevision(stdout io.Writer, st *style.Stylist, r client.EnvironmentRevision, utc bool) {
+type utcFlag bool
+
+func (utc utcFlag) time(t time.Time) time.Time {
+	if utc {
+		return t.UTC()
+	}
+	return t
+}
+
+func printRevision(stdout io.Writer, st *style.Stylist, r client.EnvironmentRevision, utc utcFlag) {
 	rules := style.Default()
 
 	st.Fprintf(stdout, rules.H1.StylePrimitive, "revision %v", r.Number)
@@ -100,14 +110,7 @@ func printRevision(stdout io.Writer, st *style.Stylist, r client.EnvironmentRevi
 		fmt.Fprintf(stdout, "Author: %v <%v>\n", r.CreatorName, r.CreatorLogin)
 	}
 
-	stamp := r.Created
-	if utc {
-		stamp = stamp.UTC()
-	} else {
-		stamp = stamp.Local()
-	}
-
-	fmt.Fprintf(stdout, "Date:   %v\n", stamp)
+	fmt.Fprintf(stdout, "Date:   %v\n", utc.time(r.Created))
 
 	if r.Retracted != nil {
 		if r.Retracted.ByLogin == "" {
@@ -115,7 +118,8 @@ func printRevision(stdout io.Writer, st *style.Stylist, r client.EnvironmentRevi
 		} else {
 			fmt.Fprintf(stdout, "\n    Retracted by %v <%v>", r.Retracted.ByName, r.Retracted.ByLogin)
 		}
-		fmt.Fprintf(stdout, " at %v and replaced with revision %v.\n", r.Retracted.At, r.Retracted.Replacement)
+
+		fmt.Fprintf(stdout, " at %v and replaced with revision %v.\n", utc.time(r.Retracted.At), r.Retracted.Replacement)
 
 		if r.Retracted.Reason != "" {
 			fmt.Fprintln(stdout, "")
@@ -128,20 +132,13 @@ func printRevision(stdout io.Writer, st *style.Stylist, r client.EnvironmentRevi
 	}
 }
 
-func printRevisionTag(stdout io.Writer, st *style.Stylist, tag client.EnvironmentRevisionTag, utc bool) {
+func printRevisionTag(stdout io.Writer, st *style.Stylist, tag client.EnvironmentRevisionTag, utc utcFlag) {
 	rules := style.Default()
 
 	st.Fprintf(stdout, rules.LinkText, "%v\n", tag.Name)
 	fmt.Fprintf(stdout, "Revision %v\n", tag.Revision)
 
-	stamp := tag.Modified
-	if utc {
-		stamp = stamp.UTC()
-	} else {
-		stamp = stamp.Local()
-	}
-
-	fmt.Fprintf(stdout, "Last updated at %v by ", stamp)
+	fmt.Fprintf(stdout, "Last updated at %v by ", utc.time(tag.Modified))
 	if tag.EditorLogin == "" {
 		fmt.Fprintf(stdout, "<unknown>")
 	} else {

--- a/cmd/esc/cli/env_version_history.go
+++ b/cmd/esc/cli/env_version_history.go
@@ -67,7 +67,7 @@ func newEnvVersionHistoryCmd(env *envCommand) *cobra.Command {
 					before = revisions[len(revisions)-1].Number
 
 					for _, r := range revisions {
-						printRevision(stdout, st, r, utc)
+						printRevision(stdout, st, r, utcFlag(utc))
 						fmt.Fprintf(stdout, "\n")
 					}
 				}

--- a/cmd/esc/cli/env_version_retract.go
+++ b/cmd/esc/cli/env_version_retract.go
@@ -43,6 +43,7 @@ func newEnvVersionRetractCmd(env *envCommand) *cobra.Command {
 			if ref.version == "latest" {
 				return errors.New("cannot retract the `latest` revision")
 			}
+			_ = args
 
 			var replacementRevision *int
 			if replacement != "" {

--- a/cmd/esc/cli/env_version_retract.go
+++ b/cmd/esc/cli/env_version_retract.go
@@ -1,0 +1,70 @@
+// Copyright 2023, Pulumi Corporation.
+
+package cli
+
+import (
+	"context"
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+func newEnvVersionRetractCmd(env *envCommand) *cobra.Command {
+	var replacement string
+	var reason string
+
+	cmd := &cobra.Command{
+		Use:   "retract [<org-name>/]<environment-name>@<version>",
+		Args:  cobra.RangeArgs(1, 2),
+		Short: "Retract a specific revision of an environment",
+		Long: "Retract a specific revision of an environment\n" +
+			"\n" +
+			"This command retracts a specific revision of an environment. A retracted\n" +
+			"revision can no longer be read or opened. Retracting a revision also updates\n" +
+			"any tags that point to the retracted revision to instead point to a\n" +
+			"replacement revision. If no replacement is specified, the latest non-retracted\n" +
+			"revision preceding the revision being retracted is used as the replacement.\n" +
+			"\n" +
+			"The revision pointed to by the `latest` tag may not be retracted. To retract\n" +
+			"the latest revision of an environment, first update the environment with a new\n" +
+			"definition.",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			if err := env.esc.getCachedClient(ctx); err != nil {
+				return err
+			}
+
+			ref, args, err := env.getEnvRef(args)
+			if err != nil {
+				return err
+			}
+			if ref.version == "latest" {
+				return errors.New("cannot retract the `latest` revision")
+			}
+
+			var replacementRevision *int
+			if replacement != "" {
+				replacementRef := env.getRelativeEnvRef(replacement, &ref)
+				rev, err := env.esc.client.GetRevisionNumber(
+					ctx,
+					replacementRef.orgName,
+					replacementRef.envName,
+					replacementRef.version,
+				)
+				if err != nil {
+					return err
+				}
+				replacementRevision = &rev
+			}
+
+			return env.esc.client.RetractEnvironmentRevision(ctx, ref.orgName, ref.envName, ref.version, replacementRevision, reason)
+		},
+	}
+
+	cmd.Flags().StringVar(&replacement, "replace-with", "", "the version to use to replace the retracted revision")
+	cmd.Flags().StringVar(&reason, "reason", "", "the reason for the retraction")
+
+	return cmd
+}

--- a/cmd/esc/cli/env_version_tag_ls.go
+++ b/cmd/esc/cli/env_version_tag_ls.go
@@ -61,7 +61,7 @@ func newEnvVersionTagLsCmd(env *envCommand) *cobra.Command {
 					after = tags[len(tags)-1].Name
 
 					for _, t := range tags {
-						printRevisionTag(stdout, st, t, utc)
+						printRevisionTag(stdout, st, t, utcFlag(utc))
 						fmt.Fprintf(stdout, "\n")
 					}
 				}

--- a/cmd/esc/cli/testdata/env-get-all.yaml
+++ b/cmd/esc/cli/testdata/env-get-all.yaml
@@ -127,6 +127,7 @@ stdout: |+
   ```
 
   > esc env get test@1
+
   > esc env get test@2
   # Value
   ```json

--- a/cmd/esc/cli/testdata/env-init-ok.yaml
+++ b/cmd/esc/cli/testdata/env-init-ok.yaml
@@ -10,6 +10,7 @@ stdout: |+
   > esc env init test-env
   Environment created.
   > esc env get test-env
+
   > esc env init test-stdin -f=-
   Environment created.
   > esc env get test-stdin

--- a/cmd/esc/cli/testdata/env-version-history.yaml
+++ b/cmd/esc/cli/testdata/env-version-history.yaml
@@ -15,6 +15,12 @@ environments:
           values: {}
       - yaml:
           values:
+            leaked-secret: oh no
+        retracted:
+          replacement: 3
+          reason: leaked secret
+      - yaml:
+          values:
             string: hello, world!
         tag: stable
       - yaml:
@@ -36,94 +42,126 @@ environments:
                 ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
 stdout: |+
   > esc env version history test --utc
-  revision 4
-  Author: test-tester <Test Tester>
+  revision 5
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 05:00:00 +0000 UTC
+
+  revision 4 (tag: stable)
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 04:00:00 +0000 UTC
 
-  revision 3 (tag: stable)
-  Author: test-tester <Test Tester>
+  revision 3 (retracted)
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
+      Retracted by Test Tester <test-tester> at 1969-12-31 19:00:00 -0800 PST and replaced with revision 3.
+
+      leaked secret
+
   revision 2
-  Author: test-tester <Test Tester>
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 02:00:00 +0000 UTC
 
   revision 1
-  Author: test-tester <Test Tester>
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
   > esc env version history test@latest --utc
-  revision 4
-  Author: test-tester <Test Tester>
+  revision 5
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 05:00:00 +0000 UTC
+
+  revision 4 (tag: stable)
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 04:00:00 +0000 UTC
 
-  revision 3 (tag: stable)
-  Author: test-tester <Test Tester>
+  revision 3 (retracted)
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
+      Retracted by Test Tester <test-tester> at 1969-12-31 19:00:00 -0800 PST and replaced with revision 3.
+
+      leaked secret
+
   revision 2
-  Author: test-tester <Test Tester>
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 02:00:00 +0000 UTC
 
   revision 1
-  Author: test-tester <Test Tester>
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
   > esc env version history test@stable --utc
-  revision 3 (tag: stable)
-  Author: test-tester <Test Tester>
+  revision 4 (tag: stable)
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 04:00:00 +0000 UTC
+
+  revision 3 (retracted)
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
+      Retracted by Test Tester <test-tester> at 1969-12-31 19:00:00 -0800 PST and replaced with revision 3.
+
+      leaked secret
+
   revision 2
-  Author: test-tester <Test Tester>
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 02:00:00 +0000 UTC
 
   revision 1
-  Author: test-tester <Test Tester>
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
   > esc env version history test@1 --utc
   revision 1
-  Author: test-tester <Test Tester>
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
   > esc env version history test@2 --utc
   revision 2
-  Author: test-tester <Test Tester>
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 02:00:00 +0000 UTC
 
   revision 1
-  Author: test-tester <Test Tester>
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
   > esc env version history test@3 --utc
-  revision 3 (tag: stable)
-  Author: test-tester <Test Tester>
+  revision 3 (retracted)
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
+      Retracted by Test Tester <test-tester> at 1969-12-31 19:00:00 -0800 PST and replaced with revision 3.
+
+      leaked secret
+
   revision 2
-  Author: test-tester <Test Tester>
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 02:00:00 +0000 UTC
 
   revision 1
-  Author: test-tester <Test Tester>
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
   > esc env version history test@4 --utc
-  revision 4
-  Author: test-tester <Test Tester>
+  revision 4 (tag: stable)
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 04:00:00 +0000 UTC
 
-  revision 3 (tag: stable)
-  Author: test-tester <Test Tester>
+  revision 3 (retracted)
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
+      Retracted by Test Tester <test-tester> at 1969-12-31 19:00:00 -0800 PST and replaced with revision 3.
+
+      leaked secret
+
   revision 2
-  Author: test-tester <Test Tester>
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 02:00:00 +0000 UTC
 
   revision 1
-  Author: test-tester <Test Tester>
+  Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
 stderr: |

--- a/cmd/esc/cli/testdata/env-version-history.yaml
+++ b/cmd/esc/cli/testdata/env-version-history.yaml
@@ -54,7 +54,7 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1969-12-31 19:00:00 -0800 PST and replaced with revision 3.
+      Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 3.
 
       leaked secret
 
@@ -79,7 +79,7 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1969-12-31 19:00:00 -0800 PST and replaced with revision 3.
+      Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 3.
 
       leaked secret
 
@@ -100,7 +100,7 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1969-12-31 19:00:00 -0800 PST and replaced with revision 3.
+      Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 3.
 
       leaked secret
 
@@ -131,7 +131,7 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1969-12-31 19:00:00 -0800 PST and replaced with revision 3.
+      Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 3.
 
       leaked secret
 
@@ -152,7 +152,7 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1969-12-31 19:00:00 -0800 PST and replaced with revision 3.
+      Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 3.
 
       leaked secret
 

--- a/cmd/esc/cli/testdata/env-version-retract.yaml
+++ b/cmd/esc/cli/testdata/env-version-retract.yaml
@@ -1,0 +1,141 @@
+run: |
+  esc env version history test --utc
+  esc env version retract test@2 --reason "plaintext secret" --replace-with @3
+  esc env version history test --utc
+  esc env version retract test@3 --reason "test retraction" --replace-with @latest
+  esc env version history test --utc
+  esc env version retract test@4
+  esc env version history test --utc
+environments:
+  test-user/test:
+    revisions:
+      - yaml:
+          values:
+            secret: oh no
+      - yaml:
+          values:
+            hello: world
+      - yaml:
+          values:
+            hello: again
+      - yaml:
+          vaues:
+            goodbye: cruel world
+stdout: |+
+  > esc env version history test --utc
+  revision 5
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 05:00:00 +0000 UTC
+
+  revision 4
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 04:00:00 +0000 UTC
+
+  revision 3
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 03:00:00 +0000 UTC
+
+  revision 2
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 02:00:00 +0000 UTC
+
+  revision 1
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 01:00:00 +0000 UTC
+
+  > esc env version retract test@2 --reason plaintext secret --replace-with @3
+  > esc env version history test --utc
+  revision 5
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 05:00:00 +0000 UTC
+
+  revision 4
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 04:00:00 +0000 UTC
+
+  revision 3
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 03:00:00 +0000 UTC
+
+  revision 2 (retracted)
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 02:00:00 +0000 UTC
+
+      Retracted by Test Tester <test-tester> at 1969-12-31 18:00:00 -0800 PST and replaced with revision 3.
+
+      plaintext secret
+
+  revision 1
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 01:00:00 +0000 UTC
+
+  > esc env version retract test@3 --reason test retraction --replace-with @latest
+  > esc env version history test --utc
+  revision 5
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 05:00:00 +0000 UTC
+
+  revision 4
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 04:00:00 +0000 UTC
+
+  revision 3 (retracted)
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 03:00:00 +0000 UTC
+
+      Retracted by Test Tester <test-tester> at 1969-12-31 19:00:00 -0800 PST and replaced with revision 5.
+
+      test retraction
+
+  revision 2 (retracted)
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 02:00:00 +0000 UTC
+
+      Retracted by Test Tester <test-tester> at 1969-12-31 18:00:00 -0800 PST and replaced with revision 3.
+
+      plaintext secret
+
+  revision 1
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 01:00:00 +0000 UTC
+
+  > esc env version retract test@4
+  > esc env version history test --utc
+  revision 5
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 05:00:00 +0000 UTC
+
+  revision 4 (retracted)
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 04:00:00 +0000 UTC
+
+      Retracted by Test Tester <test-tester> at 1969-12-31 20:00:00 -0800 PST and replaced with revision 42.
+
+  revision 3 (retracted)
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 03:00:00 +0000 UTC
+
+      Retracted by Test Tester <test-tester> at 1969-12-31 19:00:00 -0800 PST and replaced with revision 5.
+
+      test retraction
+
+  revision 2 (retracted)
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 02:00:00 +0000 UTC
+
+      Retracted by Test Tester <test-tester> at 1969-12-31 18:00:00 -0800 PST and replaced with revision 3.
+
+      plaintext secret
+
+  revision 1
+  Author: Test Tester <test-tester>
+  Date:   1970-01-01 01:00:00 +0000 UTC
+
+stderr: |
+  > esc env version history test --utc
+  > esc env version retract test@2 --reason plaintext secret --replace-with @3
+  > esc env version history test --utc
+  > esc env version retract test@3 --reason test retraction --replace-with @latest
+  > esc env version history test --utc
+  > esc env version retract test@4
+  > esc env version history test --utc

--- a/cmd/esc/cli/testdata/env-version-retract.yaml
+++ b/cmd/esc/cli/testdata/env-version-retract.yaml
@@ -61,7 +61,7 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 02:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1969-12-31 18:00:00 -0800 PST and replaced with revision 3.
+      Retracted by Test Tester <test-tester> at 1970-01-01 02:00:00 +0000 UTC and replaced with revision 3.
 
       plaintext secret
 
@@ -83,7 +83,7 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1969-12-31 19:00:00 -0800 PST and replaced with revision 5.
+      Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 5.
 
       test retraction
 
@@ -91,7 +91,7 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 02:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1969-12-31 18:00:00 -0800 PST and replaced with revision 3.
+      Retracted by Test Tester <test-tester> at 1970-01-01 02:00:00 +0000 UTC and replaced with revision 3.
 
       plaintext secret
 
@@ -109,13 +109,13 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 04:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1969-12-31 20:00:00 -0800 PST and replaced with revision 42.
+      Retracted by Test Tester <test-tester> at 1970-01-01 04:00:00 +0000 UTC and replaced with revision 42.
 
   revision 3 (retracted)
   Author: Test Tester <test-tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1969-12-31 19:00:00 -0800 PST and replaced with revision 5.
+      Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 5.
 
       test retraction
 
@@ -123,7 +123,7 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 02:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1969-12-31 18:00:00 -0800 PST and replaced with revision 3.
+      Retracted by Test Tester <test-tester> at 1970-01-01 02:00:00 +0000 UTC and replaced with revision 3.
 
       plaintext secret
 


### PR DESCRIPTION
This command retracts a specific revision of an environment. A retracted revision can no longer be read or opened. Retracting a revision also updates any tags that point to the retracted revision to instead point to a replacement revision. If no replacement is specified, the latest non-retracted revision preceding the revision being retracted is used as the replacement.

The revision pointed to by the `latest` tag may not be retracted. To retract the latest revision of an environment, first update the environment with a new definition.