### PR TITLE
eval: fix showSecrets in CheckEnvironment

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -147,7 +147,7 @@ type imported struct {
 type evalContext struct {
 	ctx          context.Context      // the cancellation context for evaluation
 	validating   bool                 // true if we are only checking the environment
-	showSecrets  bool                 // true if serets should be decrypted during validation
+	showSecrets  bool                 // true if secrets should be decrypted during validation
 	name         string               // the name of the environment
 	env          *ast.EnvironmentDecl // the root of the environment AST
 	decrypter    Decrypter            // the decrypter to use for the environment

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -79,7 +79,7 @@ func EvalEnvironment(
 	environments EnvironmentLoader,
 	execContext *esc.ExecContext,
 ) (*esc.Environment, syntax.Diagnostics) {
-	return evalEnvironment(ctx, false, name, env, decrypter, providers, environments, execContext)
+	return evalEnvironment(ctx, false, name, env, decrypter, providers, environments, execContext, true)
 }
 
 // CheckEnvironment symbolically evaluates the given environment. Calls to fn::open are not invoked, and instead
@@ -94,10 +94,7 @@ func CheckEnvironment(
 	execContext *esc.ExecContext,
 	showSecrets bool,
 ) (*esc.Environment, syntax.Diagnostics) {
-	if !showSecrets {
-		decrypter = nil
-	}
-	return evalEnvironment(ctx, true, name, env, decrypter, providers, environments, execContext)
+	return evalEnvironment(ctx, true, name, env, decrypter, providers, environments, execContext, showSecrets)
 }
 
 // evalEnvironment evaluates an environment and exports the result of evaluation.
@@ -110,12 +107,13 @@ func evalEnvironment(
 	providers ProviderLoader,
 	envs EnvironmentLoader,
 	execContext *esc.ExecContext,
+	showSecrets bool,
 ) (*esc.Environment, syntax.Diagnostics) {
 	if env == nil || (len(env.Values.GetEntries()) == 0 && len(env.Imports.GetElements()) == 0) {
 		return nil, nil
 	}
 
-	ec := newEvalContext(ctx, validating, name, env, decrypter, providers, envs, map[string]*imported{}, execContext)
+	ec := newEvalContext(ctx, validating, name, env, decrypter, providers, envs, map[string]*imported{}, execContext, showSecrets)
 	v, diags := ec.evaluate()
 
 	s := schema.Never().Schema()
@@ -149,6 +147,7 @@ type imported struct {
 type evalContext struct {
 	ctx          context.Context      // the cancellation context for evaluation
 	validating   bool                 // true if we are only checking the environment
+	showSecrets  bool                 // true if serets should be decrypted during validation
 	name         string               // the name of the environment
 	env          *ast.EnvironmentDecl // the root of the environment AST
 	decrypter    Decrypter            // the decrypter to use for the environment
@@ -175,10 +174,12 @@ func newEvalContext(
 	environments EnvironmentLoader,
 	imports map[string]*imported,
 	execContext *esc.ExecContext,
+	showSecrets bool,
 ) *evalContext {
 	return &evalContext{
 		ctx:          ctx,
 		validating:   validating,
+		showSecrets:  showSecrets,
 		name:         name,
 		env:          env,
 		decrypter:    decrypter,
@@ -191,7 +192,7 @@ func newEvalContext(
 
 // decryptSecrets returns true if static secrets should be decrypted.
 func (e *evalContext) decryptSecrets() bool {
-	return !e.validating || e.decrypter != nil
+	return !e.validating || e.showSecrets
 }
 
 // error records an evaluation error associated with an expression.
@@ -457,7 +458,7 @@ func (e *evalContext) evaluateImport(myImports map[string]*value, decl *ast.Impo
 			return
 		}
 
-		imp := newEvalContext(e.ctx, e.validating, name, env, dec, e.providers, e.environments, e.imports, e.execContext)
+		imp := newEvalContext(e.ctx, e.validating, name, env, dec, e.providers, e.environments, e.imports, e.execContext, e.showSecrets)
 		v, diags := imp.evaluate()
 		e.diags.Extend(diags...)
 

--- a/eval/testdata/eval/ciphertext-import/env.yaml
+++ b/eval/testdata/eval/ciphertext-import/env.yaml
@@ -1,0 +1,6 @@
+imports:
+  - test-base
+values:
+  password:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAHo9e705fKyKo30VQ==

--- a/eval/testdata/eval/ciphertext-import/expected.json
+++ b/eval/testdata/eval/ciphertext-import/expected.json
@@ -76,8 +76,8 @@
         },
         "properties": {
             "basePassword": {
-                "value": "hunter2",
                 "secret": true,
+                "unknown": true,
                 "trace": {
                     "def": {
                         "environment": "test-base",

--- a/eval/testdata/eval/ciphertext-import/expected.json
+++ b/eval/testdata/eval/ciphertext-import/expected.json
@@ -1,0 +1,652 @@
+{
+    "check": {
+        "exprs": {
+            "password": {
+                "range": {
+                    "environment": "ciphertext-import",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 47
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 47,
+                        "byte": 105
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "ciphertext-import",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 47
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 15,
+                            "byte": 57
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "ciphertext-import",
+                            "begin": {
+                                "line": 6,
+                                "column": 7,
+                                "byte": 65
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 47,
+                                "byte": 105
+                            }
+                        },
+                        "object": {
+                            "ciphertext": {
+                                "range": {
+                                    "environment": "ciphertext-import",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 19,
+                                        "byte": 77
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 47,
+                                        "byte": 105
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "ZXNjeAAAAAHo9e705fKyKo30VQ=="
+                                },
+                                "literal": "ZXNjeAAAAAHo9e705fKyKo30VQ=="
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "basePassword": {
+                "value": "hunter2",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "test-base",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 28
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 47,
+                            "byte": 86
+                        }
+                    }
+                }
+            },
+            "password": {
+                "secret": true,
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "ciphertext-import",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 47
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 47,
+                            "byte": 105
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "basePassword": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "required": [
+                "basePassword",
+                "password"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "ciphertext-import",
+                            "trace": {
+                                "def": {
+                                    "environment": "ciphertext-import",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "ciphertext-import",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "ciphertext-import",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "ciphertext-import",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "ciphertext-import",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "ciphertext-import",
+                            "trace": {
+                                "def": {
+                                    "environment": "ciphertext-import",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "ciphertext-import",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "ciphertext-import"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "ciphertext-import"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "checkJson": {
+        "basePassword": "[secret]",
+        "password": "[secret]"
+    },
+    "eval": {
+        "exprs": {
+            "password": {
+                "range": {
+                    "environment": "ciphertext-import",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 47
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 47,
+                        "byte": 105
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "ciphertext-import",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 47
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 15,
+                            "byte": 57
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "ciphertext-import",
+                            "begin": {
+                                "line": 6,
+                                "column": 7,
+                                "byte": 65
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 47,
+                                "byte": 105
+                            }
+                        },
+                        "object": {
+                            "ciphertext": {
+                                "range": {
+                                    "environment": "ciphertext-import",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 19,
+                                        "byte": 77
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 47,
+                                        "byte": 105
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "ZXNjeAAAAAHo9e705fKyKo30VQ=="
+                                },
+                                "literal": "ZXNjeAAAAAHo9e705fKyKo30VQ=="
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "basePassword": {
+                "value": "hunter2",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "test-base",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 28
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 47,
+                            "byte": 86
+                        }
+                    }
+                }
+            },
+            "password": {
+                "value": "hunter2",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "ciphertext-import",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 47
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 47,
+                            "byte": 105
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "basePassword": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "required": [
+                "basePassword",
+                "password"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "ciphertext-import",
+                            "trace": {
+                                "def": {
+                                    "environment": "ciphertext-import",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "ciphertext-import",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "ciphertext-import",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "ciphertext-import",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "ciphertext-import",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "ciphertext-import",
+                            "trace": {
+                                "def": {
+                                    "environment": "ciphertext-import",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "ciphertext-import",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "ciphertext-import"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "ciphertext-import"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "evalJsonRedacted": {
+        "basePassword": "[secret]",
+        "password": "[secret]"
+    },
+    "evalJSONRevealed": {
+        "basePassword": "hunter2",
+        "password": "hunter2"
+    }
+}

--- a/eval/testdata/eval/ciphertext-import/test-base.yaml
+++ b/eval/testdata/eval/ciphertext-import/test-base.yaml
@@ -1,0 +1,4 @@
+values:
+  basePassword:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAHo9e705fKyKo30VQ==


### PR DESCRIPTION
These changes fix a bug in `CheckEnvironment` when `showSecrets` is
`false`. In this case, if the environment loader supplied a decrypter
for an imported environment, the imported environment's secrets would be
decrypted, violating the `showSecrets` contract. In order to address
this issue, these changes store and propagate the value of `showSecrets`
in the evaluator's context.