### PR TITLE
Handle login.Current returning nil

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,3 +8,5 @@
 
 ### Bug Fixes
 
+- Fix a panic in fetching current credentials when the access key had expired.
+  [#368](https://github.com/pulumi/esc/pull/368)

--- a/cmd/esc/cli/login.go
+++ b/cmd/esc/cli/login.go
@@ -204,6 +204,9 @@ func (esc *escCommand) getCachedCredentials(ctx context.Context, backendURL stri
 	if err != nil {
 		return false, err
 	}
+	if account == nil {
+		return false, nil
+	}
 
 	defaultOrg, err := esc.workspace.GetBackendConfigDefaultOrg(backendURL, account.Username)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/pulumi/esc/issues/367.

If the pulumi credentials have a current account saved, but that account's access key has expired `httpstate.Current` will return `nil, nil`. `getCachedCredentials` did not correctly handle this `nil, nil` result.