### PR TITLE
Add Projects

### DIFF
--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -788,13 +788,14 @@ func (c *testPulumiClient) DeleteEnvironmentTag(ctx context.Context, orgName, pr
 func (c *testPulumiClient) GetEnvironmentRevision(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	revision int,
 ) (*client.EnvironmentRevision, error) {
 	before, count := revision+1, 1
 
 	opts := client.ListEnvironmentRevisionsOptions{Before: &before, Count: &count}
-	revs, err := c.ListEnvironmentRevisions(ctx, orgName, envName, opts)
+	revs, err := c.ListEnvironmentRevisions(ctx, orgName, projectName, envName, opts)
 	if err != nil || len(revs) == 0 {
 		return nil, err
 	}
@@ -804,6 +805,7 @@ func (c *testPulumiClient) GetEnvironmentRevision(
 func (c *testPulumiClient) ListEnvironmentRevisions(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	options client.ListEnvironmentRevisionsOptions,
 ) ([]client.EnvironmentRevision, error) {
@@ -854,6 +856,7 @@ func (c *testPulumiClient) ListEnvironmentRevisions(
 func (c *testPulumiClient) RetractEnvironmentRevision(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	version string,
 	replacement *int,

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -348,8 +348,8 @@ func mapDiags(diags syntax.Diagnostics) []client.EnvironmentDiagnostic {
 	return out
 }
 
-func (c *testPulumiClient) getEnvironment(orgName, envName, version string) (*testEnvironment, *testEnvironmentRevision, error) {
-	name := path.Join(orgName, envName)
+func (c *testPulumiClient) getEnvironment(orgName, projectName, envName, version string) (*testEnvironment, *testEnvironmentRevision, error) {
+	name := path.Join(orgName, projectName, envName)
 
 	env, ok := c.environments[name]
 	if !ok {
@@ -451,8 +451,8 @@ func (c *testPulumiClient) GetPulumiAccountDetails(ctx context.Context) (string,
 	return c.user, nil, nil, nil
 }
 
-func (c *testPulumiClient) GetRevisionNumber(ctx context.Context, orgName, envName, version string) (int, error) {
-	_, rev, err := c.getEnvironment(orgName, envName, version)
+func (c *testPulumiClient) GetRevisionNumber(ctx context.Context, orgName, projectName, envName, version string) (int, error) {
+	_, rev, err := c.getEnvironment(orgName, projectName, envName, version)
 	if err != nil {
 		return 0, err
 	}
@@ -520,7 +520,7 @@ func (c *testPulumiClient) GetEnvironment(
 	version string,
 	showSecrets bool,
 ) ([]byte, string, int, error) {
-	_, env, err := c.getEnvironment(orgName, envName, version)
+	_, env, err := c.getEnvironment(orgName, projectName, envName, version)
 	if err != nil {
 		return nil, "", 0, err
 	}
@@ -560,18 +560,19 @@ func (c *testPulumiClient) UpdateEnvironmentWithProject(
 	yaml []byte,
 	tag string,
 ) ([]client.EnvironmentDiagnostic, error) {
-	diags, _, err := c.UpdateEnvironmentWithRevision(ctx, orgName, envName, yaml, tag)
+	diags, _, err := c.UpdateEnvironmentWithRevision(ctx, orgName, projectName, envName, yaml, tag)
 	return diags, err
 }
 
 func (c *testPulumiClient) UpdateEnvironmentWithRevision(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	yaml []byte,
 	tag string,
 ) ([]client.EnvironmentDiagnostic, int, error) {
-	env, latest, err := c.getEnvironment(orgName, envName, "")
+	env, latest, err := c.getEnvironment(orgName, projectName, envName, "")
 	if err != nil {
 		return nil, 0, err
 	}
@@ -620,7 +621,7 @@ func (c *testPulumiClient) OpenEnvironment(
 	version string,
 	duration time.Duration,
 ) (string, []client.EnvironmentDiagnostic, error) {
-	_, env, err := c.getEnvironment(orgName, envName, version)
+	_, env, err := c.getEnvironment(orgName, projectName, envName, version)
 	if err != nil {
 		return "", nil, err
 	}
@@ -658,7 +659,7 @@ func (c *testPulumiClient) GetOpenEnvironmentWithProject(ctx context.Context, or
 	return env, nil
 }
 
-func (c *testPulumiClient) GetOpenProperty(ctx context.Context, orgName, envName, openEnvID, property string) (*esc.Value, error) {
+func (c *testPulumiClient) GetOpenProperty(ctx context.Context, orgName, projectName, envName, openEnvID, property string) (*esc.Value, error) {
 	return nil, errors.New("NYI")
 }
 
@@ -811,7 +812,7 @@ func (c *testPulumiClient) ListEnvironmentRevisions(
 	envName string,
 	options client.ListEnvironmentRevisionsOptions,
 ) ([]client.EnvironmentRevision, error) {
-	env, _, err := c.getEnvironment(orgName, envName, "")
+	env, _, err := c.getEnvironment(orgName, projectName, envName, "")
 	if err != nil {
 		return nil, err
 	}
@@ -864,7 +865,7 @@ func (c *testPulumiClient) RetractEnvironmentRevision(
 	replacement *int,
 	reason string,
 ) error {
-	_, rev, err := c.getEnvironment(orgName, envName, version)
+	_, rev, err := c.getEnvironment(orgName, projectName, envName, version)
 	if err != nil {
 		return err
 	}
@@ -886,7 +887,7 @@ func (c *testPulumiClient) CreateEnvironmentRevisionTag(
 	tagName string,
 	revision *int,
 ) error {
-	env, _, err := c.getEnvironment(orgName, envName, "")
+	env, _, err := c.getEnvironment(orgName, projectName, envName, "")
 	if err != nil {
 		return err
 	}
@@ -915,7 +916,7 @@ func (c *testPulumiClient) GetEnvironmentRevisionTag(
 	envName string,
 	tagName string,
 ) (*client.EnvironmentRevisionTag, error) {
-	env, _, err := c.getEnvironment(orgName, envName, "")
+	env, _, err := c.getEnvironment(orgName, projectName, envName, "")
 	if err != nil {
 		return nil, err
 	}
@@ -936,7 +937,7 @@ func (c *testPulumiClient) UpdateEnvironmentRevisionTag(
 	tagName string,
 	revision *int,
 ) error {
-	env, _, err := c.getEnvironment(orgName, envName, "")
+	env, _, err := c.getEnvironment(orgName, projectName, envName, "")
 	if err != nil {
 		return err
 	}
@@ -965,7 +966,7 @@ func (c *testPulumiClient) DeleteEnvironmentRevisionTag(
 	envName string,
 	tagName string,
 ) error {
-	env, _, err := c.getEnvironment(orgName, envName, "")
+	env, _, err := c.getEnvironment(orgName, projectName, envName, "")
 	if err != nil {
 		return err
 	}
@@ -986,7 +987,7 @@ func (c *testPulumiClient) ListEnvironmentRevisionTags(
 	envName string,
 	options client.ListEnvironmentRevisionTagsOptions,
 ) ([]client.EnvironmentRevisionTag, error) {
-	env, _, err := c.getEnvironment(orgName, envName, "")
+	env, _, err := c.getEnvironment(orgName, projectName, envName, "")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -515,6 +515,7 @@ func (c *testPulumiClient) CreateEnvironmentWithProject(ctx context.Context, org
 func (c *testPulumiClient) GetEnvironment(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	version string,
 	showSecrets bool,
@@ -602,8 +603,8 @@ func (c *testPulumiClient) UpdateEnvironmentWithRevision(
 	return diags, env.revisionTags["latest"], err
 }
 
-func (c *testPulumiClient) DeleteEnvironment(ctx context.Context, orgName, envName string) error {
-	name := path.Join(orgName, envName)
+func (c *testPulumiClient) DeleteEnvironment(ctx context.Context, orgName, projectName, envName string) error {
+	name := path.Join(orgName, projectName, envName)
 	if _, ok := c.environments[name]; !ok {
 		return errors.New("not found")
 	}
@@ -614,6 +615,7 @@ func (c *testPulumiClient) DeleteEnvironment(ctx context.Context, orgName, envNa
 func (c *testPulumiClient) OpenEnvironment(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	version string,
 	duration time.Duration,

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -879,6 +879,7 @@ func (c *testPulumiClient) RetractEnvironmentRevision(
 func (c *testPulumiClient) CreateEnvironmentRevisionTag(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	tagName string,
 	revision *int,
@@ -908,6 +909,7 @@ func (c *testPulumiClient) CreateEnvironmentRevisionTag(
 func (c *testPulumiClient) GetEnvironmentRevisionTag(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	tagName string,
 ) (*client.EnvironmentRevisionTag, error) {
@@ -927,6 +929,7 @@ func (c *testPulumiClient) GetEnvironmentRevisionTag(
 func (c *testPulumiClient) UpdateEnvironmentRevisionTag(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	tagName string,
 	revision *int,
@@ -956,6 +959,7 @@ func (c *testPulumiClient) UpdateEnvironmentRevisionTag(
 func (c *testPulumiClient) DeleteEnvironmentRevisionTag(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	tagName string,
 ) error {
@@ -976,6 +980,7 @@ func (c *testPulumiClient) DeleteEnvironmentRevisionTag(
 func (c *testPulumiClient) ListEnvironmentRevisionTags(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	options client.ListEnvironmentRevisionTagsOptions,
 ) ([]client.EnvironmentRevisionTag, error) {

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -496,7 +496,11 @@ func (c *testPulumiClient) ListEnvironments(
 }
 
 func (c *testPulumiClient) CreateEnvironment(ctx context.Context, orgName, envName string) error {
-	name := path.Join(orgName, envName)
+	return c.CreateEnvironmentWithProject(ctx, orgName, client.DefaultProject, envName)
+}
+
+func (c *testPulumiClient) CreateEnvironmentWithProject(ctx context.Context, orgName, projectName, envName string) error {
+	name := path.Join(orgName, projectName, envName)
 	if _, ok := c.environments[name]; ok {
 		return errors.New("already exists")
 	}
@@ -540,6 +544,17 @@ func (c *testPulumiClient) GetEnvironment(
 func (c *testPulumiClient) UpdateEnvironment(
 	ctx context.Context,
 	orgName string,
+	envName string,
+	yaml []byte,
+	tag string,
+) ([]client.EnvironmentDiagnostic, error) {
+	return c.UpdateEnvironmentWithProject(ctx, orgName, client.DefaultProject, envName, yaml, tag)
+}
+
+func (c *testPulumiClient) UpdateEnvironmentWithProject(
+	ctx context.Context,
+	orgName string,
+	projectName string,
 	envName string,
 	yaml []byte,
 	tag string,
@@ -630,6 +645,10 @@ func (c *testPulumiClient) OpenYAMLEnvironment(
 }
 
 func (c *testPulumiClient) GetOpenEnvironment(ctx context.Context, orgName, envName, openEnvID string) (*esc.Environment, error) {
+	return c.GetOpenEnvironmentWithProject(ctx, orgName, client.DefaultProject, envName, openEnvID)
+}
+
+func (c *testPulumiClient) GetOpenEnvironmentWithProject(ctx context.Context, orgName, projectName, envName, openEnvID string) (*esc.Environment, error) {
 	env, ok := c.openEnvs[openEnvID]
 	if !ok {
 		return nil, errors.New("not found")

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -662,9 +662,9 @@ func (c *testPulumiClient) GetOpenProperty(ctx context.Context, orgName, envName
 
 func (c *testPulumiClient) GetEnvironmentTag(
 	ctx context.Context,
-	orgName, envName, key string,
+	orgName, projectName, envName, key string,
 ) (*client.EnvironmentTag, error) {
-	env, ok := c.environments[fmt.Sprintf("%s/%s", orgName, envName)]
+	env, ok := c.environments[fmt.Sprintf("%s/%s/%s", orgName, projectName, envName)]
 	if !ok {
 		return nil, errors.New("environment not found")
 	}
@@ -687,10 +687,11 @@ func (c *testPulumiClient) GetEnvironmentTag(
 func (c *testPulumiClient) ListEnvironmentTags(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	options client.ListEnvironmentTagsOptions,
 ) ([]*client.EnvironmentTag, string, error) {
-	env, ok := c.environments[fmt.Sprintf("%s/%s", orgName, envName)]
+	env, ok := c.environments[fmt.Sprintf("%s/%s/%s", orgName, projectName, envName)]
 	if !ok {
 		return nil, "", errors.New("environment not found")
 	}
@@ -713,7 +714,7 @@ func (c *testPulumiClient) ListEnvironmentTags(
 
 func (c *testPulumiClient) CreateEnvironmentTag(
 	ctx context.Context,
-	orgName, envName, key, value string,
+	orgName, projectName, envName, key, value string,
 ) (*client.EnvironmentTag, error) {
 	ts, _ := time.Parse(time.RFC1123, "Mon, 29 Jul 2024 12:30:00 UTC")
 	tag := &client.EnvironmentTag{
@@ -725,7 +726,7 @@ func (c *testPulumiClient) CreateEnvironmentTag(
 		EditorLogin: "pulumipus",
 		EditorName:  "pulumipus",
 	}
-	env, ok := c.environments[fmt.Sprintf("%s/%s", orgName, envName)]
+	env, ok := c.environments[fmt.Sprintf("%s/%s/%s", orgName, projectName, envName)]
 	if !ok {
 		return nil, errors.New("environment not found")
 	}
@@ -738,7 +739,7 @@ func (c *testPulumiClient) CreateEnvironmentTag(
 
 func (c *testPulumiClient) UpdateEnvironmentTag(
 	ctx context.Context,
-	orgName, envName, currentKey, currentValue, newKey, newValue string,
+	orgName, projectName, envName, currentKey, currentValue, newKey, newValue string,
 ) (*client.EnvironmentTag, error) {
 	name := newKey
 	if name == "" {
@@ -749,7 +750,7 @@ func (c *testPulumiClient) UpdateEnvironmentTag(
 		value = currentValue
 	}
 	ts, _ := time.Parse(time.RFC1123, "Mon, 29 Jul 2024 12:30:00 UTC")
-	env, ok := c.environments[fmt.Sprintf("%s/%s", orgName, envName)]
+	env, ok := c.environments[fmt.Sprintf("%s/%s/%s", orgName, projectName, envName)]
 	if !ok {
 		return nil, errors.New("environment not found")
 	}
@@ -772,8 +773,8 @@ func (c *testPulumiClient) UpdateEnvironmentTag(
 	}, nil
 }
 
-func (c *testPulumiClient) DeleteEnvironmentTag(ctx context.Context, orgName, envName, tagName string) error {
-	env, ok := c.environments[fmt.Sprintf("%s/%s", orgName, envName)]
+func (c *testPulumiClient) DeleteEnvironmentTag(ctx context.Context, orgName, projectName, envName, tagName string) error {
+	env, ok := c.environments[fmt.Sprintf("%s/%s/%s", orgName, projectName, envName)]
 	if !ok {
 		return errors.New("environment not found")
 	}

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -479,12 +479,14 @@ func (c *testPulumiClient) ListEnvironments(
 
 	var envs []client.OrgEnvironment
 	for _, k := range names {
-		org, name, _ := strings.Cut(k, "/")
+		parts := strings.Split(k, "/")
+		org, projectName, envName := parts[0], parts[1], parts[2]
 
 		if orgName == "" || org == orgName {
 			envs = append(envs, client.OrgEnvironment{
 				Organization: org,
-				Name:         name,
+				Project:      projectName,
+				Name:         envName,
 			})
 		}
 	}

--- a/cmd/esc/cli/client/apitype.go
+++ b/cmd/esc/cli/client/apitype.go
@@ -127,6 +127,7 @@ type ListEnvironmentRevisionTagsResponse struct {
 }
 type OrgEnvironment struct {
 	Organization string `json:"organization,omitempty"`
+	Project      string `json:"project,omitempty"`
 	Name         string `json:"name,omitempty"`
 }
 

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -243,21 +243,22 @@ type Client interface {
 	) error
 
 	// CreateEnvironmentRevisionTag creates a new revision tag with the given name.
-	CreateEnvironmentRevisionTag(ctx context.Context, orgName, envName, tagName string, revision *int) error
+	CreateEnvironmentRevisionTag(ctx context.Context, orgName, projectName, envName, tagName string, revision *int) error
 
 	// GetEnvironmentRevisionTag returns a description of the given revision tag.
-	GetEnvironmentRevisionTag(ctx context.Context, orgName, envName, tagName string) (*EnvironmentRevisionTag, error)
+	GetEnvironmentRevisionTag(ctx context.Context, orgName, projectName, envName, tagName string) (*EnvironmentRevisionTag, error)
 
 	// UpdateEnvironmentRevisionTag updates the revision tag with the given name.
-	UpdateEnvironmentRevisionTag(ctx context.Context, orgName, envName, tagName string, revision *int) error
+	UpdateEnvironmentRevisionTag(ctx context.Context, orgName, projectName, envName, tagName string, revision *int) error
 
 	// DeleteEnvironmentRevisionTag deletes the revision tag with the given name.
-	DeleteEnvironmentRevisionTag(ctx context.Context, orgName, envName, tagName string) error
+	DeleteEnvironmentRevisionTag(ctx context.Context, orgName, projectName, envName, tagName string) error
 
 	// ListEnvironmentRevisionTags lists the revision tags for the given environment.
 	ListEnvironmentRevisionTags(
 		ctx context.Context,
 		orgName string,
+		projectName string,
 		envName string,
 		options ListEnvironmentRevisionTagsOptions,
 	) ([]EnvironmentRevisionTag, error)
@@ -829,6 +830,7 @@ func (pc *client) RetractEnvironmentRevision(
 func (pc *client) CreateEnvironmentRevisionTag(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	tagName string,
 	revision *int,
@@ -842,6 +844,7 @@ func (pc *client) CreateEnvironmentRevisionTag(
 func (pc *client) GetEnvironmentRevisionTag(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	tagName string,
 ) (*EnvironmentRevisionTag, error) {
@@ -858,6 +861,7 @@ func (pc *client) GetEnvironmentRevisionTag(
 func (pc *client) UpdateEnvironmentRevisionTag(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	tagName string,
 	revision *int,
@@ -871,6 +875,7 @@ func (pc *client) UpdateEnvironmentRevisionTag(
 func (pc *client) DeleteEnvironmentRevisionTag(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	tagName string,
 ) error {
@@ -887,6 +892,7 @@ type ListEnvironmentRevisionTagsOptions struct {
 func (pc *client) ListEnvironmentRevisionTags(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	options ListEnvironmentRevisionTagsOptions,
 ) ([]EnvironmentRevisionTag, error) {

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -192,30 +192,30 @@ type Client interface {
 	// ListEnvironmentTags lists the tags for the given environment.
 	ListEnvironmentTags(
 		ctx context.Context,
-		orgName, envName string,
+		orgName, projectName, envName string,
 		options ListEnvironmentTagsOptions,
 	) ([]*EnvironmentTag, string, error)
 
 	// CreateEnvironmentTag creates and applies a tag to the given environment.
 	CreateEnvironmentTag(
 		ctx context.Context,
-		orgName, envName, key, value string,
+		orgName, projectName, envName, key, value string,
 	) (*EnvironmentTag, error)
 
 	// GetEnvironmentTag returns a tag with the specified name for the given environment.
 	GetEnvironmentTag(
 		ctx context.Context,
-		orgName, envName, key string,
+		orgName, projectName, envName, key string,
 	) (*EnvironmentTag, error)
 
 	// UpdateEnvironmentTag updates a specified environment tag with a new key / value.
 	UpdateEnvironmentTag(
 		ctx context.Context,
-		orgName, envName, currentKey, currentValue, newKey, newValue string,
+		orgName, projectName, envName, currentKey, currentValue, newKey, newValue string,
 	) (*EnvironmentTag, error)
 
 	// DeleteEnvironmentTag deletes a specified tag on an environment.
-	DeleteEnvironmentTag(ctx context.Context, orgName, envName, tagName string) error
+	DeleteEnvironmentTag(ctx context.Context, orgName, projectName, envName, tagName string) error
 
 	// GetEnvironmentRevision returns a description of the given revision.
 	GetEnvironmentRevision(ctx context.Context, orgName, envName string, revision int) (*EnvironmentRevision, error)
@@ -685,6 +685,7 @@ type ListEnvironmentTagsOptions struct {
 func (pc *client) ListEnvironmentTags(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	options ListEnvironmentTagsOptions,
 ) ([]*EnvironmentTag, string, error) {
@@ -705,7 +706,7 @@ func (pc *client) ListEnvironmentTags(
 // CreateEnvironmentTag creates and applies a tag to the given environment.
 func (pc *client) CreateEnvironmentTag(
 	ctx context.Context,
-	orgName, envName, key, value string,
+	orgName, projectName, envName, key, value string,
 ) (*EnvironmentTag, error) {
 	var resp EnvironmentTag
 	req := CreateEnvironmentTagRequest{
@@ -722,7 +723,7 @@ func (pc *client) CreateEnvironmentTag(
 
 func (pc *client) GetEnvironmentTag(
 	ctx context.Context,
-	orgName, envName, key string,
+	orgName, projectName, envName, key string,
 ) (*EnvironmentTag, error) {
 	var resp EnvironmentTag
 	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/tags/%v", orgName, projectName, envName, key)
@@ -736,7 +737,7 @@ func (pc *client) GetEnvironmentTag(
 // UpdateEnvironmentTag updates a specified environment tag with a new key / value.
 func (pc *client) UpdateEnvironmentTag(
 	ctx context.Context,
-	orgName, envName, currentKey, currentValue, newKey, newValue string,
+	orgName, projectName, envName, currentKey, currentValue, newKey, newValue string,
 ) (*EnvironmentTag, error) {
 	var resp EnvironmentTag
 	req := UpdateEnvironmentTagRequest{
@@ -760,7 +761,7 @@ func (pc *client) UpdateEnvironmentTag(
 }
 
 // DeleteEnvironmentTag deletes a specified tag on an environment.
-func (pc *client) DeleteEnvironmentTag(ctx context.Context, orgName, envName, tagName string) error {
+func (pc *client) DeleteEnvironmentTag(ctx context.Context, orgName, projectName, envName, tagName string) error {
 	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/tags/%v", orgName, projectName, envName, tagName)
 	return pc.restCall(ctx, http.MethodDelete, path, nil, nil, nil)
 }

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -218,7 +218,7 @@ type Client interface {
 	DeleteEnvironmentTag(ctx context.Context, orgName, projectName, envName, tagName string) error
 
 	// GetEnvironmentRevision returns a description of the given revision.
-	GetEnvironmentRevision(ctx context.Context, orgName, envName string, revision int) (*EnvironmentRevision, error)
+	GetEnvironmentRevision(ctx context.Context, orgName, projectName, envName string, revision int) (*EnvironmentRevision, error)
 
 	// ListEnvironmentRevisions returns a list of revisions to the named environments in reverse order by
 	// revision number. The revision at which to start and the number of revisions to return are
@@ -226,6 +226,7 @@ type Client interface {
 	ListEnvironmentRevisions(
 		ctx context.Context,
 		orgName string,
+		projectName string,
 		envName string,
 		options ListEnvironmentRevisionsOptions,
 	) ([]EnvironmentRevision, error)
@@ -234,6 +235,7 @@ type Client interface {
 	RetractEnvironmentRevision(
 		ctx context.Context,
 		orgName string,
+		projectName string,
 		envName string,
 		version string,
 		replacement *int,
@@ -770,13 +772,14 @@ func (pc *client) DeleteEnvironmentTag(ctx context.Context, orgName, projectName
 func (pc *client) GetEnvironmentRevision(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	revision int,
 ) (*EnvironmentRevision, error) {
 	before, count := revision+1, 1
 
 	opts := ListEnvironmentRevisionsOptions{Before: &before, Count: &count}
-	revs, err := pc.ListEnvironmentRevisions(ctx, orgName, envName, opts)
+	revs, err := pc.ListEnvironmentRevisions(ctx, orgName, projectName, envName, opts)
 	if err != nil || len(revs) == 0 {
 		return nil, err
 	}
@@ -791,6 +794,7 @@ type ListEnvironmentRevisionsOptions struct {
 func (pc *client) ListEnvironmentRevisions(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	options ListEnvironmentRevisionsOptions,
 ) ([]EnvironmentRevision, error) {
@@ -807,6 +811,7 @@ func (pc *client) ListEnvironmentRevisions(
 func (pc *client) RetractEnvironmentRevision(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	version string,
 	replacement *int,

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -93,6 +93,7 @@ type Client interface {
 	GetEnvironment(
 		ctx context.Context,
 		orgName string,
+		projectName string,
 		envName string,
 		version string,
 		decrypt bool,
@@ -133,7 +134,7 @@ type Client interface {
 	) ([]EnvironmentDiagnostic, error)
 
 	// DeleteEnvironment deletes the environment envName in org orgName.
-	DeleteEnvironment(ctx context.Context, orgName, envName string) error
+	DeleteEnvironment(ctx context.Context, orgName, projectName, envName string) error
 
 	// OpenEnvironment evaluates the environment envName in org orgName and returns the ID of the opened
 	// environment. The opened environment will be available for the indicated duration, after which it
@@ -143,6 +144,7 @@ type Client interface {
 	OpenEnvironment(
 		ctx context.Context,
 		orgName string,
+		projectName string,
 		envName string,
 		version string,
 		duration time.Duration,
@@ -389,9 +391,9 @@ func (pc *client) GetPulumiAccountDetails(ctx context.Context) (string, []string
 
 // resolveEnvironmentPath resolves an environment and revision or tag to its API path.
 //
-// If version begins with a digit, it is treated as a revision number. Otherwise, it is trated as a tag. If
-// no revision or tag is present, the "latest" tag is used.
-func (pc *client) resolveEnvironmentPath(ctx context.Context, orgName, envName, version string) (string, error) {
+// If version begins with a digit, it is treated as a revision number. Otherwise, it is treated as a tag.
+// If no revision or tag is present, the "latest" tag is used.
+func (pc *client) resolveEnvironmentPath(orgName, projectName, envName, version string) (string, error) {
 	if version == "" {
 		return fmt.Sprintf("/api/esc/environments/%v/%v/%v", orgName, projectName, envName), nil
 	}
@@ -453,11 +455,12 @@ func (pc *client) CreateEnvironmentWithProject(ctx context.Context, orgName, pro
 func (pc *client) GetEnvironment(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	version string,
 	decrypt bool,
 ) ([]byte, string, int, error) {
-	path, err := pc.resolveEnvironmentPath(ctx, orgName, envName, version)
+	path, err := pc.resolveEnvironmentPath(orgName, projectName, envName, version)
 	if err != nil {
 		return nil, "", 0, err
 	}
@@ -540,7 +543,7 @@ func (pc *client) UpdateEnvironmentWithRevision(
 	return nil, revision, nil
 }
 
-func (pc *client) DeleteEnvironment(ctx context.Context, orgName, envName string) error {
+func (pc *client) DeleteEnvironment(ctx context.Context, orgName, projectName, envName string) error {
 	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v", orgName, projectName, envName)
 	return pc.restCall(ctx, http.MethodDelete, path, nil, nil, nil)
 }
@@ -548,11 +551,12 @@ func (pc *client) DeleteEnvironment(ctx context.Context, orgName, envName string
 func (pc *client) OpenEnvironment(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	version string,
 	duration time.Duration,
 ) (string, []EnvironmentDiagnostic, error) {
-	path, err := pc.resolveEnvironmentPath(ctx, orgName, envName, version)
+	path, err := pc.resolveEnvironmentPath(orgName, projectName, envName, version)
 	if err != nil {
 		return "", nil, err
 	}

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -390,9 +390,9 @@ func (pc *client) GetPulumiAccountDetails(ctx context.Context) (string, []string
 // no revision or tag is present, the "latest" tag is used.
 func (pc *client) resolveEnvironmentPath(ctx context.Context, orgName, envName, version string) (string, error) {
 	if version == "" {
-		return fmt.Sprintf("/api/preview/environments/%v/%v", orgName, envName), nil
+		return fmt.Sprintf("/api/esc/environments/%v/%v/%v", orgName, projectName, envName), nil
 	}
-	return fmt.Sprintf("/api/preview/environments/%v/%v/versions/%v", orgName, envName, version), nil
+	return fmt.Sprintf("/api/esc/environments/%v/%v/%v/versions/%v", orgName, projectName, envName, version), nil
 }
 
 func (pc *client) GetRevisionNumber(ctx context.Context, orgName, envName, version string) (int, error) {
@@ -406,7 +406,7 @@ func (pc *client) GetRevisionNumber(ctx context.Context, orgName, envName, versi
 		return int(rev), nil
 	}
 
-	path := fmt.Sprintf("/api/preview/environments/%v/%v/versions/tags/%v", orgName, envName, version)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/versions/tags/%v", orgName, projectName, envName, version)
 
 	var resp EnvironmentRevisionTag
 	if err := pc.restCall(ctx, http.MethodGet, path, nil, nil, &resp); err != nil {
@@ -429,7 +429,7 @@ func (pc *client) ListEnvironments(
 	}
 
 	var resp ListEnvironmentsResponse
-	err := pc.restCall(ctx, http.MethodGet, "/api/preview/environments", queryObj, nil, &resp)
+	err := pc.restCall(ctx, http.MethodGet, "/api/esc/environments", queryObj, nil, &resp)
 	if err != nil {
 		return nil, "", err
 	}
@@ -443,7 +443,7 @@ func (pc *client) CreateEnvironment(ctx context.Context, orgName, envName string
 
 // CreateEnvironmentWithProject creates an environment named envName in org orgName and project projectName.
 func (pc *client) CreateEnvironmentWithProject(ctx context.Context, orgName, projectName, envName string) error {
-	path := fmt.Sprintf("/api/preview/environments/%v/%v", orgName, envName)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v", orgName, projectName, envName)
 	return pc.restCall(ctx, http.MethodPost, path, nil, nil, nil)
 }
 
@@ -515,7 +515,7 @@ func (pc *client) UpdateEnvironmentWithRevision(
 	}
 
 	var errResp EnvironmentErrorResponse
-	path := fmt.Sprintf("/api/preview/environments/%v/%v", orgName, envName)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v", orgName, projectName, envName)
 	var resp *http.Response
 	err := pc.restCallWithOptions(ctx, http.MethodPatch, path, nil, json.RawMessage(yaml), &resp, httpCallOptions{
 		Header:        header,
@@ -538,7 +538,7 @@ func (pc *client) UpdateEnvironmentWithRevision(
 }
 
 func (pc *client) DeleteEnvironment(ctx context.Context, orgName, envName string) error {
-	path := fmt.Sprintf("/api/preview/environments/%v/%v", orgName, envName)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v", orgName, projectName, envName)
 	return pc.restCall(ctx, http.MethodDelete, path, nil, nil, nil)
 }
 
@@ -592,7 +592,7 @@ func (pc *client) CheckYAMLEnvironment(
 	// to any part of the client API to break the ESC CLI build. So we're limited to non-breaking changes, including adding
 	// variadic args or adding additional methods.
 
-	path := fmt.Sprintf("/api/preview/environments/%v/yaml/check", orgName)
+	path := fmt.Sprintf("/api/esc/environments/%v/yaml/check", orgName)
 
 	queryObj := struct {
 		ShowSecrets bool `url:"showSecrets"`
@@ -631,7 +631,7 @@ func (pc *client) OpenYAMLEnvironment(
 		ID string `json:"id"`
 	}
 	var errResp EnvironmentErrorResponse
-	path := fmt.Sprintf("/api/preview/environments/%v/yaml/open", orgName)
+	path := fmt.Sprintf("/api/esc/environments/%v/yaml/open", orgName)
 	err := pc.restCallWithOptions(ctx, http.MethodPost, path, queryObj, json.RawMessage(yaml), &resp, httpCallOptions{
 		ErrorResponse: &errResp,
 	})
@@ -652,7 +652,7 @@ func (pc *client) GetOpenEnvironment(ctx context.Context, orgName, envName, open
 
 func (pc *client) GetOpenEnvironmentWithProject(ctx context.Context, orgName, projectName, envName, openSessionID string) (*esc.Environment, error) {
 	var resp esc.Environment
-	path := fmt.Sprintf("/api/preview/environments/%v/%v/open/%v", orgName, envName, openSessionID)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/open/%v", orgName, projectName, envName, openSessionID)
 	err := pc.restCall(ctx, http.MethodGet, path, nil, nil, &resp)
 	if err != nil {
 		return nil, err
@@ -668,7 +668,7 @@ func (pc *client) GetOpenProperty(ctx context.Context, orgName, envName, openSes
 	}
 
 	var resp esc.Value
-	path := fmt.Sprintf("/api/preview/environments/%v/%v/open/%v", orgName, envName, openSessionID)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/open/%v", orgName, projectName, envName, openSessionID)
 	err := pc.restCall(ctx, http.MethodGet, path, queryObj, nil, &resp)
 	if err != nil {
 		return nil, err
@@ -689,7 +689,7 @@ func (pc *client) ListEnvironmentTags(
 	options ListEnvironmentTagsOptions,
 ) ([]*EnvironmentTag, string, error) {
 	var resp ListEnvironmentTagsResponse
-	path := fmt.Sprintf("/api/preview/environments/%v/%v/tags", orgName, envName)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/tags", orgName, projectName, envName)
 	err := pc.restCall(ctx, http.MethodGet, path, options, nil, &resp)
 	if err != nil {
 		return nil, "", err
@@ -712,7 +712,7 @@ func (pc *client) CreateEnvironmentTag(
 		Name:  key,
 		Value: value,
 	}
-	path := fmt.Sprintf("/api/preview/environments/%v/%v/tags", orgName, envName)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/tags", orgName, projectName, envName)
 	err := pc.restCall(ctx, http.MethodPost, path, nil, &req, &resp)
 	if err != nil {
 		return nil, err
@@ -725,7 +725,7 @@ func (pc *client) GetEnvironmentTag(
 	orgName, envName, key string,
 ) (*EnvironmentTag, error) {
 	var resp EnvironmentTag
-	path := fmt.Sprintf("/api/preview/environments/%v/%v/tags/%v", orgName, envName, key)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/tags/%v", orgName, projectName, envName, key)
 	err := pc.restCall(ctx, http.MethodGet, path, nil, nil, &resp)
 	if err != nil {
 		return nil, err
@@ -751,7 +751,7 @@ func (pc *client) UpdateEnvironmentTag(
 	if newValue != "" {
 		req.NewTag.Value = newValue
 	}
-	path := fmt.Sprintf("/api/preview/environments/%v/%v/tags/%v", orgName, envName, currentKey)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/tags/%v", orgName, projectName, envName, currentKey)
 	err := pc.restCall(ctx, http.MethodPatch, path, nil, &req, &resp)
 	if err != nil {
 		return nil, err
@@ -761,7 +761,7 @@ func (pc *client) UpdateEnvironmentTag(
 
 // DeleteEnvironmentTag deletes a specified tag on an environment.
 func (pc *client) DeleteEnvironmentTag(ctx context.Context, orgName, envName, tagName string) error {
-	path := fmt.Sprintf("/api/preview/environments/%v/%v/tags/%v", orgName, envName, tagName)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/tags/%v", orgName, projectName, envName, tagName)
 	return pc.restCall(ctx, http.MethodDelete, path, nil, nil, nil)
 }
 
@@ -794,7 +794,7 @@ func (pc *client) ListEnvironmentRevisions(
 	options ListEnvironmentRevisionsOptions,
 ) ([]EnvironmentRevision, error) {
 	var resp []EnvironmentRevision
-	path := fmt.Sprintf("/api/preview/environments/%v/%v/versions", orgName, envName)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/versions", orgName, projectName, envName)
 	err := pc.restCall(ctx, http.MethodGet, path, options, nil, &resp)
 	if err != nil {
 		return nil, err
@@ -815,7 +815,7 @@ func (pc *client) RetractEnvironmentRevision(
 		Replacement: replacement,
 		Reason:      reason,
 	}
-	path := fmt.Sprintf("/api/preview/environments/%v/%v/versions/%v/retract", orgName, envName, version)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/versions/%v/retract", orgName, projectName, envName, version)
 	return pc.restCall(ctx, http.MethodPost, path, nil, &req, nil)
 }
 
@@ -828,7 +828,7 @@ func (pc *client) CreateEnvironmentRevisionTag(
 	revision *int,
 ) error {
 	req := CreateEnvironmentRevisionTagRequest{Revision: revision}
-	path := fmt.Sprintf("/api/preview/environments/%v/%v/versions/tags/%v", orgName, envName, tagName)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/versions/tags/%v", orgName, projectName, envName, tagName)
 	return pc.restCall(ctx, http.MethodPost, path, nil, &req, nil)
 }
 
@@ -840,7 +840,7 @@ func (pc *client) GetEnvironmentRevisionTag(
 	tagName string,
 ) (*EnvironmentRevisionTag, error) {
 	var resp EnvironmentRevisionTag
-	path := fmt.Sprintf("/api/preview/environments/%v/%v/versions/tags/%v", orgName, envName, tagName)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/versions/tags/%v", orgName, projectName, envName, tagName)
 	err := pc.restCall(ctx, http.MethodGet, path, nil, nil, &resp)
 	if err != nil {
 		return nil, err
@@ -857,7 +857,7 @@ func (pc *client) UpdateEnvironmentRevisionTag(
 	revision *int,
 ) error {
 	req := UpdateEnvironmentRevisionTagRequest{Revision: revision}
-	path := fmt.Sprintf("/api/preview/environments/%v/%v/versions/tags/%v", orgName, envName, tagName)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/versions/tags/%v", orgName, projectName, envName, tagName)
 	return pc.restCall(ctx, http.MethodPatch, path, nil, &req, nil)
 }
 
@@ -868,7 +868,7 @@ func (pc *client) DeleteEnvironmentRevisionTag(
 	envName string,
 	tagName string,
 ) error {
-	path := fmt.Sprintf("/api/preview/environments/%v/%v/versions/tags/%v", orgName, envName, tagName)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/versions/tags/%v", orgName, projectName, envName, tagName)
 	return pc.restCall(ctx, http.MethodDelete, path, nil, nil, nil)
 }
 
@@ -885,7 +885,7 @@ func (pc *client) ListEnvironmentRevisionTags(
 	options ListEnvironmentRevisionTagsOptions,
 ) ([]EnvironmentRevisionTag, error) {
 	var resp ListEnvironmentRevisionTagsResponse
-	path := fmt.Sprintf("/api/preview/environments/%v/%v/versions/tags", orgName, envName)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/versions/tags", orgName, projectName, envName)
 	err := pc.restCall(ctx, http.MethodGet, path, options, nil, &resp)
 	if err != nil {
 		return nil, err

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -66,7 +66,7 @@ type Client interface {
 	GetPulumiAccountDetails(ctx context.Context) (string, []string, *workspace.TokenInformation, error)
 
 	// GetRevisionNumber returns the revision number for version.
-	GetRevisionNumber(ctx context.Context, orgName, envName, version string) (int, error)
+	GetRevisionNumber(ctx context.Context, orgName, projectName, envName, version string) (int, error)
 
 	// ListEnvironments lists all environments in the given org that are accessible to the calling user.
 	//
@@ -109,6 +109,7 @@ type Client interface {
 	UpdateEnvironmentWithRevision(
 		ctx context.Context,
 		orgName string,
+		projectName string,
 		envName string,
 		yaml []byte,
 		etag string,
@@ -189,7 +190,7 @@ type Client interface {
 	//     aws.login
 	//     environmentVariables["AWS_ACCESS_KEY_ID"]
 	//
-	GetOpenProperty(ctx context.Context, orgName, envName, openEnvID, property string) (*esc.Value, error)
+	GetOpenProperty(ctx context.Context, orgName, projectName, envName, openEnvID, property string) (*esc.Value, error)
 
 	// ListEnvironmentTags lists the tags for the given environment.
 	ListEnvironmentTags(
@@ -400,7 +401,7 @@ func (pc *client) resolveEnvironmentPath(orgName, projectName, envName, version 
 	return fmt.Sprintf("/api/esc/environments/%v/%v/%v/versions/%v", orgName, projectName, envName, version), nil
 }
 
-func (pc *client) GetRevisionNumber(ctx context.Context, orgName, envName, version string) (int, error) {
+func (pc *client) GetRevisionNumber(ctx context.Context, orgName, projectName, envName, version string) (int, error) {
 	if version == "" {
 		version = "latest"
 	} else if version[0] >= '0' && version[0] <= '9' {
@@ -504,13 +505,14 @@ func (pc *client) UpdateEnvironmentWithProject(
 	yaml []byte,
 	tag string,
 ) ([]EnvironmentDiagnostic, error) {
-	diags, _, err := pc.UpdateEnvironmentWithRevision(ctx, orgName, envName, yaml, tag)
+	diags, _, err := pc.UpdateEnvironmentWithRevision(ctx, orgName, projectName, envName, yaml, tag)
 	return diags, err
 }
 
 func (pc *client) UpdateEnvironmentWithRevision(
 	ctx context.Context,
 	orgName string,
+	projectName string,
 	envName string,
 	yaml []byte,
 	tag string,
@@ -667,7 +669,7 @@ func (pc *client) GetOpenEnvironmentWithProject(ctx context.Context, orgName, pr
 	return &resp, nil
 }
 
-func (pc *client) GetOpenProperty(ctx context.Context, orgName, envName, openSessionID, property string) (*esc.Value, error) {
+func (pc *client) GetOpenProperty(ctx context.Context, orgName, projectName, envName, openSessionID, property string) (*esc.Value, error) {
 	queryObj := struct {
 		Property string `url:"property"`
 	}{

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -259,6 +259,14 @@ type Client interface {
 		envName string,
 		options ListEnvironmentRevisionTagsOptions,
 	) ([]EnvironmentRevisionTag, error)
+
+	// EnvironmentExists checks if the specified environment exists.
+	EnvironmentExists(
+		ctx context.Context,
+		orgName string,
+		projectName string,
+		envName string,
+	) (exists bool, err error)
 }
 
 type client struct {
@@ -883,6 +891,26 @@ func (pc *client) ListEnvironmentRevisionTags(
 		return nil, err
 	}
 	return resp.Tags, nil
+}
+
+// EnvironmentExists checks if the specified environment exists.
+func (pc *client) EnvironmentExists(
+	ctx context.Context,
+	orgName string,
+	projectName string,
+	envName string,
+) (bool, error) {
+	path, err := pc.resolveEnvironmentPath(orgName, projectName, envName, "")
+	if err != nil {
+		return false, err
+	}
+
+	var resp *http.Response
+	if err := pc.restCall(ctx, http.MethodGet, path, nil, nil, &resp); err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 type httpCallOptions struct {

--- a/cmd/esc/cli/client/client_test.go
+++ b/cmd/esc/cli/client/client_test.go
@@ -201,7 +201,7 @@ func TestGetEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		actualYAML, actualTag, revision, err := client.GetEnvironment(context.Background(), "test-org", "test-env", "", false)
+		actualYAML, actualTag, revision, err := client.GetEnvironment(context.Background(), "test-org", "test-project", "test-env", "", false)
 		require.NoError(t, err)
 		assert.Equal(t, string(expectedYAML), string(actualYAML))
 		assert.Equal(t, expectedTag, actualTag)
@@ -219,7 +219,7 @@ func TestGetEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		actualYAML, actualTag, revision, err := client.GetEnvironment(context.Background(), "test-org", "test-env", "42", false)
+		actualYAML, actualTag, revision, err := client.GetEnvironment(context.Background(), "test-org", "test-project", "test-env", "42", false)
 		require.NoError(t, err)
 		assert.Equal(t, string(expectedYAML), string(actualYAML))
 		assert.Equal(t, expectedTag, actualTag)
@@ -239,7 +239,7 @@ func TestGetEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		actualYAML, actualTag, revision, err := client.GetEnvironment(context.Background(), "test-org", "test-env", "stable", false)
+		actualYAML, actualTag, revision, err := client.GetEnvironment(context.Background(), "test-org", "test-project", "test-env", "stable", false)
 		require.NoError(t, err)
 		assert.Equal(t, string(expectedYAML), string(actualYAML))
 		assert.Equal(t, expectedTag, actualTag)
@@ -257,7 +257,7 @@ func TestGetEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		actualYAML, actualTag, revision, err := client.GetEnvironment(context.Background(), "test-org", "test-env", "", true)
+		actualYAML, actualTag, revision, err := client.GetEnvironment(context.Background(), "test-org", "test-project", "test-env", "", true)
 		require.NoError(t, err)
 		assert.Equal(t, string(expectedYAML), string(actualYAML))
 		assert.Equal(t, expectedTag, actualTag)
@@ -275,7 +275,7 @@ func TestGetEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		_, _, _, err := client.GetEnvironment(context.Background(), "test-org", "test-env", "", false)
+		_, _, _, err := client.GetEnvironment(context.Background(), "test-org", "test-project", "test-env", "", false)
 		assert.ErrorContains(t, err, "not found")
 	})
 }
@@ -360,7 +360,7 @@ func TestDeleteEnvironment(t *testing.T) {
 		client := newTestClient(t, http.MethodDelete, "/api/esc/environments/test-org/test-project/test-env", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
-		err := client.DeleteEnvironment(context.Background(), "test-org", "test-env")
+		err := client.DeleteEnvironment(context.Background(), "test-org", "test-project", "test-env")
 		assert.NoError(t, err)
 	})
 }
@@ -377,7 +377,7 @@ func TestOpenEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		id, diags, err := client.OpenEnvironment(context.Background(), "test-org", "test-env", "", duration)
+		id, diags, err := client.OpenEnvironment(context.Background(), "test-org", "test-project", "test-env", "", duration)
 		require.NoError(t, err)
 		assert.Equal(t, expectedID, id)
 		assert.Empty(t, diags)
@@ -394,7 +394,7 @@ func TestOpenEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		id, diags, err := client.OpenEnvironment(context.Background(), "test-org", "test-env", "42", duration)
+		id, diags, err := client.OpenEnvironment(context.Background(), "test-org", "test-project", "test-env", "42", duration)
 		require.NoError(t, err)
 		assert.Equal(t, expectedID, id)
 		assert.Empty(t, diags)
@@ -413,7 +413,7 @@ func TestOpenEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		id, diags, err := client.OpenEnvironment(context.Background(), "test-org", "test-env", "stable", duration)
+		id, diags, err := client.OpenEnvironment(context.Background(), "test-org", "test-project", "test-env", "stable", duration)
 		require.NoError(t, err)
 		assert.Equal(t, expectedID, id)
 		assert.Empty(t, diags)
@@ -450,7 +450,7 @@ func TestOpenEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		_, diags, err := client.OpenEnvironment(context.Background(), "test-org", "test-env", "", 2*time.Hour)
+		_, diags, err := client.OpenEnvironment(context.Background(), "test-org", "test-project", "test-env", "", 2*time.Hour)
 		require.NoError(t, err)
 		assert.Equal(t, expected, diags)
 	})
@@ -466,7 +466,7 @@ func TestOpenEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		_, _, err := client.OpenEnvironment(context.Background(), "test-org", "test-env", "", 2*time.Hour)
+		_, _, err := client.OpenEnvironment(context.Background(), "test-org", "test-project", "test-env", "", 2*time.Hour)
 		assert.ErrorContains(t, err, "not found")
 	})
 }

--- a/cmd/esc/cli/client/client_test.go
+++ b/cmd/esc/cli/client/client_test.go
@@ -685,7 +685,7 @@ func TestGetEnvironmentTag(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		tag, err := client.GetEnvironmentTag(context.Background(), "test-org", "test-env", "owner")
+		tag, err := client.GetEnvironmentTag(context.Background(), "test-org", "test-project", "test-env", "owner")
 
 		require.NoError(t, err)
 		assert.Equal(t, expectedTag.ID, tag.ID)
@@ -708,7 +708,7 @@ func TestGetEnvironmentTag(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		_, err := client.GetEnvironmentTag(context.Background(), "test-org", "test-env", "owner")
+		_, err := client.GetEnvironmentTag(context.Background(), "test-org", "test-project", "test-env", "owner")
 		assert.ErrorContains(t, err, http.StatusText(http.StatusNotFound))
 	})
 }
@@ -744,7 +744,7 @@ func TestListEnvironmentTags(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		val, next, err := client.ListEnvironmentTags(context.Background(), "test-org", "test-env", ListEnvironmentTagsOptions{
+		val, next, err := client.ListEnvironmentTags(context.Background(), "test-org", "test-project", "test-env", ListEnvironmentTagsOptions{
 			After: after,
 			Count: &count,
 		})
@@ -773,7 +773,7 @@ func TestListEnvironmentTags(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		_, _, err := client.ListEnvironmentTags(context.Background(), "test-org", "test-env", ListEnvironmentTagsOptions{})
+		_, _, err := client.ListEnvironmentTags(context.Background(), "test-org", "test-project", "test-env", ListEnvironmentTagsOptions{})
 		assert.ErrorContains(t, err, http.StatusText(http.StatusNotFound))
 	})
 }
@@ -797,7 +797,7 @@ func TestCreateEnvironmentTags(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		val, err := client.CreateEnvironmentTag(context.Background(), "test-org", "test-env", "owner", "pulumi")
+		val, err := client.CreateEnvironmentTag(context.Background(), "test-org", "test-project", "test-env", "owner", "pulumi")
 		require.NoError(t, err)
 		assert.Equal(t, expectedTag.ID, val.ID)
 		assert.Equal(t, expectedTag.Created.UTC(), val.Created.UTC())
@@ -819,7 +819,7 @@ func TestCreateEnvironmentTags(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		_, err := client.CreateEnvironmentTag(context.Background(), "test-org", "test-env", "owner", "pulumi")
+		_, err := client.CreateEnvironmentTag(context.Background(), "test-org", "test-project", "test-env", "owner", "pulumi")
 		assert.ErrorContains(t, err, http.StatusText(http.StatusBadRequest))
 	})
 }
@@ -858,7 +858,7 @@ func TestUpdateEnvironmentTags(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		val, err := client.UpdateEnvironmentTag(context.Background(), "test-org", "test-env", "owner", "pulumi", "", "pulumipus")
+		val, err := client.UpdateEnvironmentTag(context.Background(), "test-org", "test-project", "test-env", "owner", "pulumi", "", "pulumipus")
 		require.NoError(t, err)
 		assert.Equal(t, expectedTag.ID, val.ID)
 		assert.Equal(t, expectedTag.Created.UTC(), val.Created.UTC())
@@ -902,7 +902,7 @@ func TestUpdateEnvironmentTags(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		val, err := client.UpdateEnvironmentTag(context.Background(), "test-org", "test-env", "owner", "pulumi", "team", "")
+		val, err := client.UpdateEnvironmentTag(context.Background(), "test-org", "test-project", "test-env", "owner", "pulumi", "team", "")
 		require.NoError(t, err)
 		assert.Equal(t, expectedTag.ID, val.ID)
 		assert.Equal(t, expectedTag.Created.UTC(), val.Created.UTC())
@@ -924,7 +924,7 @@ func TestUpdateEnvironmentTags(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		_, err := client.UpdateEnvironmentTag(context.Background(), "test-org", "test-env", "owner", "pulumi", "team", "")
+		_, err := client.UpdateEnvironmentTag(context.Background(), "test-org", "test-project", "test-env", "owner", "pulumi", "team", "")
 		assert.ErrorContains(t, err, http.StatusText(http.StatusNotFound))
 	})
 }
@@ -935,7 +935,7 @@ func TestDeleteEnvironmentTags(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		err := client.DeleteEnvironmentTag(context.Background(), "test-org", "test-env", "tagName")
+		err := client.DeleteEnvironmentTag(context.Background(), "test-org", "test-project", "test-env", "tagName")
 		require.NoError(t, err)
 	})
 
@@ -950,7 +950,7 @@ func TestDeleteEnvironmentTags(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		err := client.DeleteEnvironmentTag(context.Background(), "test-org", "test-env", "tagName")
+		err := client.DeleteEnvironmentTag(context.Background(), "test-org", "test-project", "test-env", "tagName")
 		assert.ErrorContains(t, err, http.StatusText(http.StatusNotFound))
 	})
 }

--- a/cmd/esc/cli/client/client_test.go
+++ b/cmd/esc/cli/client/client_test.go
@@ -169,7 +169,7 @@ func TestCreateEnvironment(t *testing.T) {
 		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/test-project/test-env", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
-		err := client.CreateEnvironment(context.Background(), "test-org", "test-env")
+		err := client.CreateEnvironmentWithProject(context.Background(), "test-org", "test-project", "test-env")
 		assert.NoError(t, err)
 	})
 
@@ -183,7 +183,7 @@ func TestCreateEnvironment(t *testing.T) {
 			})
 			require.NoError(t, err)
 		})
-		err := client.CreateEnvironment(context.Background(), "test-org", "test-env")
+		err := client.CreateEnvironmentWithProject(context.Background(), "test-org", "test-project", "test-env")
 		assert.ErrorContains(t, err, "conflict")
 	})
 
@@ -612,7 +612,7 @@ func TestGetOpenEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		env, err := client.GetOpenEnvironment(context.Background(), "test-org", "test-env", "session")
+		env, err := client.GetOpenEnvironmentWithProject(context.Background(), "test-org", "test-project", "test-env", "session")
 		require.NoError(t, err)
 		assert.Equal(t, expected, env)
 	})
@@ -628,7 +628,7 @@ func TestGetOpenEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		_, err := client.GetOpenEnvironment(context.Background(), "test-org", "test-env", "session")
+		_, err := client.GetOpenEnvironmentWithProject(context.Background(), "test-org", "test-project", "test-env", "session")
 		assert.ErrorContains(t, err, "not found")
 	})
 }

--- a/cmd/esc/cli/client/client_test.go
+++ b/cmd/esc/cli/client/client_test.go
@@ -103,7 +103,7 @@ func TestListEnvironments(t *testing.T) {
 
 		expectedToken := "next-token"
 
-		client := newTestClient(t, http.MethodGet, "/api/preview/environments", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "", r.URL.Query().Get("continuationToken"))
 			assert.Equal(t, "", r.URL.Query().Get("organization"))
 
@@ -129,7 +129,7 @@ func TestListEnvironments(t *testing.T) {
 
 		expectedToken := "next-token"
 
-		client := newTestClient(t, http.MethodGet, "/api/preview/environments", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "", r.URL.Query().Get("continuationToken"))
 			assert.Equal(t, org, r.URL.Query().Get("organization"))
 
@@ -149,7 +149,7 @@ func TestListEnvironments(t *testing.T) {
 	t.Run("token", func(t *testing.T) {
 		token := "next-token"
 
-		client := newTestClient(t, http.MethodGet, "/api/preview/environments", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, token, r.URL.Query().Get("continuationToken"))
 			assert.Equal(t, "", r.URL.Query().Get("organization"))
 
@@ -166,7 +166,7 @@ func TestListEnvironments(t *testing.T) {
 
 func TestCreateEnvironment(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
-		client := newTestClient(t, http.MethodPost, "/api/preview/environments/test-org/test-env", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/test-project/test-env", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
 		err := client.CreateEnvironment(context.Background(), "test-org", "test-env")
@@ -174,7 +174,7 @@ func TestCreateEnvironment(t *testing.T) {
 	})
 
 	t.Run("Conflict", func(t *testing.T) {
-		client := newTestClient(t, http.MethodPost, "/api/preview/environments/test-org/test-env", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/test-project/test-env", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusConflict)
 
 			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
@@ -194,7 +194,7 @@ func TestGetEnvironment(t *testing.T) {
 		expectedYAML := []byte("arbitrary content")
 		expectedTag := "new-tag"
 
-		client := newTestClient(t, http.MethodGet, "/api/preview/environments/test-org/test-env", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/test-org/test-project/test-env", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("ETag", expectedTag)
 			w.Header().Set(revisionHeader, "1")
 			_, err := w.Write(expectedYAML)
@@ -212,7 +212,7 @@ func TestGetEnvironment(t *testing.T) {
 		expectedYAML := []byte("arbitrary content")
 		expectedTag := "new-tag"
 
-		client := newTestClient(t, http.MethodGet, "/api/preview/environments/test-org/test-env/versions/42", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/test-org/test-project/test-env/versions/42", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("ETag", expectedTag)
 			w.Header().Set(revisionHeader, "1")
 			_, err := w.Write(expectedYAML)
@@ -232,7 +232,7 @@ func TestGetEnvironment(t *testing.T) {
 
 		mux, client := newTestServer(t)
 
-		mux.HandleFunc("/api/preview/environments/test-org/test-env/versions/stable", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("/api/esc/environments/test-org/test-project/test-env/versions/stable", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("ETag", expectedTag)
 			w.Header().Set(revisionHeader, "1")
 			_, err := w.Write(expectedYAML)
@@ -250,7 +250,7 @@ func TestGetEnvironment(t *testing.T) {
 		expectedYAML := []byte("arbitrary content")
 		expectedTag := "new-tag"
 
-		client := newTestClient(t, http.MethodGet, "/api/preview/environments/test-org/test-env/decrypt", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/test-org/test-project/test-env/decrypt", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("ETag", expectedTag)
 			w.Header().Set(revisionHeader, "1")
 			_, err := w.Write(expectedYAML)
@@ -265,7 +265,7 @@ func TestGetEnvironment(t *testing.T) {
 	})
 
 	t.Run("Not found", func(t *testing.T) {
-		client := newTestClient(t, http.MethodGet, "/api/preview/environments/test-org/test-env", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/test-org/test-project/test-env", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 
 			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
@@ -285,7 +285,7 @@ func TestUpdateEnvironment(t *testing.T) {
 		yaml := []byte("new definition")
 		tag := "old tag"
 
-		client := newTestClient(t, http.MethodPatch, "/api/preview/environments/test-org/test-env", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPatch, "/api/esc/environments/test-org/test-project/test-env", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, tag, r.Header.Get("ETag"))
 
 			body, err := io.ReadAll(r.Body)
@@ -322,7 +322,7 @@ func TestUpdateEnvironment(t *testing.T) {
 			},
 		}
 
-		client := newTestClient(t, http.MethodPatch, "/api/preview/environments/test-org/test-env", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPatch, "/api/esc/environments/test-org/test-project/test-env", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 
 			err := json.NewEncoder(w).Encode(EnvironmentErrorResponse{
@@ -340,7 +340,7 @@ func TestUpdateEnvironment(t *testing.T) {
 	})
 
 	t.Run("Conflict", func(t *testing.T) {
-		client := newTestClient(t, http.MethodPatch, "/api/preview/environments/test-org/test-env", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPatch, "/api/esc/environments/test-org/test-project/test-env", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusConflict)
 
 			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
@@ -357,7 +357,7 @@ func TestUpdateEnvironment(t *testing.T) {
 
 func TestDeleteEnvironment(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
-		client := newTestClient(t, http.MethodDelete, "/api/preview/environments/test-org/test-env", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodDelete, "/api/esc/environments/test-org/test-project/test-env", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
 		err := client.DeleteEnvironment(context.Background(), "test-org", "test-env")
@@ -370,7 +370,7 @@ func TestOpenEnvironment(t *testing.T) {
 		const expectedID = "open-id"
 		duration := 2 * time.Hour
 
-		client := newTestClient(t, http.MethodPost, "/api/preview/environments/test-org/test-env/open", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/test-project/test-env/open", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, duration.String(), r.URL.Query().Get("duration"))
 
 			err := json.NewEncoder(w).Encode(map[string]any{"id": expectedID})
@@ -387,7 +387,7 @@ func TestOpenEnvironment(t *testing.T) {
 		const expectedID = "open-id"
 		duration := 2 * time.Hour
 
-		client := newTestClient(t, http.MethodPost, "/api/preview/environments/test-org/test-env/versions/42/open", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/test-project/test-env/versions/42/open", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, duration.String(), r.URL.Query().Get("duration"))
 
 			err := json.NewEncoder(w).Encode(map[string]any{"id": expectedID})
@@ -406,7 +406,7 @@ func TestOpenEnvironment(t *testing.T) {
 
 		mux, client := newTestServer(t)
 
-		mux.HandleFunc("/api/preview/environments/test-org/test-env/versions/stable/open", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("/api/esc/environments/test-org/test-project/test-env/versions/stable/open", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, duration.String(), r.URL.Query().Get("duration"))
 
 			err := json.NewEncoder(w).Encode(map[string]any{"id": expectedID})
@@ -439,7 +439,7 @@ func TestOpenEnvironment(t *testing.T) {
 			},
 		}
 
-		client := newTestClient(t, http.MethodPost, "/api/preview/environments/test-org/test-env/open", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/test-project/test-env/open", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 
 			err := json.NewEncoder(w).Encode(EnvironmentErrorResponse{
@@ -456,7 +456,7 @@ func TestOpenEnvironment(t *testing.T) {
 	})
 
 	t.Run("Not found", func(t *testing.T) {
-		client := newTestClient(t, http.MethodPost, "/api/preview/environments/test-org/test-env/open", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/test-project/test-env/open", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 
 			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
@@ -481,7 +481,7 @@ func TestCheckYAMLEnvironment(t *testing.T) {
 			Schema:     schema.Record(map[string]schema.Builder{"foo": schema.String().Const("bar")}).Schema(),
 		}
 
-		client := newTestClient(t, http.MethodPost, "/api/preview/environments/test-org/yaml/check", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/yaml/check", func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			assert.Equal(t, yaml, body)
@@ -518,7 +518,7 @@ func TestCheckYAMLEnvironment(t *testing.T) {
 			},
 		}
 
-		client := newTestClient(t, http.MethodPost, "/api/preview/environments/test-org/yaml/check", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/yaml/check", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 
 			err := json.NewEncoder(w).Encode(EnvironmentErrorResponse{
@@ -542,7 +542,7 @@ func TestOpenYAMLEnvironment(t *testing.T) {
 		const expectedID = "open-id"
 		duration := 2 * time.Hour
 
-		client := newTestClient(t, http.MethodPost, "/api/preview/environments/test-org/yaml/open", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/yaml/open", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, duration.String(), r.URL.Query().Get("duration"))
 
 			body, err := io.ReadAll(r.Body)
@@ -581,7 +581,7 @@ func TestOpenYAMLEnvironment(t *testing.T) {
 			},
 		}
 
-		client := newTestClient(t, http.MethodPost, "/api/preview/environments/test-org/yaml/open", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/yaml/open", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 
 			err := json.NewEncoder(w).Encode(EnvironmentErrorResponse{
@@ -607,7 +607,7 @@ func TestGetOpenEnvironment(t *testing.T) {
 			Schema:     schema.Record(map[string]schema.Builder{"foo": schema.String().Const("bar")}).Schema(),
 		}
 
-		client := newTestClient(t, http.MethodGet, "/api/preview/environments/test-org/test-env/open/session", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/test-org/test-project/test-env/open/session", func(w http.ResponseWriter, r *http.Request) {
 			err := json.NewEncoder(w).Encode(expected)
 			require.NoError(t, err)
 		})
@@ -618,7 +618,7 @@ func TestGetOpenEnvironment(t *testing.T) {
 	})
 
 	t.Run("Not found", func(t *testing.T) {
-		client := newTestClient(t, http.MethodGet, "/api/preview/environments/test-org/test-env/open/session", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/test-org/test-project/test-env/open/session", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 
 			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
@@ -638,7 +638,7 @@ func TestGetOpenProperty(t *testing.T) {
 		property := `foo[0].baz["qux"]`
 		expected := esc.NewValue("bar")
 
-		client := newTestClient(t, http.MethodGet, "/api/preview/environments/test-org/test-env/open/session", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/test-org/test-project/test-env/open/session", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, property, r.URL.Query().Get("property"))
 
 			err := json.NewEncoder(w).Encode(expected)
@@ -651,7 +651,7 @@ func TestGetOpenProperty(t *testing.T) {
 	})
 
 	t.Run("Not found", func(t *testing.T) {
-		client := newTestClient(t, http.MethodGet, "/api/preview/environments/test-org/test-env/open/session", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/test-org/test-project/test-env/open/session", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 
 			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
@@ -680,7 +680,7 @@ func TestGetEnvironmentTag(t *testing.T) {
 			EditorName:  "pulumipus",
 		}
 
-		client := newTestClient(t, http.MethodGet, "/api/preview/environments/test-org/test-env/tags/owner", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/test-org/test-project/test-env/tags/owner", func(w http.ResponseWriter, r *http.Request) {
 			err := json.NewEncoder(w).Encode(expectedTag)
 			require.NoError(t, err)
 		})
@@ -698,7 +698,7 @@ func TestGetEnvironmentTag(t *testing.T) {
 	})
 
 	t.Run("Not found", func(t *testing.T) {
-		client := newTestClient(t, http.MethodGet, "/api/preview/environments/test-org/test-env/tags/owner", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/test-org/test-project/test-env/tags/owner", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 
 			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
@@ -736,7 +736,7 @@ func TestListEnvironmentTags(t *testing.T) {
 			NextToken: "16",
 		}
 
-		client := newTestClient(t, http.MethodGet, "/api/preview/environments/test-org/test-env/tags", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/test-org/test-project/test-env/tags", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, after, r.URL.Query().Get("after"))
 			assert.Equal(t, fmt.Sprint(count), r.URL.Query().Get("count"))
 
@@ -763,7 +763,7 @@ func TestListEnvironmentTags(t *testing.T) {
 	})
 
 	t.Run("Not found", func(t *testing.T) {
-		client := newTestClient(t, http.MethodGet, "/api/preview/environments/test-org/test-env/tags", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/test-org/test-project/test-env/tags", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 
 			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
@@ -792,7 +792,7 @@ func TestCreateEnvironmentTags(t *testing.T) {
 			EditorName:  "pulumipus",
 		}
 
-		client := newTestClient(t, http.MethodPost, "/api/preview/environments/test-org/test-env/tags", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/test-project/test-env/tags", func(w http.ResponseWriter, r *http.Request) {
 			err := json.NewEncoder(w).Encode(expectedTag)
 			require.NoError(t, err)
 		})
@@ -809,7 +809,7 @@ func TestCreateEnvironmentTags(t *testing.T) {
 	})
 
 	t.Run("Bad request", func(t *testing.T) {
-		client := newTestClient(t, http.MethodPost, "/api/preview/environments/test-org/test-env/tags", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/test-project/test-env/tags", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 
 			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
@@ -847,7 +847,7 @@ func TestUpdateEnvironmentTags(t *testing.T) {
 			EditorName:  "pulumipus",
 		}
 
-		client := newTestClient(t, http.MethodPatch, "/api/preview/environments/test-org/test-env/tags/owner", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPatch, "/api/esc/environments/test-org/test-project/test-env/tags/owner", func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			expectedBodyJSON, err := json.Marshal(expectedBody)
@@ -891,7 +891,7 @@ func TestUpdateEnvironmentTags(t *testing.T) {
 			EditorName:  "pulumipus",
 		}
 
-		client := newTestClient(t, http.MethodPatch, "/api/preview/environments/test-org/test-env/tags/owner", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPatch, "/api/esc/environments/test-org/test-project/test-env/tags/owner", func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			expectedBodyJSON, err := json.Marshal(expectedBody)
@@ -914,7 +914,7 @@ func TestUpdateEnvironmentTags(t *testing.T) {
 	})
 
 	t.Run("Not found", func(t *testing.T) {
-		client := newTestClient(t, http.MethodPatch, "/api/preview/environments/test-org/test-env/tags/owner", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPatch, "/api/esc/environments/test-org/test-project/test-env/tags/owner", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 
 			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
@@ -931,7 +931,7 @@ func TestUpdateEnvironmentTags(t *testing.T) {
 
 func TestDeleteEnvironmentTags(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
-		client := newTestClient(t, http.MethodDelete, "/api/preview/environments/test-org/test-env/tags/tagName", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodDelete, "/api/esc/environments/test-org/test-project/test-env/tags/tagName", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
 
@@ -940,7 +940,7 @@ func TestDeleteEnvironmentTags(t *testing.T) {
 	})
 
 	t.Run("Not found", func(t *testing.T) {
-		client := newTestClient(t, http.MethodDelete, "/api/preview/environments/test-org/test-env/tags/tagName", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodDelete, "/api/esc/environments/test-org/test-project/test-env/tags/tagName", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 
 			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{

--- a/cmd/esc/cli/client/client_test.go
+++ b/cmd/esc/cli/client/client_test.go
@@ -296,7 +296,7 @@ func TestUpdateEnvironment(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		diags, revision, err := client.UpdateEnvironmentWithRevision(context.Background(), "test-org", "test-env", yaml, tag)
+		diags, revision, err := client.UpdateEnvironmentWithRevision(context.Background(), "test-org", "test-project", "test-env", yaml, tag)
 		require.NoError(t, err)
 		assert.Equal(t, 1, revision)
 		assert.Len(t, diags, 0)
@@ -333,7 +333,7 @@ func TestUpdateEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		diags, revision, err := client.UpdateEnvironmentWithRevision(context.Background(), "test-org", "test-env", nil, "")
+		diags, revision, err := client.UpdateEnvironmentWithRevision(context.Background(), "test-org", "test-project", "test-env", nil, "")
 		require.Equal(t, 0, revision)
 		require.NoError(t, err)
 		assert.Equal(t, expected, diags)
@@ -349,7 +349,7 @@ func TestUpdateEnvironment(t *testing.T) {
 			})
 			require.NoError(t, err)
 		})
-		_, revision, err := client.UpdateEnvironmentWithRevision(context.Background(), "test-org", "test-env", nil, "")
+		_, revision, err := client.UpdateEnvironmentWithRevision(context.Background(), "test-org", "test-project", "test-env", nil, "")
 		require.Equal(t, 0, revision)
 		assert.ErrorContains(t, err, "conflict")
 	})
@@ -645,7 +645,7 @@ func TestGetOpenProperty(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		val, err := client.GetOpenProperty(context.Background(), "test-org", "test-env", "session", property)
+		val, err := client.GetOpenProperty(context.Background(), "test-org", "test-project", "test-env", "session", property)
 		require.NoError(t, err)
 		assert.Equal(t, &expected, val)
 	})
@@ -661,7 +661,7 @@ func TestGetOpenProperty(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		_, err := client.GetOpenProperty(context.Background(), "test-org", "test-env", "session", "foo")
+		_, err := client.GetOpenProperty(context.Background(), "test-org", "test-project", "test-env", "session", "foo")
 		assert.ErrorContains(t, err, "not found")
 	})
 }

--- a/cmd/esc/cli/env_diff.go
+++ b/cmd/esc/cli/env_diff.go
@@ -43,7 +43,7 @@ func newEnvDiffCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			baseRef, args, err := env.getEnvRef(args)
+			baseRef, args, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}
@@ -51,9 +51,12 @@ func newEnvDiffCmd(env *envCommand) *cobra.Command {
 				baseRef.version = "latest"
 			}
 
-			compareRef := environmentRef{baseRef.orgName, baseRef.envName, "latest"}
+			compareRef := environmentRef{baseRef.orgName, baseRef.projectName, baseRef.envName, "latest", baseRef.hasAmbiguousPath}
 			if len(args) != 0 {
-				compareRef = env.getRelativeEnvRef(args[0], &baseRef)
+				compareRef, err = env.getExistingEnvRefWithRelative(ctx, args[0], &baseRef)
+				if err != nil {
+					return err
+				}
 			}
 
 			var path resource.PropertyPath

--- a/cmd/esc/cli/env_diff.go
+++ b/cmd/esc/cli/env_diff.go
@@ -23,7 +23,7 @@ func newEnvDiffCmd(env *envCommand) *cobra.Command {
 	diff := &envGetCommand{env: env}
 
 	cmd := &cobra.Command{
-		Use:   "diff [<org-name>/]<environment-name>[@<version>] [[[org-name/]<environment-name>]@<version>]",
+		Use:   "diff [<org-name>/][<project-name>/]<environment-name>[@<version>] [[[org-name/][<project-name>/]<environment-name>]@<version>]",
 		Args:  cobra.RangeArgs(1, 2),
 		Short: "Show changes between versions.",
 		Long: "Show changes between versions\n" +

--- a/cmd/esc/cli/env_edit.go
+++ b/cmd/esc/cli/env_edit.go
@@ -34,7 +34,7 @@ func newEnvEditCmd(env *envCommand) *cobra.Command {
 	edit := &envEditCommand{env: env}
 
 	cmd := &cobra.Command{
-		Use:   "edit [<org-name>/]<environment-name>",
+		Use:   "edit [<org-name>/][<project-name>/]<environment-name>",
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Edit an environment definition",
 		Long: "Edit an environment definition\n" +

--- a/cmd/esc/cli/env_edit.go
+++ b/cmd/esc/cli/env_edit.go
@@ -74,7 +74,7 @@ func newEnvEditCmd(env *envCommand) *cobra.Command {
 					return fmt.Errorf("reading environment definition: %w", err)
 				}
 
-				diags, err := edit.env.esc.client.UpdateEnvironment(ctx, ref.orgName, ref.envName, yaml, "")
+				diags, err := edit.env.esc.client.UpdateEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName, yaml, "")
 				if err != nil {
 					return fmt.Errorf("updating environment definition: %w", err)
 				}
@@ -112,7 +112,7 @@ func newEnvEditCmd(env *envCommand) *cobra.Command {
 					return nil
 				}
 
-				diags, err = edit.env.esc.client.UpdateEnvironment(ctx, ref.orgName, ref.envName, newYAML, tag)
+				diags, err = edit.env.esc.client.UpdateEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName, newYAML, tag)
 				if err != nil {
 					return fmt.Errorf("updating environment definition: %w", err)
 				}

--- a/cmd/esc/cli/env_edit.go
+++ b/cmd/esc/cli/env_edit.go
@@ -53,7 +53,7 @@ func newEnvEditCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := edit.env.getEnvRef(args)
+			ref, args, err := edit.env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_edit.go
+++ b/cmd/esc/cli/env_edit.go
@@ -91,7 +91,7 @@ func newEnvEditCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			yaml, tag, _, err := edit.env.esc.client.GetEnvironment(ctx, ref.orgName, ref.envName, "", showSecrets)
+			yaml, tag, _, err := edit.env.esc.client.GetEnvironment(ctx, ref.orgName, ref.projectName, ref.envName, "", showSecrets)
 			if err != nil {
 				return fmt.Errorf("getting environment definition: %w", err)
 			}

--- a/cmd/esc/cli/env_get.go
+++ b/cmd/esc/cli/env_get.go
@@ -144,7 +144,7 @@ func (get *envGetCommand) writeValue(
 	format string,
 	showSecrets bool,
 ) error {
-	def, _, _, err := get.env.esc.client.GetEnvironment(ctx, ref.orgName, ref.envName, ref.version, showSecrets)
+	def, _, _, err := get.env.esc.client.GetEnvironment(ctx, ref.orgName, ref.projectName, ref.envName, ref.version, showSecrets)
 	if err != nil {
 		return fmt.Errorf("getting environment definition: %w", err)
 	}
@@ -216,7 +216,7 @@ func (get *envGetCommand) getEnvironment(
 	path resource.PropertyPath,
 	showSecrets bool,
 ) (*envGetTemplateData, error) {
-	def, _, _, err := get.env.esc.client.GetEnvironment(ctx, ref.orgName, ref.envName, ref.version, showSecrets)
+	def, _, _, err := get.env.esc.client.GetEnvironment(ctx, ref.orgName, ref.projectName, ref.envName, ref.version, showSecrets)
 	if err != nil {
 		return nil, fmt.Errorf("getting environment definition: %w", err)
 	}

--- a/cmd/esc/cli/env_get.go
+++ b/cmd/esc/cli/env_get.go
@@ -37,7 +37,7 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 	get := &envGetCommand{env: env}
 
 	cmd := &cobra.Command{
-		Use:   "get [<org-name>/]<environment-name>[@<version>] <path>",
+		Use:   "get [<org-name>/][<project-name>/]<environment-name>[@<version>] <path>",
 		Args:  cobra.RangeArgs(1, 2),
 		Short: "Get a value within an environment.",
 		Long: "Get a value within an environment\n" +

--- a/cmd/esc/cli/env_get.go
+++ b/cmd/esc/cli/env_get.go
@@ -53,7 +53,7 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getEnvRef(args)
+			ref, args, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_init.go
+++ b/cmd/esc/cli/env_init.go
@@ -56,12 +56,12 @@ func newEnvInitCmd(env *envCommand) *cobra.Command {
 				return fmt.Errorf("reading environment definition: %w", err)
 			}
 
-			if err := env.esc.client.CreateEnvironment(ctx, ref.orgName, ref.envName); err != nil {
+			if err := env.esc.client.CreateEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName); err != nil {
 				return fmt.Errorf("creating environment: %w", err)
 			}
 			fmt.Fprintln(env.esc.stdout, "Environment created.")
 			if len(yaml) != 0 {
-				diags, err := env.esc.client.UpdateEnvironment(ctx, ref.orgName, ref.envName, yaml, "")
+				diags, err := env.esc.client.UpdateEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName, yaml, "")
 				if err != nil {
 					return fmt.Errorf("updating environment definition: %w", err)
 				}

--- a/cmd/esc/cli/env_init.go
+++ b/cmd/esc/cli/env_init.go
@@ -59,7 +59,7 @@ func newEnvInitCmd(env *envCommand) *cobra.Command {
 			if err := env.esc.client.CreateEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName); err != nil {
 				return fmt.Errorf("creating environment: %w", err)
 			}
-			fmt.Fprintln(env.esc.stdout, "Environment created.")
+			fmt.Fprintf(env.esc.stdout, "Environment created: %v\n", ref.String())
 			if len(yaml) != 0 {
 				diags, err := env.esc.client.UpdateEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName, yaml, "")
 				if err != nil {

--- a/cmd/esc/cli/env_init.go
+++ b/cmd/esc/cli/env_init.go
@@ -16,7 +16,7 @@ func newEnvInitCmd(env *envCommand) *cobra.Command {
 	var file string
 
 	cmd := &cobra.Command{
-		Use:   "init [<org-name>/]<environment-name>",
+		Use:   "init [<org-name>/][<project-name>/]<environment-name>",
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Create an empty environment with the given name.",
 		Long: "Create an empty environment with the given name, ready for editing\n" +

--- a/cmd/esc/cli/env_init.go
+++ b/cmd/esc/cli/env_init.go
@@ -34,7 +34,7 @@ func newEnvInitCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getEnvRef(args)
+			ref, args, err := env.getNewEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_ls.go
+++ b/cmd/esc/cli/env_ls.go
@@ -44,9 +44,9 @@ func newEnvLsCmd(env *envCommand) *cobra.Command {
 
 			for _, e := range allEnvs {
 				if e.Organization == "" {
-					fmt.Fprintln(env.esc.stdout, e.Name)
+					fmt.Fprintf(env.esc.stdout, "%v/%v\n", e.Project, e.Name)
 				} else {
-					fmt.Fprintf(env.esc.stdout, "%v/%v\n", e.Organization, e.Name)
+					fmt.Fprintf(env.esc.stdout, "%v/%v/%v\n", e.Organization, e.Project, e.Name)
 				}
 			}
 

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -36,7 +36,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := envcmd.getEnvRef(args)
+			ref, args, err := envcmd.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -164,7 +164,7 @@ func (env *envCommand) openEnvironment(
 	ref environmentRef,
 	duration time.Duration,
 ) (*esc.Environment, []client.EnvironmentDiagnostic, error) {
-	envID, diags, err := env.esc.client.OpenEnvironment(ctx, ref.orgName, ref.envName, ref.version, duration)
+	envID, diags, err := env.esc.client.OpenEnvironment(ctx, ref.orgName, ref.projectName, ref.envName, ref.version, duration)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -21,7 +21,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 	var format string
 
 	cmd := &cobra.Command{
-		Use:   "open [<org-name>/]<environment-name>[@<version>] [property path]",
+		Use:   "open [<org-name>/][<project-name>/]<environment-name>[@<version>] [property path]",
 		Args:  cobra.MaximumNArgs(2),
 		Short: "Open the environment with the given name.",
 		Long: "Open the environment with the given name and return the result\n" +

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -171,6 +171,6 @@ func (env *envCommand) openEnvironment(
 	if len(diags) != 0 {
 		return nil, diags, err
 	}
-	open, err := env.esc.client.GetOpenEnvironment(ctx, ref.orgName, ref.envName, envID)
+	open, err := env.esc.client.GetOpenEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName, envID)
 	return open, nil, err
 }

--- a/cmd/esc/cli/env_rm.go
+++ b/cmd/esc/cli/env_rm.go
@@ -19,7 +19,7 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 	var yes bool
 
 	cmd := &cobra.Command{
-		Use:   "rm [<org-name>/]<environment-name> [path]",
+		Use:   "rm [<org-name>/][<project-name>/]<environment-name> [path]",
 		Args:  cobra.MaximumNArgs(2),
 		Short: "Remove an environment or a value from an environment.",
 		Long: "Remove an environment or a value from an environment\n" +

--- a/cmd/esc/cli/env_rm.go
+++ b/cmd/esc/cli/env_rm.go
@@ -98,7 +98,7 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 				return fmt.Errorf("marshaling definition: %w", err)
 			}
 
-			diags, err := env.esc.client.UpdateEnvironment(ctx, ref.orgName, ref.envName, newYAML, tag)
+			diags, err := env.esc.client.UpdateEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName, newYAML, tag)
 			if err != nil {
 				return fmt.Errorf("updating environment definition: %w", err)
 			}

--- a/cmd/esc/cli/env_rm.go
+++ b/cmd/esc/cli/env_rm.go
@@ -48,7 +48,7 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 
 			// Are we removing the entire environment?
 			if len(args) == 0 {
-				envSlug := fmt.Sprintf("%v/%v", ref.orgName, ref.envName)
+				envSlug := fmt.Sprintf("%v/%v/%v", ref.orgName, ref.projectName, ref.envName)
 
 				// Ensure the user really wants to do this.
 				prompt := fmt.Sprintf("This will permanently remove the %q environment!", envSlug)
@@ -56,7 +56,7 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 					return errors.New("confirmation declined")
 				}
 
-				err = env.esc.client.DeleteEnvironment(ctx, ref.orgName, ref.envName)
+				err = env.esc.client.DeleteEnvironment(ctx, ref.orgName, ref.projectName, ref.envName)
 				if err != nil {
 					return err
 				}
@@ -72,7 +72,7 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 				return fmt.Errorf("invalid path: %w", err)
 			}
 
-			def, tag, _, err := env.esc.client.GetEnvironment(ctx, ref.orgName, ref.envName, "", false)
+			def, tag, _, err := env.esc.client.GetEnvironment(ctx, ref.orgName, ref.projectName, ref.envName, "", false)
 			if err != nil {
 				return fmt.Errorf("getting environment definition: %w", err)
 			}

--- a/cmd/esc/cli/env_rm.go
+++ b/cmd/esc/cli/env_rm.go
@@ -38,7 +38,7 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getEnvRef(args)
+			ref, args, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_run.go
+++ b/cmd/esc/cli/env_run.go
@@ -100,7 +100,7 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 	shell := valueOrDefault(filepath.Base(envcmd.esc.environ.Get("SHELL")), "sh")
 
 	cmd := &cobra.Command{
-		Use:   "run [<org-name>/]<environment-name> [flags] -- [command]",
+		Use:   "run [<org-name>/][<project-name>/]<environment-name> [flags] -- [command]",
 		Args:  cobra.ArbitraryArgs,
 		Short: "Open the environment with the given name and run a command.",
 		Long: fmt.Sprintf("Open the environment with the given name and run a command\n"+

--- a/cmd/esc/cli/env_run.go
+++ b/cmd/esc/cli/env_run.go
@@ -130,7 +130,7 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := envcmd.getEnvRef(args)
+			ref, args, err := envcmd.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -37,7 +37,7 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getEnvRef(args)
+			ref, args, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -129,7 +129,7 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 				return fmt.Errorf("marshaling definition: %w", err)
 			}
 
-			diags, err := env.esc.client.UpdateEnvironment(ctx, ref.orgName, ref.envName, newYAML, tag)
+			diags, err := env.esc.client.UpdateEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName, newYAML, tag)
 			if err != nil {
 				return fmt.Errorf("updating environment definition: %w", err)
 			}

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -90,7 +90,7 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 				yamlValue = *yamlValue.Content[0]
 			}
 
-			def, tag, _, err := env.esc.client.GetEnvironment(ctx, ref.orgName, ref.envName, "", false)
+			def, tag, _, err := env.esc.client.GetEnvironment(ctx, ref.orgName, ref.projectName, ref.envName, "", false)
 			if err != nil {
 				return fmt.Errorf("getting environment definition: %w", err)
 			}

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -21,7 +21,7 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 	var plaintext bool
 
 	cmd := &cobra.Command{
-		Use:   "set [<org-name>/]<environment-name> <path> <value>",
+		Use:   "set [<org-name>/][<project-name>/]<environment-name> <path> <value>",
 		Args:  cobra.RangeArgs(2, 3),
 		Short: "Set a value within an environment.",
 		Long: "Set a value within an environment\n" +

--- a/cmd/esc/cli/env_tag.go
+++ b/cmd/esc/cli/env_tag.go
@@ -33,7 +33,7 @@ func newEnvTagCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getEnvRef(args)
+			ref, args, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_tag.go
+++ b/cmd/esc/cli/env_tag.go
@@ -50,7 +50,7 @@ func newEnvTagCmd(env *envCommand) *cobra.Command {
 				return errors.New("environment tag value cannot be empty")
 			}
 
-			tag, err := env.esc.client.GetEnvironmentTag(ctx, ref.orgName, ref.envName, name)
+			tag, err := env.esc.client.GetEnvironmentTag(ctx, ref.orgName, ref.projectName, ref.envName, name)
 			if err != nil && !client.IsNotFound(err) {
 				return err
 			}
@@ -63,7 +63,7 @@ func newEnvTagCmd(env *envCommand) *cobra.Command {
 					return nil
 				}
 
-				t, err := env.esc.client.UpdateEnvironmentTag(ctx, ref.orgName, ref.envName, tag.Name, tag.Value, tag.Name, value)
+				t, err := env.esc.client.UpdateEnvironmentTag(ctx, ref.orgName, ref.projectName, ref.envName, tag.Name, tag.Value, tag.Name, value)
 				if err == nil {
 					printTag(env.esc.stdout, st, t, utcFlag(utc))
 					return nil
@@ -71,7 +71,7 @@ func newEnvTagCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			t, err := env.esc.client.CreateEnvironmentTag(ctx, ref.orgName, ref.envName, name, value)
+			t, err := env.esc.client.CreateEnvironmentTag(ctx, ref.orgName, ref.projectName, ref.envName, name, value)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_tag.go
+++ b/cmd/esc/cli/env_tag.go
@@ -17,7 +17,7 @@ func newEnvTagCmd(env *envCommand) *cobra.Command {
 	var utc bool
 
 	cmd := &cobra.Command{
-		Use:   "tag [<org-name>/]<environment-name> <name> <value>",
+		Use:   "tag [<org-name>/][<project-name>/]<environment-name> <name> <value>",
 		Args:  cobra.ExactArgs(3),
 		Short: "Manage environment tags",
 		Long: "Manage environment tags\n" +

--- a/cmd/esc/cli/env_tag_get.go
+++ b/cmd/esc/cli/env_tag_get.go
@@ -28,7 +28,7 @@ func newEnvTagGetCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getEnvRef(args)
+			ref, args, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_tag_get.go
+++ b/cmd/esc/cli/env_tag_get.go
@@ -42,7 +42,7 @@ func newEnvTagGetCmd(env *envCommand) *cobra.Command {
 				return errors.New("environment tag name cannot be empty")
 			}
 
-			tag, err := env.esc.client.GetEnvironmentTag(ctx, ref.orgName, ref.envName, name)
+			tag, err := env.esc.client.GetEnvironmentTag(ctx, ref.orgName, ref.projectName, ref.envName, name)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_tag_get.go
+++ b/cmd/esc/cli/env_tag_get.go
@@ -14,7 +14,7 @@ func newEnvTagGetCmd(env *envCommand) *cobra.Command {
 	var utc bool
 
 	cmd := &cobra.Command{
-		Use:   "get [<org-name>/]<environment-name> <name>",
+		Use:   "get [<org-name>/][<project-name>/]<environment-name> <name>",
 		Args:  cobra.ExactArgs(2),
 		Short: "Get an environment tag",
 		Long: "Get an environment tag\n" +

--- a/cmd/esc/cli/env_tag_ls.go
+++ b/cmd/esc/cli/env_tag_ls.go
@@ -34,7 +34,7 @@ func newEnvTagLsCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, _, err := env.getEnvRef(args)
+			ref, _, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_tag_ls.go
+++ b/cmd/esc/cli/env_tag_ls.go
@@ -20,7 +20,7 @@ func newEnvTagLsCmd(env *envCommand) *cobra.Command {
 	var utc bool
 
 	cmd := &cobra.Command{
-		Use:   "ls [<org-name>/]<environment-name>",
+		Use:   "ls [<org-name>/][<project-name>/]<environment-name>",
 		Short: "List environment tags.",
 		Long: "List environment tags\n" +
 			"\n" +

--- a/cmd/esc/cli/env_tag_ls.go
+++ b/cmd/esc/cli/env_tag_ls.go
@@ -53,7 +53,7 @@ func newEnvTagLsCmd(env *envCommand) *cobra.Command {
 						After: after,
 						Count: &count,
 					}
-					tags, next, err := env.esc.client.ListEnvironmentTags(ctx, ref.orgName, ref.envName, options)
+					tags, next, err := env.esc.client.ListEnvironmentTags(ctx, ref.orgName, ref.projectName, ref.envName, options)
 					if err != nil {
 						return err
 					}

--- a/cmd/esc/cli/env_tag_mv.go
+++ b/cmd/esc/cli/env_tag_mv.go
@@ -14,7 +14,7 @@ func newEnvTagMvCmd(env *envCommand) *cobra.Command {
 	var utc bool
 
 	cmd := &cobra.Command{
-		Use:   "mv [<org-name>/]<environment-name> <name> <new-name>",
+		Use:   "mv [<org-name>/][<project-name>/]<environment-name> <name> <new-name>",
 		Args:  cobra.ExactArgs(3),
 		Short: "Move an environment tag",
 		Long: "Move an environment tag\n" +

--- a/cmd/esc/cli/env_tag_mv.go
+++ b/cmd/esc/cli/env_tag_mv.go
@@ -29,7 +29,7 @@ func newEnvTagMvCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getEnvRef(args)
+			ref, args, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_tag_mv.go
+++ b/cmd/esc/cli/env_tag_mv.go
@@ -46,7 +46,7 @@ func newEnvTagMvCmd(env *envCommand) *cobra.Command {
 				return errors.New("environment tag value cannot be empty")
 			}
 
-			tag, err := env.esc.client.GetEnvironmentTag(ctx, ref.orgName, ref.envName, name)
+			tag, err := env.esc.client.GetEnvironmentTag(ctx, ref.orgName, ref.projectName, ref.envName, name)
 			if err != nil {
 				return err
 			}
@@ -58,7 +58,7 @@ func newEnvTagMvCmd(env *envCommand) *cobra.Command {
 				return nil
 			}
 
-			t, err := env.esc.client.UpdateEnvironmentTag(ctx, ref.orgName, ref.envName, tag.Name, tag.Value, newName, tag.Value)
+			t, err := env.esc.client.UpdateEnvironmentTag(ctx, ref.orgName, ref.projectName, ref.envName, tag.Name, tag.Value, newName, tag.Value)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_tag_rm.go
+++ b/cmd/esc/cli/env_tag_rm.go
@@ -35,7 +35,7 @@ func newEnvTagRmCmd(env *envCommand) *cobra.Command {
 
 			tagIdentifier := args[1]
 
-			if err := env.esc.client.DeleteEnvironmentTag(ctx, ref.orgName, ref.envName, tagIdentifier); err != nil {
+			if err := env.esc.client.DeleteEnvironmentTag(ctx, ref.orgName, ref.projectName, ref.envName, tagIdentifier); err != nil {
 				return err
 			}
 

--- a/cmd/esc/cli/env_tag_rm.go
+++ b/cmd/esc/cli/env_tag_rm.go
@@ -25,7 +25,7 @@ func newEnvTagRmCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, _, err := env.getEnvRef(args)
+			ref, _, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_tag_rm.go
+++ b/cmd/esc/cli/env_tag_rm.go
@@ -11,7 +11,7 @@ import (
 
 func newEnvTagRmCmd(env *envCommand) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rm [<org-name>/]<environment-name> <tag-name>",
+		Use:   "rm [<org-name>/][<project-name>/]<environment-name> <tag-name>",
 		Short: "Remove an environment tag.",
 		Long: "Remove an environment tag\n" +
 			"\n" +

--- a/cmd/esc/cli/env_test.go
+++ b/cmd/esc/cli/env_test.go
@@ -1,0 +1,71 @@
+// Copyright 2024, Pulumi Corporation.
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/pulumi/esc/cmd/esc/cli/client"
+	"github.com/pulumi/esc/cmd/esc/cli/workspace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetEnvRef(t *testing.T) {
+	defaultOrg := "default-org"
+	account := workspace.Account{DefaultOrg: defaultOrg}
+	esc := &escCommand{account: account}
+	cmd := &envCommand{esc: esc}
+
+	t.Run("1 identifier", func(t *testing.T) {
+		refString := "abc@v1"
+
+		ref := cmd.getEnvRef(refString, nil)
+
+		assert.Equal(t, ref.orgName, defaultOrg)
+		assert.Equal(t, ref.projectName, client.DefaultProject)
+		assert.Equal(t, ref.envName, "abc")
+		assert.Equal(t, ref.version, "v1")
+		assert.Equal(t, ref.hasAmbiguousPath, false)
+	})
+
+	t.Run("2 identifiers", func(t *testing.T) {
+		refString := "a/b@v1"
+
+		ref := cmd.getEnvRef(refString, nil)
+
+		assert.Equal(t, ref.orgName, defaultOrg)
+		assert.Equal(t, ref.projectName, "a")
+		assert.Equal(t, ref.envName, "b")
+		assert.Equal(t, ref.version, "v1")
+		assert.Equal(t, ref.hasAmbiguousPath, true)
+	})
+
+	t.Run("3 identifiers", func(t *testing.T) {
+		refString := "a/b/c@v1"
+
+		ref := cmd.getEnvRef(refString, nil)
+
+		assert.Equal(t, ref.orgName, "a")
+		assert.Equal(t, ref.projectName, "b")
+		assert.Equal(t, ref.envName, "c")
+		assert.Equal(t, ref.version, "v1")
+		assert.Equal(t, ref.hasAmbiguousPath, false)
+	})
+
+	t.Run("with relative env", func(t *testing.T) {
+		refString := "@v1"
+		rel := &environmentRef{
+			orgName:     "rel-org",
+			projectName: "rel-project",
+			envName:     "rel-env",
+			version:     "rel-version",
+		}
+
+		ref := cmd.getEnvRef(refString, rel)
+
+		assert.Equal(t, ref.orgName, "rel-org")
+		assert.Equal(t, ref.projectName, "rel-project")
+		assert.Equal(t, ref.envName, "rel-env")
+		assert.Equal(t, ref.version, "v1")
+	})
+}

--- a/cmd/esc/cli/env_version.go
+++ b/cmd/esc/cli/env_version.go
@@ -52,7 +52,7 @@ func newEnvVersionCmd(env *envCommand) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				rev, err := env.esc.client.GetEnvironmentRevision(ctx, ref.orgName, ref.envName, int(revisionNumber))
+				rev, err := env.esc.client.GetEnvironmentRevision(ctx, ref.orgName, ref.projectName, ref.envName, int(revisionNumber))
 				if err != nil {
 					return err
 				}

--- a/cmd/esc/cli/env_version.go
+++ b/cmd/esc/cli/env_version.go
@@ -58,7 +58,7 @@ func newEnvVersionCmd(env *envCommand) *cobra.Command {
 				}
 				printRevision(env.esc.stdout, st, *rev, utcFlag(utc))
 			} else {
-				tag, err := env.esc.client.GetEnvironmentRevisionTag(ctx, ref.orgName, ref.envName, ref.version)
+				tag, err := env.esc.client.GetEnvironmentRevisionTag(ctx, ref.orgName, ref.projectName, ref.envName, ref.version)
 				if err != nil {
 					return err
 				}

--- a/cmd/esc/cli/env_version.go
+++ b/cmd/esc/cli/env_version.go
@@ -20,7 +20,7 @@ func newEnvVersionCmd(env *envCommand) *cobra.Command {
 	var utc bool
 
 	cmd := &cobra.Command{
-		Use:   "version [<org-name>/]<environment-name>@<version>",
+		Use:   "version [<org-name>/][<project-name>/]<environment-name>@<version>",
 		Args:  cobra.ExactArgs(1),
 		Short: "Manage versions",
 		Long: "Manage versions\n" +

--- a/cmd/esc/cli/env_version.go
+++ b/cmd/esc/cli/env_version.go
@@ -37,7 +37,7 @@ func newEnvVersionCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getEnvRef(args)
+			ref, args, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_version_history.go
+++ b/cmd/esc/cli/env_version_history.go
@@ -18,7 +18,7 @@ func newEnvVersionHistoryCmd(env *envCommand) *cobra.Command {
 	var utc bool
 
 	cmd := &cobra.Command{
-		Use:   "history [<org-name>/]<environment-name>[@<version>]",
+		Use:   "history [<org-name>/][<project-name>/]<environment-name>[@<version>]",
 		Short: "Show revision history.",
 		Long: "Show revision history\n" +
 			"\n" +

--- a/cmd/esc/cli/env_version_history.go
+++ b/cmd/esc/cli/env_version_history.go
@@ -57,7 +57,7 @@ func newEnvVersionHistoryCmd(env *envCommand) *cobra.Command {
 						Before: &before,
 						Count:  &count,
 					}
-					revisions, err := env.esc.client.ListEnvironmentRevisions(ctx, ref.orgName, ref.envName, options)
+					revisions, err := env.esc.client.ListEnvironmentRevisions(ctx, ref.orgName, ref.projectName, ref.envName, options)
 					if err != nil {
 						return err
 					}

--- a/cmd/esc/cli/env_version_history.go
+++ b/cmd/esc/cli/env_version_history.go
@@ -33,7 +33,7 @@ func newEnvVersionHistoryCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getEnvRef(args)
+			ref, args, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_version_history.go
+++ b/cmd/esc/cli/env_version_history.go
@@ -41,7 +41,7 @@ func newEnvVersionHistoryCmd(env *envCommand) *cobra.Command {
 
 			before := 0
 			if ref.version != "" {
-				rev, err := env.esc.client.GetRevisionNumber(ctx, ref.orgName, ref.envName, ref.version)
+				rev, err := env.esc.client.GetRevisionNumber(ctx, ref.orgName, ref.projectName, ref.envName, ref.version)
 				if err != nil {
 					return err
 				}

--- a/cmd/esc/cli/env_version_retract.go
+++ b/cmd/esc/cli/env_version_retract.go
@@ -64,7 +64,7 @@ func newEnvVersionRetractCmd(env *envCommand) *cobra.Command {
 				replacementRevision = &rev
 			}
 
-			return env.esc.client.RetractEnvironmentRevision(ctx, ref.orgName, ref.envName, ref.version, replacementRevision, reason)
+			return env.esc.client.RetractEnvironmentRevision(ctx, ref.orgName, ref.projectName, ref.envName, ref.version, replacementRevision, reason)
 		},
 	}
 

--- a/cmd/esc/cli/env_version_retract.go
+++ b/cmd/esc/cli/env_version_retract.go
@@ -36,7 +36,7 @@ func newEnvVersionRetractCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getEnvRef(args)
+			ref, args, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}
@@ -47,7 +47,11 @@ func newEnvVersionRetractCmd(env *envCommand) *cobra.Command {
 
 			var replacementRevision *int
 			if replacement != "" {
-				replacementRef := env.getRelativeEnvRef(replacement, &ref)
+				replacementRef, err := env.getExistingEnvRefWithRelative(ctx, replacement, &ref)
+				if err != nil {
+					return err
+				}
+
 				rev, err := env.esc.client.GetRevisionNumber(
 					ctx,
 					replacementRef.orgName,

--- a/cmd/esc/cli/env_version_retract.go
+++ b/cmd/esc/cli/env_version_retract.go
@@ -55,6 +55,7 @@ func newEnvVersionRetractCmd(env *envCommand) *cobra.Command {
 				rev, err := env.esc.client.GetRevisionNumber(
 					ctx,
 					replacementRef.orgName,
+					replacementRef.projectName,
 					replacementRef.envName,
 					replacementRef.version,
 				)

--- a/cmd/esc/cli/env_version_retract.go
+++ b/cmd/esc/cli/env_version_retract.go
@@ -14,7 +14,7 @@ func newEnvVersionRetractCmd(env *envCommand) *cobra.Command {
 	var reason string
 
 	cmd := &cobra.Command{
-		Use:   "retract [<org-name>/]<environment-name>@<version>",
+		Use:   "retract [<org-name>/][<project-name>/]<environment-name>@<version>",
 		Args:  cobra.RangeArgs(1, 2),
 		Short: "Retract a specific revision of an environment",
 		Long: "Retract a specific revision of an environment\n" +

--- a/cmd/esc/cli/env_version_rollback.go
+++ b/cmd/esc/cli/env_version_rollback.go
@@ -42,7 +42,7 @@ func newEnvVersionRollbackCmd(env *envCommand) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			diags, err := env.esc.client.UpdateEnvironment(ctx, ref.orgName, ref.envName, yaml, "")
+			diags, err := env.esc.client.UpdateEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName, yaml, "")
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_version_rollback.go
+++ b/cmd/esc/cli/env_version_rollback.go
@@ -13,7 +13,7 @@ import (
 
 func newEnvVersionRollbackCmd(env *envCommand) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rollback [<org-name>/]<environment-name>@<version>",
+		Use:   "rollback [<org-name>/][<project-name>/]<environment-name>@<version>",
 		Args:  cobra.ExactArgs(1),
 		Short: "Roll back to a specific version",
 		Long: "Roll back to a specific version\n" +

--- a/cmd/esc/cli/env_version_rollback.go
+++ b/cmd/esc/cli/env_version_rollback.go
@@ -38,7 +38,7 @@ func newEnvVersionRollbackCmd(env *envCommand) *cobra.Command {
 			}
 			_ = args
 
-			yaml, _, _, err := env.esc.client.GetEnvironment(ctx, ref.orgName, ref.envName, ref.version, false)
+			yaml, _, _, err := env.esc.client.GetEnvironment(ctx, ref.orgName, ref.projectName, ref.envName, ref.version, false)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_version_rollback.go
+++ b/cmd/esc/cli/env_version_rollback.go
@@ -29,7 +29,7 @@ func newEnvVersionRollbackCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getEnvRef(args)
+			ref, args, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_version_tag.go
+++ b/cmd/esc/cli/env_version_tag.go
@@ -34,7 +34,7 @@ func newEnvVersionTagCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getEnvRef(args)
+			ref, args, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_version_tag.go
+++ b/cmd/esc/cli/env_version_tag.go
@@ -15,7 +15,7 @@ func newEnvVersionTagCmd(env *envCommand) *cobra.Command {
 	var utc bool
 
 	cmd := &cobra.Command{
-		Use:   "tag [<org-name>/]<environment-name>@<tag> [@<version>]",
+		Use:   "tag [<org-name>/][<project-name>/]<environment-name>@<tag> [@<version>]",
 		Args:  cobra.RangeArgs(1, 2),
 		Short: "Manage tagged versions",
 		Long: "Manage tagged versions\n" +

--- a/cmd/esc/cli/env_version_tag.go
+++ b/cmd/esc/cli/env_version_tag.go
@@ -44,7 +44,7 @@ func newEnvVersionTagCmd(env *envCommand) *cobra.Command {
 
 			var revision int
 			if len(args) == 0 {
-				latest, err := env.esc.client.GetEnvironmentRevisionTag(ctx, ref.orgName, ref.envName, "latest")
+				latest, err := env.esc.client.GetEnvironmentRevisionTag(ctx, ref.orgName, ref.projectName, ref.envName, "latest")
 				if err != nil {
 					return err
 				}
@@ -57,14 +57,14 @@ func newEnvVersionTagCmd(env *envCommand) *cobra.Command {
 				}
 			}
 
-			err = env.esc.client.UpdateEnvironmentRevisionTag(ctx, ref.orgName, ref.envName, ref.version, &revision)
+			err = env.esc.client.UpdateEnvironmentRevisionTag(ctx, ref.orgName, ref.projectName, ref.envName, ref.version, &revision)
 			if err == nil {
 				return err
 			}
 			if !client.IsNotFound(err) {
 				return err
 			}
-			return env.esc.client.CreateEnvironmentRevisionTag(ctx, ref.orgName, ref.envName, ref.version, &revision)
+			return env.esc.client.CreateEnvironmentRevisionTag(ctx, ref.orgName, ref.projectName, ref.envName, ref.version, &revision)
 		},
 	}
 

--- a/cmd/esc/cli/env_version_tag.go
+++ b/cmd/esc/cli/env_version_tag.go
@@ -51,7 +51,7 @@ func newEnvVersionTagCmd(env *envCommand) *cobra.Command {
 				revision = latest.Revision
 			} else {
 				version, _ := strings.CutPrefix(args[0], "@")
-				revision, err = env.esc.client.GetRevisionNumber(ctx, ref.orgName, ref.envName, version)
+				revision, err = env.esc.client.GetRevisionNumber(ctx, ref.orgName, ref.projectName, ref.envName, version)
 				if err != nil {
 					return err
 				}

--- a/cmd/esc/cli/env_version_tag_ls.go
+++ b/cmd/esc/cli/env_version_tag_ls.go
@@ -32,7 +32,7 @@ func newEnvVersionTagLsCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getEnvRef(args)
+			ref, args, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_version_tag_ls.go
+++ b/cmd/esc/cli/env_version_tag_ls.go
@@ -51,7 +51,7 @@ func newEnvVersionTagLsCmd(env *envCommand) *cobra.Command {
 						After: after,
 						Count: &count,
 					}
-					tags, err := env.esc.client.ListEnvironmentRevisionTags(ctx, ref.orgName, ref.envName, options)
+					tags, err := env.esc.client.ListEnvironmentRevisionTags(ctx, ref.orgName, ref.projectName, ref.envName, options)
 					if err != nil {
 						return err
 					}

--- a/cmd/esc/cli/env_version_tag_ls.go
+++ b/cmd/esc/cli/env_version_tag_ls.go
@@ -18,7 +18,7 @@ func newEnvVersionTagLsCmd(env *envCommand) *cobra.Command {
 	var utc bool
 
 	cmd := &cobra.Command{
-		Use:   "ls [<org-name>/]<environment-name>",
+		Use:   "ls [<org-name>/][<project-name>/]<environment-name>",
 		Short: "List tagged versions.",
 		Long: "List tagged versions\n" +
 			"\n" +

--- a/cmd/esc/cli/env_version_tag_rm.go
+++ b/cmd/esc/cli/env_version_tag_rm.go
@@ -25,7 +25,7 @@ func newEnvVersionTagRmCmd(env *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := env.getEnvRef(args)
+			ref, args, err := env.getExistingEnvRef(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/env_version_tag_rm.go
+++ b/cmd/esc/cli/env_version_tag_rm.go
@@ -11,7 +11,7 @@ import (
 
 func newEnvVersionTagRmCmd(env *envCommand) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rm [<org-name>/]<environment-name>@<tag>",
+		Use:   "rm [<org-name>/][<project-name>/]<environment-name>@<tag>",
 		Args:  cobra.ExactArgs(1),
 		Short: "Remove a tagged version.",
 		Long: "Remove a tagged version\n" +

--- a/cmd/esc/cli/env_version_tag_rm.go
+++ b/cmd/esc/cli/env_version_tag_rm.go
@@ -34,7 +34,7 @@ func newEnvVersionTagRmCmd(env *envCommand) *cobra.Command {
 			}
 			_ = args
 
-			return env.esc.client.DeleteEnvironmentRevisionTag(ctx, ref.orgName, ref.envName, ref.version)
+			return env.esc.client.DeleteEnvironmentRevisionTag(ctx, ref.orgName, ref.projectName, ref.envName, ref.version)
 		},
 	}
 

--- a/cmd/esc/cli/testdata/env-diff.yaml
+++ b/cmd/esc/cli/testdata/env-diff.yaml
@@ -14,9 +14,9 @@ run: |
   esc env diff test@stable --format dotenv
   esc env diff test@stable --format shell
 environments:
-  test-user/a: {}
-  test-user/b: {}
-  test-user/test:
+  test-user/default/a: {}
+  test-user/default/b: {}
+  test-user/default/test:
     revisions:
       - yaml:
           values:
@@ -45,7 +45,7 @@ environments:
             environmentVariables:
               FOO: baz
               BAR: qux
-  test-user/test-v2:
+  test-user/default/test-v2:
     revisions:
       - yaml:
           values:
@@ -70,8 +70,8 @@ stdout: |
   > esc env diff test@stable
   # Value
   ```diff
-  --- test-user/test@stable
-  +++ test-user/test@latest
+  --- test-user/default/test@stable
+  +++ test-user/default/test@latest
   @@ -1,6 +1,19 @@
    {
   +  "array": [
@@ -99,8 +99,8 @@ stdout: |
   ```
   # Definition
   ```diff
-  --- test-user/test@stable
-  +++ test-user/test@latest
+  --- test-user/default/test@stable
+  +++ test-user/default/test@latest
   @@ -1,4 +1,19 @@
   +imports:
   +  - a
@@ -128,8 +128,8 @@ stdout: |
   > esc env diff test@1
   # Value
   ```diff
-  --- test-user/test@1
-  +++ test-user/test@latest
+  --- test-user/default/test@1
+  +++ test-user/default/test@latest
   @@ -1 +1,19 @@
   +{
   +  "array": [
@@ -155,8 +155,8 @@ stdout: |
   ```
   # Definition
   ```diff
-  --- test-user/test@1
-  +++ test-user/test@latest
+  --- test-user/default/test@1
+  +++ test-user/default/test@latest
   @@ -1 +1,19 @@
   +imports:
   +  - a
@@ -182,8 +182,8 @@ stdout: |
   > esc env diff test@2
   # Value
   ```diff
-  --- test-user/test@2
-  +++ test-user/test@latest
+  --- test-user/default/test@2
+  +++ test-user/default/test@latest
   @@ -1,6 +1,19 @@
    {
   +  "array": [
@@ -211,8 +211,8 @@ stdout: |
   ```
   # Definition
   ```diff
-  --- test-user/test@2
-  +++ test-user/test@latest
+  --- test-user/default/test@2
+  +++ test-user/default/test@latest
   @@ -1,4 +1,19 @@
   +imports:
   +  - a
@@ -241,8 +241,8 @@ stdout: |
   > esc env diff test@1 @2
   # Value
   ```diff
-  --- test-user/test@1
-  +++ test-user/test@2
+  --- test-user/default/test@1
+  +++ test-user/default/test@2
   @@ -1 +1,6 @@
   +{
   +  "environmentVariables": {
@@ -255,8 +255,8 @@ stdout: |
   ```
   # Definition
   ```diff
-  --- test-user/test@1
-  +++ test-user/test@2
+  --- test-user/default/test@1
+  +++ test-user/default/test@2
   @@ -1 +1,4 @@
   +values:
   +  string: hello, world!
@@ -267,8 +267,8 @@ stdout: |
   > esc env diff test@1 @stable
   # Value
   ```diff
-  --- test-user/test@1
-  +++ test-user/test@stable
+  --- test-user/default/test@1
+  +++ test-user/default/test@stable
   @@ -1 +1,6 @@
   +{
   +  "environmentVariables": {
@@ -281,8 +281,8 @@ stdout: |
   ```
   # Definition
   ```diff
-  --- test-user/test@1
-  +++ test-user/test@stable
+  --- test-user/default/test@1
+  +++ test-user/default/test@stable
   @@ -1 +1,4 @@
   +values:
   +  string: hello, world!
@@ -293,8 +293,8 @@ stdout: |
   > esc env diff test@stable test-v2@stable
   # Value
   ```diff
-  --- test-user/test@stable
-  +++ test-user/test-v2@stable
+  --- test-user/default/test@stable
+  +++ test-user/default/test-v2@stable
   @@ -2,5 +2,5 @@
      "environmentVariables": {
        "FOO": "bar"
@@ -307,8 +307,8 @@ stdout: |
   ```
   # Definition
   ```diff
-  --- test-user/test@stable
-  +++ test-user/test-v2@stable
+  --- test-user/default/test@stable
+  +++ test-user/default/test-v2@stable
   @@ -1,4 +1,4 @@
    values:
   -  string: hello, world!
@@ -320,8 +320,8 @@ stdout: |
   > esc env diff test test-v2
   # Value
   ```diff
-  --- test-user/test@latest
-  +++ test-user/test-v2
+  --- test-user/default/test@latest
+  +++ test-user/default/test-v2
   @@ -1,19 +1,7 @@
    {
   -  "array": [
@@ -349,8 +349,8 @@ stdout: |
   ```
   # Definition
   ```diff
-  --- test-user/test@latest
-  +++ test-user/test-v2
+  --- test-user/default/test@latest
+  +++ test-user/default/test-v2
   @@ -3,17 +3,7 @@
      - b
    values:
@@ -374,8 +374,8 @@ stdout: |
 
   ```
   > esc env diff test@stable --format json
-  --- test-user/test@stable
-  +++ test-user/test@latest
+  --- test-user/default/test@stable
+  +++ test-user/default/test@latest
   @@ -1,6 +1,19 @@
    {
   +  "array": [
@@ -399,21 +399,21 @@ stdout: |
   +  "string": "esc"
    }
   > esc env diff test@stable --format string
-  --- test-user/test@stable
-  +++ test-user/test@latest
+  --- test-user/default/test@stable
+  +++ test-user/default/test@latest
   @@ -1 +1 @@
   -"environmentVariables"="\"FOO\"=\"bar\"","string"="hello, world!"
   +"array"="\"hello\",\"world\"","boolean"="true","environmentVariables"="\"BAR\"=\"qux\",\"FOO\"=\"baz\"","null"="","number"="42","object"="\"hello\"=\"world\"","open"="[unknown]","secret"="[secret]","string"="esc"
   > esc env diff test@stable --format dotenv
-  --- test-user/test@stable
-  +++ test-user/test@latest
+  --- test-user/default/test@stable
+  +++ test-user/default/test@latest
   @@ -1 +1,2 @@
   -FOO="bar"
   +BAR="qux"
   +FOO="baz"
   > esc env diff test@stable --format shell
-  --- test-user/test@stable
-  +++ test-user/test@latest
+  --- test-user/default/test@stable
+  +++ test-user/default/test@latest
   @@ -1 +1,2 @@
   -export FOO="bar"
   +export BAR="qux"

--- a/cmd/esc/cli/testdata/env-edit-editor-abort.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-abort.yaml
@@ -6,7 +6,7 @@ process:
     my-editor: |
       echo -n "" >$1
 environments:
-  test-user/test:
+  test-user/default/test:
     values:
       foo: bar
 stdout: |

--- a/cmd/esc/cli/testdata/env-edit-editor-diags.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-diags.yaml
@@ -8,7 +8,7 @@ process:
     my-editor: |
       echo -e "values:\n  foo: baz\n" >$1
 environments:
-  test-user/test:
+  test-user/default/test:
     imports:
       - a
     values:

--- a/cmd/esc/cli/testdata/env-edit-editor-docs-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-docs-ok.yaml
@@ -8,7 +8,7 @@ process:
     my-editor: |
       echo -e "values:\n  foo: baz\n---\n extra YAML doc" >$1
 environments:
-  test-user/test:
+  test-user/default/test:
     values:
       foo: bar
 stdout: |+

--- a/cmd/esc/cli/testdata/env-edit-editor-invalid.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-invalid.yaml
@@ -6,7 +6,7 @@ process:
     my-editor: |
       echo -e "imports:\n" >$1
 environments:
-  test-user/test:
+  test-user/default/test:
     values:
       foo: bar
 stdout: |

--- a/cmd/esc/cli/testdata/env-edit-editor-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-ok.yaml
@@ -8,7 +8,7 @@ process:
     my-editor: |
       echo -e "values:\n  foo: baz\n" >$1
 environments:
-  test-user/test:
+  test-user/default/test:
     values:
       foo: bar
 stdout: |+

--- a/cmd/esc/cli/testdata/env-edit-file.yaml
+++ b/cmd/esc/cli/testdata/env-edit-file.yaml
@@ -5,7 +5,7 @@ run: |
   esc env edit test -f=def.yaml
   esc env get test
 environments:
-  test-user/test:
+  test-user/default/test:
     values:
       foo: bar
 stdout: |+

--- a/cmd/esc/cli/testdata/env-edit-flag-code-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-code-ok.yaml
@@ -7,7 +7,7 @@ process:
       if [[ "$1" -ne "-w" ]]; then exit 1; fi
       echo -e "values:\n  foo: baz\n" >$2
 environments:
-  test-user/test:
+  test-user/default/test:
     values:
       foo: bar
 stdout: |+

--- a/cmd/esc/cli/testdata/env-edit-flag-editor-args.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-editor-args.yaml
@@ -8,7 +8,7 @@ process:
       if [[ "$2" -ne '--other-flag=a\"b' ]]; then exit 1; fi
       echo -e "values:\n  foo: baz\n" >$2
 environments:
-  test-user/test:
+  test-user/default/test:
     values:
       foo: bar
 stdout: |+

--- a/cmd/esc/cli/testdata/env-edit-flag-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-ok.yaml
@@ -6,7 +6,7 @@ process:
     my-editor: |
       echo -e "values:\n  foo: baz\n" >$1
 environments:
-  test-user/test:
+  test-user/default/test:
     values:
       foo: bar
 stdout: |+

--- a/cmd/esc/cli/testdata/env-edit-none-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-none-ok.yaml
@@ -6,7 +6,7 @@ process:
     vi: |
       echo -e "values:\n  foo: baz\n" >$1
 environments:
-  test-user/test:
+  test-user/default/test:
     values:
       foo: bar
 stdout: |+

--- a/cmd/esc/cli/testdata/env-edit-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-edit-revision-or-tag.yaml
@@ -7,7 +7,7 @@ process:
     my-editor: |
       echo -e "\n" >$1
 environments:
-  test-user/test:
+  test-user/default/test:
     values:
       foo: bar
 stdout: |

--- a/cmd/esc/cli/testdata/env-edit-visual-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-visual-ok.yaml
@@ -8,7 +8,7 @@ process:
     my-editor: |
       echo -e "values:\n  foo: baz\n" >$1
 environments:
-  test-user/test:
+  test-user/default/test:
     values:
       foo: bar
 stdout: |+

--- a/cmd/esc/cli/testdata/env-get-all-value-dotenv.yaml
+++ b/cmd/esc/cli/testdata/env-get-all-value-dotenv.yaml
@@ -2,9 +2,9 @@ run: |
   esc env get test --value=dotenv
   esc env get test --value=dotenv --show-secrets
 environments:
-  test-user/a: {}
-  test-user/b: {}
-  test-user/test:
+  test-user/default/a: {}
+  test-user/default/b: {}
+  test-user/default/test:
     imports:
       - a
       - b

--- a/cmd/esc/cli/testdata/env-get-all-value-shell.yaml
+++ b/cmd/esc/cli/testdata/env-get-all-value-shell.yaml
@@ -2,9 +2,9 @@ run: |
   esc env get test --value=shell
   esc env get test --value=shell --show-secrets
 environments:
-  test-user/a: {}
-  test-user/b: {}
-  test-user/test:
+  test-user/default/a: {}
+  test-user/default/b: {}
+  test-user/default/test:
     imports:
       - a
       - b

--- a/cmd/esc/cli/testdata/env-get-all.yaml
+++ b/cmd/esc/cli/testdata/env-get-all.yaml
@@ -7,13 +7,13 @@ run: |
   esc env get test@3
   esc env get test@latest --show-secrets
 environments:
-  test-user/a: {}
-  test-user/b:
+  test-user/default/a: {}
+  test-user/default/b:
     values:
       baseSecret:
         fn::secret:
           ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
-  test-user/test:
+  test-user/default/test:
     revisions:
       - yaml:
           values:

--- a/cmd/esc/cli/testdata/env-get-each-import.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-import.yaml
@@ -3,14 +3,14 @@ run: |
   esc env get test 'imports[0]'
   esc env get test 'imports[1]'
 environments:
-  test-user/a:
+  test-user/default/a:
     values:
       object: {hello: esc, goodbye: world}
-  test-user/b:
+  test-user/default/b:
     values:
       string: foo
       object: {goodbye: all}
-  test-user/test:
+  test-user/default/test:
     imports:
       - a
       - b

--- a/cmd/esc/cli/testdata/env-get-each-value-detailed.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-value-detailed.yaml
@@ -11,14 +11,14 @@ run: |
   esc env get test --value detailed object.goodbye
   esc env get test --value detailed open
 environments:
-  test-user/a:
+  test-user/default/a:
     values:
       object: {hello: esc, goodbye: world}
-  test-user/b:
+  test-user/default/b:
     values:
       string: foo
       object: {goodbye: all}
-  test-user/test:
+  test-user/default/test:
     imports:
       - a
       - b

--- a/cmd/esc/cli/testdata/env-get-each-value-json.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-value-json.yaml
@@ -11,14 +11,14 @@ run: |
   esc env get test --value json object.goodbye
   esc env get test --value json open
 environments:
-  test-user/a:
+  test-user/default/a:
     values:
       object: {hello: esc, goodbye: world}
-  test-user/b:
+  test-user/default/b:
     values:
       string: foo
       object: {goodbye: all}
-  test-user/test:
+  test-user/default/test:
     imports:
       - a
       - b

--- a/cmd/esc/cli/testdata/env-get-each-value-string.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-value-string.yaml
@@ -11,14 +11,14 @@ run: |
   esc env get test --value string object.goodbye
   esc env get test --value string open
 environments:
-  test-user/a:
+  test-user/default/a:
     values:
       object: {hello: esc, goodbye: world}
-  test-user/b:
+  test-user/default/b:
     values:
       string: foo
       object: {goodbye: all}
-  test-user/test:
+  test-user/default/test:
     imports:
       - a
       - b

--- a/cmd/esc/cli/testdata/env-get-each.yaml
+++ b/cmd/esc/cli/testdata/env-get-each.yaml
@@ -13,14 +13,14 @@ run: |
   esc env get test 'open["fn::open::test"]'
   esc env get test 'open["fn::open::test"].foo'
 environments:
-  test-user/a:
+  test-user/default/a:
     values:
       object: {hello: esc, goodbye: world}
-  test-user/b:
+  test-user/default/b:
     values:
       string: foo
       object: {goodbye: all}
-  test-user/test:
+  test-user/default/test:
     imports:
       - a
       - b

--- a/cmd/esc/cli/testdata/env-init-conflict.yaml
+++ b/cmd/esc/cli/testdata/env-init-conflict.yaml
@@ -1,7 +1,7 @@
 run: esc env init dup
 error: exit status 1
 environments:
-  test-user/dup: arbitrary
+  test-user/default/dup: arbitrary
 stdout: |
   > esc env init dup
 stderr: |

--- a/cmd/esc/cli/testdata/env-init-diags.yaml
+++ b/cmd/esc/cli/testdata/env-init-diags.yaml
@@ -4,7 +4,7 @@ run: |
 error: exit status 1
 stdout: |
   > esc env init test-stdin -f=-
-  Environment created.
+  Environment created: test-user/default/test-stdin
 stderr: |
   > esc env init test-stdin -f=-
   Error: unknown property "bar"

--- a/cmd/esc/cli/testdata/env-init-ok.yaml
+++ b/cmd/esc/cli/testdata/env-init-ok.yaml
@@ -8,11 +8,11 @@ run: |
   esc env get test-file
 stdout: |+
   > esc env init test-env
-  Environment created.
+  Environment created: test-user/default/test-env
   > esc env get test-env
 
   > esc env init test-stdin -f=-
-  Environment created.
+  Environment created: test-user/default/test-stdin
   > esc env get test-stdin
   # Value
   ```json
@@ -27,7 +27,7 @@ stdout: |+
   ```
 
   > esc env init test-file -f def.yaml
-  Environment created.
+  Environment created: test-user/default/test-file
   > esc env get test-file
   # Value
   ```json

--- a/cmd/esc/cli/testdata/env-ls.yaml
+++ b/cmd/esc/cli/testdata/env-ls.yaml
@@ -1,16 +1,16 @@
 run: esc env ls
 environments:
-  test-org-2/env: true
-  test-org/env: true
-  test-org/env-2: true
-  test-user/env: true
-  test-user/env-2: true
+  test-org-2/default/env: true
+  test-org/default/env: true
+  test-org/default/env-2: true
+  test-user/default/env: true
+  test-user/default/env-2: true
 stdout: |
   > esc env ls
-  env
-  env-2
-  test-org/env
-  test-org/env-2
-  test-org-2/env
+  default/env
+  default/env-2
+  test-org/default/env
+  test-org/default/env-2
+  test-org-2/default/env
 stderr: |
   > esc env ls

--- a/cmd/esc/cli/testdata/env-rm-each.yaml
+++ b/cmd/esc/cli/testdata/env-rm-each.yaml
@@ -11,14 +11,14 @@ run: |
   esc env rm test 'open["fn::open::test"].foo' && esc env get test
   esc env rm test open && esc env get test
 environments:
-  test-user/a:
+  test-user/default/a:
     values:
       object: {hello: esc, goodbye: world}
-  test-user/b:
+  test-user/default/b:
     values:
       string: foo
       object: {goodbye: all}
-  test-user/test:
+  test-user/default/test:
     imports:
       - a
       - b

--- a/cmd/esc/cli/testdata/env-rm-ok.yaml
+++ b/cmd/esc/cli/testdata/env-rm-ok.yaml
@@ -1,8 +1,8 @@
 run: esc env rm dup -y
 environments:
-  test-user/dup: arbitrary
+  test-user/default/dup: arbitrary
 stdout: |
   > esc env rm dup -y
-  Environment "test-user/dup" has been removed!
+  Environment "test-user/default/dup" has been removed!
 stderr: |
   > esc env rm dup -y

--- a/cmd/esc/cli/testdata/env-set-invalid.yaml
+++ b/cmd/esc/cli/testdata/env-set-invalid.yaml
@@ -8,7 +8,7 @@ run: |
   esc env set test array.foo bar || echo -n ""
 stdout: |
   > esc env init test
-  Environment created.
+  Environment created: test-user/default/test
   > esc env set test string foo
   > esc env set test object {}
   > esc env set test array []

--- a/cmd/esc/cli/testdata/env-set-secret-error.yaml
+++ b/cmd/esc/cli/testdata/env-set-secret-error.yaml
@@ -4,7 +4,7 @@ run: |
 error: exit status 1
 stdout: |
   > esc env init test
-  Environment created.
+  Environment created: test-user/default/test
   > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
 stderr: |
   > esc env init test

--- a/cmd/esc/cli/testdata/env-set-secret.yaml
+++ b/cmd/esc/cli/testdata/env-set-secret.yaml
@@ -19,7 +19,7 @@ run: |
   esc env set test password '[]' --secret || echo OK
 stdout: |
   > esc env init test
-  Environment created.
+  Environment created: test-user/default/test
   > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
   OK
   > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret

--- a/cmd/esc/cli/testdata/env-set.yaml
+++ b/cmd/esc/cli/testdata/env-set.yaml
@@ -17,7 +17,7 @@ run: |
   esc env set test 'imports[1]' test3 && esc env get test
 stdout: |+
   > esc env init test
-  Environment created.
+  Environment created: test-user/default/test
   > esc env set test foo.bar.baz qux
   > esc env get test
   # Value
@@ -397,7 +397,7 @@ stdout: |+
   ```
 
   > esc env init test2
-  Environment created.
+  Environment created: test-user/default/test2
   > esc env set test imports[0] test2
   > esc env get test
   # Value
@@ -445,7 +445,7 @@ stdout: |+
   ```
 
   > esc env init test3
-  Environment created.
+  Environment created: test-user/default/test3
   > esc env set test imports[1] test3
   > esc env get test
   # Value

--- a/cmd/esc/cli/testdata/env-tag-arg-err.yaml
+++ b/cmd/esc/cli/testdata/env-tag-arg-err.yaml
@@ -1,13 +1,13 @@
 run: |
-  esc env tag ls test-org/env
-  esc env tag test-org/env owner
+  esc env tag ls test-org/default/env
+  esc env tag test-org/default/env owner
 error: exit status 1
 environments:
-  test-org/env: {}
+  test-org/default/env: {}
 stdout: |
-  > esc env tag ls test-org/env
-  > esc env tag test-org/env owner
+  > esc env tag ls test-org/default/env
+  > esc env tag test-org/default/env owner
 stderr: |
-  > esc env tag ls test-org/env
-  > esc env tag test-org/env owner
+  > esc env tag ls test-org/default/env
+  > esc env tag test-org/default/env owner
   Error: accepts 3 arg(s), received 2

--- a/cmd/esc/cli/testdata/env-tag-empty-err.yaml
+++ b/cmd/esc/cli/testdata/env-tag-empty-err.yaml
@@ -1,6 +1,6 @@
-run: esc env tag test-org/env "" ""
+run: esc env tag test-org/default/env "" ""
 error: exit status 1
 environments:
-  test-org/env: {}
-stdout: "> esc env tag test-org/env  \n"
-stderr: "> esc env tag test-org/env  \nError: environment tag name cannot be empty\n"
+  test-org/default/env: {}
+stdout: "> esc env tag test-org/default/env  \n"
+stderr: "> esc env tag test-org/default/env  \nError: environment tag name cannot be empty\n"

--- a/cmd/esc/cli/testdata/env-tag-ls.yaml
+++ b/cmd/esc/cli/testdata/env-tag-ls.yaml
@@ -1,26 +1,26 @@
 run: |
-  esc env tag ls test-org/one-tag --utc
-  esc env tag ls test-org/no-tags --utc
-  esc env tag ls test-user/multi-tags --utc
+  esc env tag ls test-org/default/one-tag --utc
+  esc env tag ls test-org/default/no-tags --utc
+  esc env tag ls test-user/default/multi-tags --utc
 environments:
-  test-org/no-tags: {}
-  test-org/one-tag:
+  test-org/default/no-tags: {}
+  test-org/default/one-tag:
     tags:
       owner: pulumi
-  test-user/multi-tags:
+  test-user/default/multi-tags:
     tags:
       owner: pulumipus
       team: esc
-  test-user/unused:
+  test-user/default/unused:
     tags:
       owner: pulumipus
 stdout: |
-  > esc env tag ls test-org/one-tag --utc
+  > esc env tag ls test-org/default/one-tag --utc
   Name: owner
   Value: pulumi
   Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag ls test-org/no-tags --utc
-  > esc env tag ls test-user/multi-tags --utc
+  > esc env tag ls test-org/default/no-tags --utc
+  > esc env tag ls test-user/default/multi-tags --utc
   Name: owner
   Value: pulumipus
   Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
@@ -28,6 +28,6 @@ stdout: |
   Value: esc
   Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
 stderr: |
-  > esc env tag ls test-org/one-tag --utc
-  > esc env tag ls test-org/no-tags --utc
-  > esc env tag ls test-user/multi-tags --utc
+  > esc env tag ls test-org/default/one-tag --utc
+  > esc env tag ls test-org/default/no-tags --utc
+  > esc env tag ls test-user/default/multi-tags --utc

--- a/cmd/esc/cli/testdata/env-tag-mv.yaml
+++ b/cmd/esc/cli/testdata/env-tag-mv.yaml
@@ -1,30 +1,30 @@
 run: |
-  esc env tag ls test-org/env --utc
-  esc env tag mv test-org/env team owner --utc
-  esc env tag get test-org/env owner --utc
-  esc env tag mv test-org/env team --utc
+  esc env tag ls test-org/default/env --utc
+  esc env tag mv test-org/default/env team owner --utc
+  esc env tag get test-org/default/env owner --utc
+  esc env tag mv test-org/default/env team --utc
 error: exit status 1
 environments:
-  test-org/env:
+  test-org/default/env:
     tags:
       team: pulumi
 stdout: |
-  > esc env tag ls test-org/env --utc
+  > esc env tag ls test-org/default/env --utc
   Name: team
   Value: pulumi
   Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag mv test-org/env team owner --utc
+  > esc env tag mv test-org/default/env team owner --utc
   Name: owner
   Value: pulumi
   Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag get test-org/env owner --utc
+  > esc env tag get test-org/default/env owner --utc
   Name: owner
   Value: pulumi
   Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag mv test-org/env team --utc
+  > esc env tag mv test-org/default/env team --utc
 stderr: |
-  > esc env tag ls test-org/env --utc
-  > esc env tag mv test-org/env team owner --utc
-  > esc env tag get test-org/env owner --utc
-  > esc env tag mv test-org/env team --utc
+  > esc env tag ls test-org/default/env --utc
+  > esc env tag mv test-org/default/env team owner --utc
+  > esc env tag get test-org/default/env owner --utc
+  > esc env tag mv test-org/default/env team --utc
   Error: accepts 3 arg(s), received 2

--- a/cmd/esc/cli/testdata/env-tag-rm.yaml
+++ b/cmd/esc/cli/testdata/env-tag-rm.yaml
@@ -1,25 +1,25 @@
 run: |
-  esc env tag ls test-org/env --utc
-  esc env tag rm test-org/env owner
-  esc env tag ls test-org/env --utc
-  esc env tag rm test-org/env owner
+  esc env tag ls test-org/default/env --utc
+  esc env tag rm test-org/default/env owner
+  esc env tag ls test-org/default/env --utc
+  esc env tag rm test-org/default/env owner
 error: exit status 1
 environments:
-  test-org/env:
+  test-org/default/env:
     tags:
       owner: pulumi
 stdout: |
-  > esc env tag ls test-org/env --utc
+  > esc env tag ls test-org/default/env --utc
   Name: owner
   Value: pulumi
   Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag rm test-org/env owner
+  > esc env tag rm test-org/default/env owner
   Successfully deleted environment tag: owner
-  > esc env tag ls test-org/env --utc
-  > esc env tag rm test-org/env owner
+  > esc env tag ls test-org/default/env --utc
+  > esc env tag rm test-org/default/env owner
 stderr: |
-  > esc env tag ls test-org/env --utc
-  > esc env tag rm test-org/env owner
-  > esc env tag ls test-org/env --utc
-  > esc env tag rm test-org/env owner
+  > esc env tag ls test-org/default/env --utc
+  > esc env tag rm test-org/default/env owner
+  > esc env tag ls test-org/default/env --utc
+  > esc env tag rm test-org/default/env owner
   Error: tag not found

--- a/cmd/esc/cli/testdata/env-tag.yaml
+++ b/cmd/esc/cli/testdata/env-tag.yaml
@@ -1,31 +1,31 @@
 run: |
-  esc env tag ls test-org/env --utc
-  esc env tag test-org/env owner pulumi --utc
-  esc env tag get test-org/env owner --utc
-  esc env tag test-org/env team esc-team --utc
-  esc env tag ls test-org/env --utc
+  esc env tag ls test-org/default/env --utc
+  esc env tag test-org/default/env owner pulumi --utc
+  esc env tag get test-org/default/env owner --utc
+  esc env tag test-org/default/env team esc-team --utc
+  esc env tag ls test-org/default/env --utc
 environments:
-  test-org/env:
+  test-org/default/env:
     tags:
       team: esc
 stdout: |
-  > esc env tag ls test-org/env --utc
+  > esc env tag ls test-org/default/env --utc
   Name: team
   Value: esc
   Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag test-org/env owner pulumi --utc
+  > esc env tag test-org/default/env owner pulumi --utc
   Name: owner
   Value: pulumi
   Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag get test-org/env owner --utc
+  > esc env tag get test-org/default/env owner --utc
   Name: owner
   Value: pulumi
   Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag test-org/env team esc-team --utc
+  > esc env tag test-org/default/env team esc-team --utc
   Name: team
   Value: esc-team
   Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag ls test-org/env --utc
+  > esc env tag ls test-org/default/env --utc
   Name: owner
   Value: pulumi
   Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
@@ -33,8 +33,8 @@ stdout: |
   Value: esc-team
   Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
 stderr: |
-  > esc env tag ls test-org/env --utc
-  > esc env tag test-org/env owner pulumi --utc
-  > esc env tag get test-org/env owner --utc
-  > esc env tag test-org/env team esc-team --utc
-  > esc env tag ls test-org/env --utc
+  > esc env tag ls test-org/default/env --utc
+  > esc env tag test-org/default/env owner pulumi --utc
+  > esc env tag get test-org/default/env owner --utc
+  > esc env tag test-org/default/env team esc-team --utc
+  > esc env tag ls test-org/default/env --utc

--- a/cmd/esc/cli/testdata/env-version-history.yaml
+++ b/cmd/esc/cli/testdata/env-version-history.yaml
@@ -7,9 +7,9 @@ run: |
   esc env version history test@3 --utc
   esc env version history test@4 --utc
 environments:
-  test-user/a: {}
-  test-user/b: {}
-  test-user/test:
+  test-user/default/a: {}
+  test-user/default/b: {}
+  test-user/default/test:
     revisions:
       - yaml:
           values: {}

--- a/cmd/esc/cli/testdata/env-version-retract.yaml
+++ b/cmd/esc/cli/testdata/env-version-retract.yaml
@@ -7,7 +7,7 @@ run: |
   esc env version retract test@4
   esc env version history test --utc
 environments:
-  test-user/test:
+  test-user/default/test:
     revisions:
       - yaml:
           values:

--- a/cmd/esc/cli/testdata/env-version-rollback.yaml
+++ b/cmd/esc/cli/testdata/env-version-rollback.yaml
@@ -4,9 +4,9 @@ run: |
   esc env version rollback test@2
 error: exit status 1
 environments:
-  test-user/a: {}
-  test-user/b: {}
-  test-user/test:
+  test-user/default/a: {}
+  test-user/default/b: {}
+  test-user/default/test:
     revisions:
       - yaml:
           imports:

--- a/cmd/esc/cli/testdata/env-version-tag.yaml
+++ b/cmd/esc/cli/testdata/env-version-tag.yaml
@@ -12,9 +12,9 @@ run: |
   esc env version tag rm test@initial
   esc env version tag ls test --utc
 environments:
-  test-user/a: {}
-  test-user/b: {}
-  test-user/test:
+  test-user/default/a: {}
+  test-user/default/b: {}
+  test-user/default/test:
     revisions:
       - yaml:
           values: {}

--- a/cmd/esc/cli/testdata/open-detailed.yaml
+++ b/cmd/esc/cli/testdata/open-detailed.yaml
@@ -1,11 +1,11 @@
 run: esc open test --format detailed
 environments:
-  test-user/test:
+  test-user/default/test:
     imports:
       - test-2
     values:
       foo: bar
-  test-user/test-2:
+  test-user/default/test-2:
     values:
       foo: baz
       hello: world

--- a/cmd/esc/cli/testdata/open-dotenv.yaml
+++ b/cmd/esc/cli/testdata/open-dotenv.yaml
@@ -1,6 +1,6 @@
 run: esc open test --format dotenv
 environments:
-  test-user/test:
+  test-user/default/test:
     imports:
       - test-2
     values:
@@ -14,7 +14,7 @@ environments:
       files:
         BOOL_FILE: ${yup}
         NUM_FILE: ${pi}
-  test-user/test-2:
+  test-user/default/test-2:
     values:
       foo: baz
       hello: world

--- a/cmd/esc/cli/testdata/open-json-error.yaml
+++ b/cmd/esc/cli/testdata/open-json-error.yaml
@@ -1,6 +1,6 @@
 run: esc open test --format json
 environments:
-  test-user/test:
+  test-user/default/test:
     values:
       object: {}
       missing: ${foo}

--- a/cmd/esc/cli/testdata/open-json.yaml
+++ b/cmd/esc/cli/testdata/open-json.yaml
@@ -6,7 +6,7 @@ run: |
   esc open test@2
   esc open test@3
 environments:
-  test-user/test:
+  test-user/default/test:
     revisions:
       - yaml:
           values:
@@ -18,7 +18,7 @@ environments:
             - test-2
           values:
             foo: bar
-  test-user/test-2:
+  test-user/default/test-2:
     values:
       foo: baz
       hello: world

--- a/cmd/esc/cli/testdata/open-shell.yaml
+++ b/cmd/esc/cli/testdata/open-shell.yaml
@@ -1,6 +1,6 @@
 run: esc open test --format shell
 environments:
-  test-user/test:
+  test-user/default/test:
     imports:
       - test-2
     values:
@@ -14,7 +14,7 @@ environments:
       files:
         BOOL_FILE: ${yup}
         NUM_FILE: ${pi}
-  test-user/test-2:
+  test-user/default/test-2:
     values:
       foo: baz
       hello: world

--- a/cmd/esc/cli/testdata/open-string.yaml
+++ b/cmd/esc/cli/testdata/open-string.yaml
@@ -1,11 +1,11 @@
 run: esc open test --format string
 environments:
-  test-user/test:
+  test-user/default/test:
     imports:
       - test-2
     values:
       foo: bar
-  test-user/test-2:
+  test-user/default/test-2:
     values:
       foo: baz
       hello: world

--- a/cmd/esc/cli/testdata/open-yaml.yaml
+++ b/cmd/esc/cli/testdata/open-yaml.yaml
@@ -1,11 +1,11 @@
 run: esc open test --format yaml
 environments:
-  test-user/test:
+  test-user/default/test:
     imports:
       - test-2
     values:
       foo: bar
-  test-user/test-2:
+  test-user/default/test-2:
     values:
       foo: baz
       hello: world

--- a/cmd/esc/cli/testdata/run.yaml
+++ b/cmd/esc/cli/testdata/run.yaml
@@ -17,7 +17,7 @@ process:
       source $FILE
       echo "secret: $F_SECRET, plain: $F_PLAIN"
 environments:
-  test-user/test:
+  test-user/default/test:
     values:
       secret: {"fn::secret": "hunter2"}
       plain: plaintext


### PR DESCRIPTION
## Description
Adds Projects (groupings of ESC environments) to the ESC CLI

## Testing
setup: personal/default org = `syeh2`. other orgs = `ambiguous`

### Init
```bash
❯ go run ./cmd/esc env init env1
Environment created: syeh2/default/env1

❯ go run ./cmd/esc env init new-project/env1
Environment created: syeh2/new-project/env1

# Legacy pattern (org/env) because I have an org called `ambiguous`
❯ go run ./cmd/esc env init ambiguous/myenv
Environment created: ambiguous/default/myenv

# Test creating a project with the same name as an org
❯ go run ./cmd/esc env init syeh2/ambiguous/env1
Environment created: syeh2/ambiguous/env1

# Because now I have an existing env under the `ambiguous` project, I can create a new env under the same project with just `ambiguous/env2`
❯ go run ./cmd/esc env init ambiguous/env2
Environment created: syeh2/ambiguous/env2

```

### Get
Setup: Created 'syeh2/ambiguous/myenv' and 'ambiguous/default/myenv` envs beforehand
```bash
❯ go run ./cmd/esc env get ambiguous/myenv --value json
Error: ambiguous path provided

Environments found at both 'syeh2/ambiguous/myenv' and 'ambiguous/default/myenv'.
Please specify the full path as <org-name>/<project-name>/<env-name>
exit status 1

❯ go run ./cmd/esc env get syeh2/ambiguous/myenv --value json
{
...
}

❯ go run ./cmd/esc env get ambiguous/default/myenv --value json
{
...
}
```

### Get with cross-project imports
Setup: created proj1/shared, proj2/env
```bash
❯ go run ./cmd/esc env get proj2/env

   Value

    {
      "a": "hello"
    }

   Definition

    imports:
      - proj1/shared


```

### Edit/open
```bash
❯ go run ./cmd/esc env edit new-project/env1
Environment updated.

❯ go run ./cmd/esc env open new-project/env1
{
  "a": "hello"
}
```
### Rm
```bash
❯ go run ./cmd/esc env rm new-project/env1
This will permanently remove the "syeh2/new-project/env1" environment!
Please confirm that this is what you'd like to do by typing `syeh2/new-project/env1`: syeh2/new-project/env1
Environment "syeh2/new-project/env1" has been removed!
```

### Diff
Setup: created 'test2/default/versioned' with the `old` tag pointing to an older version
```bash
❯ go run ./cmd/esc env diff test2/versioned@old -f json
--- test2/default/versioned@old
+++ test2/default/versioned@latest
@@ -1,3 +1,3 @@
 {
-  "example": "first"
+  "example": "newer"
 }

❯ go run ./cmd/esc env diff test2/versioned@old test2/versioned@old -f json
# empty because diffing against itself

❯ go run ./cmd/esc env diff test2/versioned@old test2/versioned@latest -f json
--- test2/default/versioned@old
+++ test2/default/versioned@latest
@@ -1,3 +1,3 @@
 {
-  "example": "first"
+  "example": "newer"
 }

❯ go run ./cmd/esc env diff test2/versioned@old test2/default/versioned@latest -f json
--- test2/default/versioned@old
+++ test2/default/versioned@latest
@@ -1,3 +1,3 @@
 {
-  "example": "first"
+  "example": "newer"
 }
```

### Version
```bash
❯ go run ./cmd/esc env version test2/test-project/envvars@latest
latest
Revision 2
Last updated at 2024-08-09 08:45:52.766 -0500 CDT by  <syeh2>

❯ go run ./cmd/esc env version history test2/test-project/envvars
revision 2 (tag: latest)
Author:  <syeh2>
Date:   2024-08-09 08:45:52.765 -0500 CDT

revision 1
Author:  <syeh2>
Date:   2024-08-09 08:44:34.019 -0500 CDT
```