### PR TITLE
eval: allow secret decryption in CheckEnvironment

### DIFF
--- a/analysis/describe_test.go
+++ b/analysis/describe_test.go
@@ -34,7 +34,7 @@ func TestDescribe(t *testing.T) {
 	execContext, err := esc.NewExecContext(make(map[string]esc.Value))
 	require.NoError(t, err)
 
-	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, execContext)
+	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, nil, testProviders{}, testEnvironments{}, execContext, false)
 	require.Empty(t, diags)
 
 	analysis := New(*env, map[string]*schema.Schema{"test": testProviderSchema})
@@ -108,7 +108,7 @@ func TestDescribeOpen(t *testing.T) {
 	execContext, err := esc.NewExecContext(make(map[string]esc.Value))
 	require.NoError(t, err)
 
-	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, execContext)
+	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, nil, testProviders{}, testEnvironments{}, execContext, false)
 	require.Empty(t, diags)
 
 	analysis := New(*env, map[string]*schema.Schema{"test": testProviderSchema})

--- a/analysis/traversal_test.go
+++ b/analysis/traversal_test.go
@@ -33,7 +33,7 @@ func TestExpressionAt(t *testing.T) {
 	execContext, err := esc.NewExecContext(make(map[string]esc.Value))
 	require.NoError(t, err)
 
-	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, testProviders{}, testEnvironments{}, execContext)
+	env, diags := eval.CheckEnvironment(context.Background(), "def", syntax, nil, testProviders{}, testEnvironments{}, execContext, false)
 	require.Empty(t, diags)
 
 	analysis := New(*env, map[string]*schema.Schema{"test": testProviderSchema})

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -392,8 +392,7 @@ func (c *testPulumiClient) checkEnvironment(ctx context.Context, orgName, envNam
 		return nil, nil, fmt.Errorf("initializing the ESC exec context: %w", err)
 	}
 
-	checked, checkDiags := eval.CheckEnvironment(ctx, envName, environment,
-		providers, envLoader, execContext)
+	checked, checkDiags := eval.CheckEnvironment(ctx, envName, environment, nil, providers, envLoader, execContext, false)
 	diags.Extend(checkDiags...)
 	return checked, mapDiags(diags), nil
 }

--- a/eval/testdata/eval/ciphertext-show-secrets/env.yaml
+++ b/eval/testdata/eval/ciphertext-show-secrets/env.yaml
@@ -1,0 +1,6 @@
+imports:
+  - test-base
+values:
+  password:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAHo9e705fKyKo30VQ==

--- a/eval/testdata/eval/ciphertext-show-secrets/expected.json
+++ b/eval/testdata/eval/ciphertext-show-secrets/expected.json
@@ -1,0 +1,652 @@
+{
+    "check": {
+        "exprs": {
+            "password": {
+                "range": {
+                    "environment": "ciphertext-show-secrets",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 47
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 47,
+                        "byte": 105
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "ciphertext-show-secrets",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 47
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 15,
+                            "byte": 57
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "ciphertext-show-secrets",
+                            "begin": {
+                                "line": 6,
+                                "column": 7,
+                                "byte": 65
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 47,
+                                "byte": 105
+                            }
+                        },
+                        "object": {
+                            "ciphertext": {
+                                "range": {
+                                    "environment": "ciphertext-show-secrets",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 19,
+                                        "byte": 77
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 47,
+                                        "byte": 105
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "ZXNjeAAAAAHo9e705fKyKo30VQ=="
+                                },
+                                "literal": "ZXNjeAAAAAHo9e705fKyKo30VQ=="
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "basePassword": {
+                "value": "hunter2",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "test-base",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 28
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 47,
+                            "byte": 86
+                        }
+                    }
+                }
+            },
+            "password": {
+                "value": "hunter2",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "ciphertext-show-secrets",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 47
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 47,
+                            "byte": 105
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "basePassword": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "required": [
+                "basePassword",
+                "password"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "ciphertext-show-secrets",
+                            "trace": {
+                                "def": {
+                                    "environment": "ciphertext-show-secrets",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "ciphertext-show-secrets",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "ciphertext-show-secrets",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "ciphertext-show-secrets",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "ciphertext-show-secrets",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "ciphertext-show-secrets",
+                            "trace": {
+                                "def": {
+                                    "environment": "ciphertext-show-secrets",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "ciphertext-show-secrets",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "ciphertext-show-secrets"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "ciphertext-show-secrets"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "checkJson": {
+        "basePassword": "[secret]",
+        "password": "[secret]"
+    },
+    "eval": {
+        "exprs": {
+            "password": {
+                "range": {
+                    "environment": "ciphertext-show-secrets",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 47
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 47,
+                        "byte": 105
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "ciphertext-show-secrets",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 47
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 15,
+                            "byte": 57
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "ciphertext-show-secrets",
+                            "begin": {
+                                "line": 6,
+                                "column": 7,
+                                "byte": 65
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 47,
+                                "byte": 105
+                            }
+                        },
+                        "object": {
+                            "ciphertext": {
+                                "range": {
+                                    "environment": "ciphertext-show-secrets",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 19,
+                                        "byte": 77
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 47,
+                                        "byte": 105
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "ZXNjeAAAAAHo9e705fKyKo30VQ=="
+                                },
+                                "literal": "ZXNjeAAAAAHo9e705fKyKo30VQ=="
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "basePassword": {
+                "value": "hunter2",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "test-base",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 28
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 47,
+                            "byte": 86
+                        }
+                    }
+                }
+            },
+            "password": {
+                "value": "hunter2",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "ciphertext-show-secrets",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 47
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 47,
+                            "byte": 105
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "basePassword": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "required": [
+                "basePassword",
+                "password"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "ciphertext-show-secrets",
+                            "trace": {
+                                "def": {
+                                    "environment": "ciphertext-show-secrets",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "ciphertext-show-secrets",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "ciphertext-show-secrets",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "ciphertext-show-secrets",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "ciphertext-show-secrets",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "ciphertext-show-secrets",
+                            "trace": {
+                                "def": {
+                                    "environment": "ciphertext-show-secrets",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "ciphertext-show-secrets",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "ciphertext-show-secrets"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "ciphertext-show-secrets"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "evalJsonRedacted": {
+        "basePassword": "[secret]",
+        "password": "[secret]"
+    },
+    "evalJSONRevealed": {
+        "basePassword": "hunter2",
+        "password": "hunter2"
+    }
+}

--- a/eval/testdata/eval/ciphertext-show-secrets/overrides.json
+++ b/eval/testdata/eval/ciphertext-show-secrets/overrides.json
@@ -1,0 +1,1 @@
+{"showSecrets": true}

--- a/eval/testdata/eval/ciphertext-show-secrets/test-base.yaml
+++ b/eval/testdata/eval/ciphertext-show-secrets/test-base.yaml
@@ -1,0 +1,4 @@
+values:
+  basePassword:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAHo9e705fKyKo30VQ==


### PR DESCRIPTION
These changes allow clients to request that CheckEnvironment decrypt static secrets rather than treating their contents as unknown. This allows clients to more reliably implement `showSecrets` by supplying a decrypter and setting the `showSecrets` flag to `true`. To acheive equivalent behavior without these changes, the client must decrypt secrets in environment definitions prior to calling `CheckEnvironment` and as part of `LoadEnviroment`.

Part of #347.