### PR TITLE
cli: env rollback -> env version rollback

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,9 @@
 - Add a command to retract a specific revision of an environment.
   [#330](https://github.com/pulumi/esc/pull/330)
 
+- Move the `rollback` command under the `version` command for consistency.
+  [#331](https://github.com/pulumi/esc/pull/331)
+
 ### Bug Fixes
 
 - Buffer output to the system pager in paged commands.

--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -55,7 +55,6 @@ func newEnvCmd(esc *escCommand) *cobra.Command {
 	cmd.AddCommand(newEnvDiffCmd(env))
 	cmd.AddCommand(newEnvSetCmd(env))
 	cmd.AddCommand(newEnvVersionCmd(env))
-	cmd.AddCommand(newEnvRollbackCmd(env))
 	cmd.AddCommand(newEnvLsCmd(env))
 	cmd.AddCommand(newEnvRmCmd(env))
 	cmd.AddCommand(newEnvOpenCmd(env))

--- a/cmd/esc/cli/env_version.go
+++ b/cmd/esc/cli/env_version.go
@@ -71,6 +71,7 @@ func newEnvVersionCmd(env *envCommand) *cobra.Command {
 	cmd.AddCommand(newEnvVersionTagCmd(env))
 	cmd.AddCommand(newEnvVersionHistoryCmd(env))
 	cmd.AddCommand(newEnvVersionRetractCmd(env))
+	cmd.AddCommand(newEnvVersionRollbackCmd(env))
 
 	cmd.Flags().BoolVar(&utc, "utc", false, "display times in UTC")
 

--- a/cmd/esc/cli/env_version_rollback.go
+++ b/cmd/esc/cli/env_version_rollback.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newEnvRollbackCmd(env *envCommand) *cobra.Command {
+func newEnvVersionRollbackCmd(env *envCommand) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rollback [<org-name>/]<environment-name>@<version>",
 		Args:  cobra.ExactArgs(1),

--- a/cmd/esc/cli/testdata/env-version-rollback.yaml
+++ b/cmd/esc/cli/testdata/env-version-rollback.yaml
@@ -1,7 +1,7 @@
 run: |
-  esc env rollback test@stable
+  esc env version rollback test@stable
   esc env get test
-  esc env rollback test@2
+  esc env version rollback test@2
 error: exit status 1
 environments:
   test-user/a: {}
@@ -34,7 +34,7 @@ environments:
               fn::secret:
                 ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
 stdout: |
-  > esc env rollback test@stable
+  > esc env version rollback test@stable
   Environment updated.
   > esc env get test
   # Value
@@ -50,11 +50,11 @@ stdout: |
 
   ```
 
-  > esc env rollback test@2
+  > esc env version rollback test@2
 stderr: |
-  > esc env rollback test@stable
+  > esc env version rollback test@stable
   > esc env get test
-  > esc env rollback test@2
+  > esc env version rollback test@2
   Error: not found
 
     on test line 2:


### PR DESCRIPTION
Move the rollback command under the `version` command for the sake of consistency.