### PR TITLE
fix panic in eval

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -326,6 +326,10 @@ func declare[Expr exprNode](e *evalContext, path string, x Expr, base *value) *e
 	case *ast.ObjectExpr:
 		properties := make(map[string]*expr, len(x.Entries))
 		for _, entry := range x.Entries {
+			if entry.Key == nil {
+				e.errorf(entry.Key, "missing key")
+				continue
+			}
 			k := entry.Key.Value
 			if _, ok := properties[k]; ok {
 				e.errorf(entry.Key, "duplicate key %q", k)


### PR DESCRIPTION
Fixes a panic in the evaluator 

```
Callstack
panic({0x2b282c0?, 0x5f48800?})
    /usr/local/go/src/runtime/panic.go:770 +0x124
[github.com/pulumi/esc/eval.declare[...](0x400370fc78](http://github.com/pulumi/esc/eval.declare[...](0x400370fc78)?, {0x4004796940, 0x7}, {0x3c2d7e0, 0x4004337dd0?}, 0x0)
    /go/src/github.com/pulumi/pulumi-service/vendor/github.com/pulumi/esc/eval/eval.go:318 +0x1808
[github.com/pulumi/esc/eval.(*evalContext).evaluate(0x400370fc78)](http://github.com/pulumi/esc/eval.(*evalContext).evaluate(0x400370fc78))
    /go/src/github.com/pulumi/pulumi-service/vendor/github.com/pulumi/esc/eval/eval.go:369 +0x414
[github.com/pulumi/esc/eval.evalEnvironment({0x3c319f8](http://github.com/pulumi/esc/eval.evalEnvironment(%7B0x3c319f8), 0x40043363c0}, 0x1, {0x32197cf, 0x6}, 0x4003716840, {0x0, 0x0}, {0x3c07520, 0x4003666b48}, ...)
    /go/src/github.com/pulumi/pulumi-service/vendor/github.com/pulumi/esc/eval/eval.go:114 +0x154
[github.com/pulumi/esc/eval.CheckEnvironment(...)](http://github.com/pulumi/esc/eval.CheckEnvironment(...))
    /go/src/github.com/pulumi/pulumi-service/vendor/github.com/pulumi/esc/eval/eval.go:95
```