### PR TITLE
[cli] Stringify scalar secrets

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,7 @@
 ### Improvements
 
+- Coerce non-string scalars passed to `esc env set --secret` to strings
+  [#353](https://github.com/pulumi/esc/pull/353)
+
 ### Bug Fixes
 

--- a/cmd/esc/cli/testdata/env-set-secret.yaml
+++ b/cmd/esc/cli/testdata/env-set-secret.yaml
@@ -8,7 +8,16 @@ run: |
   esc env get test password --show-secrets
   esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
   esc env get test
-stdout: |+
+  esc env set test password 1234 --secret
+  esc env get test
+  esc env set test password 123.4 --secret
+  esc env get test
+  esc env set test password false --secret
+  esc env get test
+  esc env set test password true --secret
+  esc env get test
+  esc env set test password '[]' --secret || echo OK
+stdout: |
   > esc env init test
   Environment created.
   > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
@@ -89,6 +98,75 @@ stdout: |+
 
   ```
 
+  > esc env set test password 1234 --secret
+  > esc env get test
+  # Value
+  ```json
+  {
+    "password": "[secret]"
+  }
+  ```
+  # Definition
+  ```yaml
+  values:
+    password:
+      fn::secret:
+        ciphertext: ZXNjeAAAAAGxsrO0gN+X5A==
+
+  ```
+
+  > esc env set test password 123.4 --secret
+  > esc env get test
+  # Value
+  ```json
+  {
+    "password": "[secret]"
+  }
+  ```
+  # Definition
+  ```yaml
+  values:
+    password:
+      fn::secret:
+        ciphertext: ZXNjeAAAAAGxsrOutAnEmzU=
+
+  ```
+
+  > esc env set test password false --secret
+  > esc env get test
+  # Value
+  ```json
+  {
+    "password": "[secret]"
+  }
+  ```
+  # Definition
+  ```yaml
+  values:
+    password:
+      fn::secret:
+        ciphertext: ZXNjeAAAAAHm4ezz5S7WA1Q=
+
+  ```
+
+  > esc env set test password true --secret
+  > esc env get test
+  # Value
+  ```json
+  {
+    "password": "[secret]"
+  }
+  ```
+  # Definition
+  ```yaml
+  values:
+    password:
+      fn::secret:
+        ciphertext: ZXNjeAAAAAH08vXl5sA7yg==
+
+  ```
+
+  > esc env set test password [] --secret
 stderr: |
   > esc env init test
   > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
@@ -100,3 +178,13 @@ stderr: |
   > esc env get test password --show-secrets
   > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
   > esc env get test
+  > esc env set test password 1234 --secret
+  > esc env get test
+  > esc env set test password 123.4 --secret
+  > esc env get test
+  > esc env set test password false --secret
+  > esc env get test
+  > esc env set test password true --secret
+  > esc env get test
+  > esc env set test password [] --secret
+  test:3:21: secret values must be string literals


### PR DESCRIPTION
`esc env set --secret` requires that its argument is a string literal. While this is consistent with the requirements of the evaluator, it is somewhat less than ergonomic for CLI users, who must surround numeric or boolean values in both single and double quotes:

```console
esc env set my-env --secret foo.bar '"1234"'
```

These changes detect non-string scalar values passed to `esc env set --secret` and automatically coerce these values to strings. Non-scalar values are passed through to the evaluator as-is, which will report that the argument must be a string literal.

Fixes #296.