### PR TITLE
Add warning message when using deprecated env name format

### DIFF
--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -74,14 +74,20 @@ type environmentRef struct {
 	hasAmbiguousPath bool
 }
 
-func (r *environmentRef) String() string {
+func (r *environmentRef) Id() string {
 	s := fmt.Sprintf("%s/%s", r.projectName, r.envName)
+
+	if r.version != "" {
+		s = fmt.Sprintf("%s@%s", s, r.version)
+	}
+	return s
+}
+
+func (r *environmentRef) String() string {
+	s := r.Id()
 
 	if r.orgName != "" {
 		s = fmt.Sprintf("%s/%s", r.orgName, s)
-	}
-	if r.version != "" {
-		s = fmt.Sprintf("%s@%s", s, r.version)
 	}
 	return s
 }
@@ -128,17 +134,24 @@ func (cmd *envCommand) parseRef(refStr string) environmentRef {
 }
 
 // getEnvRef returns an environment reference corresponding to the given ref string
-// If a non-nil environmentRef is provided, default to its values if only a sole version is specified
-func (cmd *envCommand) getEnvRef(refString string, rel *environmentRef) environmentRef {
+// and a bool indicating if the environment reference is relative.
+//
+// If `refString` is only a version (i.e. "@123") and a non-nil environmentRef `rel` is provided,
+// the returned environment reference is "relative" and will default to the provided environmentRef's values
+func (cmd *envCommand) getEnvRef(refString string, rel *environmentRef) (environmentRef, bool) {
 	envRef := cmd.parseRef(refString)
 
+	isRelative := false
+	// If refString is only a version, copy fields from `rel`
 	if rel != nil && envRef.envName == "" && envRef.version != "" {
 		envRef.orgName = rel.orgName
 		envRef.projectName = rel.projectName
 		envRef.envName = rel.envName
+
+		isRelative = true
 	}
 
-	return envRef
+	return envRef, isRelative
 }
 
 // Get an environment reference when creating a new environment
@@ -154,9 +167,13 @@ func (cmd *envCommand) getNewEnvRef(
 		cmd.envNameFlag, args = args[0], args[1:]
 	}
 
-	ref := cmd.getEnvRef(cmd.envNameFlag, nil)
+	ref, isRelative := cmd.getEnvRef(cmd.envNameFlag, nil)
 
 	if !ref.hasAmbiguousPath {
+		if !strings.Contains(cmd.envNameFlag, "/") && !isRelative {
+			cmd.printDeprecatedNameMessage(cmd.envNameFlag, ref)
+		}
+
 		return ref, args, nil
 	}
 
@@ -189,6 +206,7 @@ func (cmd *envCommand) getNewEnvRef(
 	}
 
 	if !existsProject && existsLegacyPath {
+		cmd.printDeprecatedNameMessage(cmd.envNameFlag, legacyRef)
 		return legacyRef, args, nil
 	}
 
@@ -218,9 +236,13 @@ func (cmd *envCommand) getExistingEnvRefWithRelative(
 	refString string,
 	rel *environmentRef,
 ) (environmentRef, error) {
-	ref := cmd.getEnvRef(refString, rel)
+	ref, isRelative := cmd.getEnvRef(refString, rel)
 
 	if !ref.hasAmbiguousPath {
+		if !strings.Contains(refString, "/") && !isRelative {
+			cmd.printDeprecatedNameMessage(refString, ref)
+		}
+
 		return ref, nil
 	}
 
@@ -253,6 +275,7 @@ func (cmd *envCommand) getExistingEnvRefWithRelative(
 	}
 
 	if existsLegacyPath {
+		cmd.printDeprecatedNameMessage(refString, legacyRef)
 		return legacyRef, nil
 	}
 
@@ -351,4 +374,11 @@ func (cmd *envCommand) writePropertyEnvironmentDiagnostics(out io.Writer, diags 
 	}
 
 	return nil
+}
+
+func (cmd *envCommand) printDeprecatedNameMessage(name string, ref environmentRef) {
+	msg := fmt.Sprintf(
+		"%sWarning: Referring to an environment name ('%s') without a project is deprecated.\nPlease use '%s/%s' or '%s' instead.%s",
+		colors.SpecWarning, name, ref.orgName, ref.Id(), ref.Id(), colors.Reset)
+	fmt.Fprintln(cmd.esc.stderr, cmd.esc.colors.Colorize(msg))
 }

--- a/cmd/esc/cli/env_test.go
+++ b/cmd/esc/cli/env_test.go
@@ -19,37 +19,40 @@ func TestGetEnvRef(t *testing.T) {
 	t.Run("1 identifier", func(t *testing.T) {
 		refString := "abc@v1"
 
-		ref := cmd.getEnvRef(refString, nil)
+		ref, isRelative := cmd.getEnvRef(refString, nil)
 
 		assert.Equal(t, ref.orgName, defaultOrg)
 		assert.Equal(t, ref.projectName, client.DefaultProject)
 		assert.Equal(t, ref.envName, "abc")
 		assert.Equal(t, ref.version, "v1")
 		assert.Equal(t, ref.hasAmbiguousPath, false)
+		assert.Equal(t, isRelative, false)
 	})
 
 	t.Run("2 identifiers", func(t *testing.T) {
 		refString := "a/b@v1"
 
-		ref := cmd.getEnvRef(refString, nil)
+		ref, isRelative := cmd.getEnvRef(refString, nil)
 
 		assert.Equal(t, ref.orgName, defaultOrg)
 		assert.Equal(t, ref.projectName, "a")
 		assert.Equal(t, ref.envName, "b")
 		assert.Equal(t, ref.version, "v1")
 		assert.Equal(t, ref.hasAmbiguousPath, true)
+		assert.Equal(t, isRelative, false)
 	})
 
 	t.Run("3 identifiers", func(t *testing.T) {
 		refString := "a/b/c@v1"
 
-		ref := cmd.getEnvRef(refString, nil)
+		ref, isRelative := cmd.getEnvRef(refString, nil)
 
 		assert.Equal(t, ref.orgName, "a")
 		assert.Equal(t, ref.projectName, "b")
 		assert.Equal(t, ref.envName, "c")
 		assert.Equal(t, ref.version, "v1")
 		assert.Equal(t, ref.hasAmbiguousPath, false)
+		assert.Equal(t, isRelative, false)
 	})
 
 	t.Run("with relative env", func(t *testing.T) {
@@ -61,11 +64,12 @@ func TestGetEnvRef(t *testing.T) {
 			version:     "rel-version",
 		}
 
-		ref := cmd.getEnvRef(refString, rel)
+		ref, isRelative := cmd.getEnvRef(refString, rel)
 
 		assert.Equal(t, ref.orgName, "rel-org")
 		assert.Equal(t, ref.projectName, "rel-project")
 		assert.Equal(t, ref.envName, "rel-env")
 		assert.Equal(t, ref.version, "v1")
+		assert.Equal(t, isRelative, true)
 	})
 }

--- a/cmd/esc/cli/testdata/env-diff.yaml
+++ b/cmd/esc/cli/testdata/env-diff.yaml
@@ -1,18 +1,18 @@
 run: |
-  esc env diff test
-  esc env diff test@latest
-  esc env diff test@stable
-  esc env diff test@1
-  esc env diff test@2
-  esc env diff test@3
-  esc env diff test@1 @2
-  esc env diff test@1 @stable
-  esc env diff test@stable test-v2@stable
-  esc env diff test test-v2
-  esc env diff test@stable --format json
-  esc env diff test@stable --format string
-  esc env diff test@stable --format dotenv
-  esc env diff test@stable --format shell
+  esc env diff default/test
+  esc env diff default/test@latest
+  esc env diff default/test@stable
+  esc env diff default/test@1
+  esc env diff default/test@2
+  esc env diff default/test@3
+  esc env diff default/test@1 @2
+  esc env diff default/test@1 @stable
+  esc env diff default/test@stable default/test-v2@stable
+  esc env diff default/test default/test-v2
+  esc env diff default/test@stable --format json
+  esc env diff default/test@stable --format string
+  esc env diff default/test@stable --format dotenv
+  esc env diff default/test@stable --format shell
 environments:
   test-user/default/a: {}
   test-user/default/b: {}
@@ -65,9 +65,9 @@ environments:
               FOO: bar
               BAR: qux
 stdout: |
-  > esc env diff test
-  > esc env diff test@latest
-  > esc env diff test@stable
+  > esc env diff default/test
+  > esc env diff default/test@latest
+  > esc env diff default/test@stable
   # Value
   ```diff
   --- test-user/default/test@stable
@@ -125,7 +125,7 @@ stdout: |
   +    BAR: qux
 
   ```
-  > esc env diff test@1
+  > esc env diff default/test@1
   # Value
   ```diff
   --- test-user/default/test@1
@@ -179,7 +179,7 @@ stdout: |
   +    BAR: qux
 
   ```
-  > esc env diff test@2
+  > esc env diff default/test@2
   # Value
   ```diff
   --- test-user/default/test@2
@@ -237,8 +237,8 @@ stdout: |
   +    BAR: qux
 
   ```
-  > esc env diff test@3
-  > esc env diff test@1 @2
+  > esc env diff default/test@3
+  > esc env diff default/test@1 @2
   # Value
   ```diff
   --- test-user/default/test@1
@@ -264,7 +264,7 @@ stdout: |
   +    FOO: bar
 
   ```
-  > esc env diff test@1 @stable
+  > esc env diff default/test@1 @stable
   # Value
   ```diff
   --- test-user/default/test@1
@@ -290,7 +290,7 @@ stdout: |
   +    FOO: bar
 
   ```
-  > esc env diff test@stable test-v2@stable
+  > esc env diff default/test@stable default/test-v2@stable
   # Value
   ```diff
   --- test-user/default/test@stable
@@ -317,7 +317,7 @@ stdout: |
        FOO: bar
 
   ```
-  > esc env diff test test-v2
+  > esc env diff default/test default/test-v2
   # Value
   ```diff
   --- test-user/default/test@latest
@@ -373,7 +373,7 @@ stdout: |
        BAR: qux
 
   ```
-  > esc env diff test@stable --format json
+  > esc env diff default/test@stable --format json
   --- test-user/default/test@stable
   +++ test-user/default/test@latest
   @@ -1,6 +1,19 @@
@@ -398,20 +398,20 @@ stdout: |
   +  "secret": "[secret]",
   +  "string": "esc"
    }
-  > esc env diff test@stable --format string
+  > esc env diff default/test@stable --format string
   --- test-user/default/test@stable
   +++ test-user/default/test@latest
   @@ -1 +1 @@
   -"environmentVariables"="\"FOO\"=\"bar\"","string"="hello, world!"
   +"array"="\"hello\",\"world\"","boolean"="true","environmentVariables"="\"BAR\"=\"qux\",\"FOO\"=\"baz\"","null"="","number"="42","object"="\"hello\"=\"world\"","open"="[unknown]","secret"="[secret]","string"="esc"
-  > esc env diff test@stable --format dotenv
+  > esc env diff default/test@stable --format dotenv
   --- test-user/default/test@stable
   +++ test-user/default/test@latest
   @@ -1 +1,2 @@
   -FOO="bar"
   +BAR="qux"
   +FOO="baz"
-  > esc env diff test@stable --format shell
+  > esc env diff default/test@stable --format shell
   --- test-user/default/test@stable
   +++ test-user/default/test@latest
   @@ -1 +1,2 @@
@@ -419,17 +419,17 @@ stdout: |
   +export BAR="qux"
   +export FOO="baz"
 stderr: |
-  > esc env diff test
-  > esc env diff test@latest
-  > esc env diff test@stable
-  > esc env diff test@1
-  > esc env diff test@2
-  > esc env diff test@3
-  > esc env diff test@1 @2
-  > esc env diff test@1 @stable
-  > esc env diff test@stable test-v2@stable
-  > esc env diff test test-v2
-  > esc env diff test@stable --format json
-  > esc env diff test@stable --format string
-  > esc env diff test@stable --format dotenv
-  > esc env diff test@stable --format shell
+  > esc env diff default/test
+  > esc env diff default/test@latest
+  > esc env diff default/test@stable
+  > esc env diff default/test@1
+  > esc env diff default/test@2
+  > esc env diff default/test@3
+  > esc env diff default/test@1 @2
+  > esc env diff default/test@1 @stable
+  > esc env diff default/test@stable default/test-v2@stable
+  > esc env diff default/test default/test-v2
+  > esc env diff default/test@stable --format json
+  > esc env diff default/test@stable --format string
+  > esc env diff default/test@stable --format dotenv
+  > esc env diff default/test@stable --format shell

--- a/cmd/esc/cli/testdata/env-edit-editor-abort.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-abort.yaml
@@ -1,4 +1,4 @@
-run: esc env edit test
+run: esc env edit default/test
 process:
   environ:
     EDITOR: my-editor
@@ -10,7 +10,7 @@ environments:
     values:
       foo: bar
 stdout: |
-  > esc env edit test
+  > esc env edit default/test
 stderr: |
-  > esc env edit test
+  > esc env edit default/test
   Aborting edit due to empty definition.

--- a/cmd/esc/cli/testdata/env-edit-editor-diags.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-diags.yaml
@@ -1,6 +1,6 @@
 run: |
-  esc env edit test
-  esc env get test
+  esc env edit default/test
+  esc env get default/test
 process:
   environ:
     EDITOR: my-editor
@@ -14,9 +14,9 @@ environments:
     values:
       foo: bar
 stdout: |+
-  > esc env edit test
+  > esc env edit default/test
   Environment updated.
-  > esc env get test
+  > esc env get default/test
   # Value
   ```json
   {
@@ -31,5 +31,5 @@ stdout: |+
   ```
 
 stderr: |
-  > esc env edit test
-  > esc env get test
+  > esc env edit default/test
+  > esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-editor-docs-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-docs-ok.yaml
@@ -1,6 +1,6 @@
 run: |
-  esc env edit test
-  esc env get test
+  esc env edit default/test
+  esc env get default/test
 process:
   environ:
     EDITOR: my-editor
@@ -12,9 +12,9 @@ environments:
     values:
       foo: bar
 stdout: |+
-  > esc env edit test
+  > esc env edit default/test
   Environment updated.
-  > esc env get test
+  > esc env get default/test
   # Value
   ```json
   {
@@ -29,5 +29,5 @@ stdout: |+
   ```
 
 stderr: |
-  > esc env edit test
-  > esc env get test
+  > esc env edit default/test
+  > esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-editor-invalid.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-invalid.yaml
@@ -1,4 +1,4 @@
-run: esc env edit test
+run: esc env edit default/test
 process:
   environ:
     EDITOR: my-editor
@@ -10,9 +10,9 @@ environments:
     values:
       foo: bar
 stdout: |
-  > esc env edit test
+  > esc env edit default/test
 stderr: |
-  > esc env edit test
+  > esc env edit default/test
   Error: imports must be a list
 
     on test line 1:

--- a/cmd/esc/cli/testdata/env-edit-editor-not-found.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-not-found.yaml
@@ -1,10 +1,10 @@
-run: esc env edit test
+run: esc env edit default/test
 error: exit status 1
 process:
   environ:
     EDITOR: my-editor
 stdout: |
-  > esc env edit test
+  > esc env edit default/test
 stderr: |
-  > esc env edit test
+  > esc env edit default/test
   Error: finding "my-editor" on path: command not found

--- a/cmd/esc/cli/testdata/env-edit-editor-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-ok.yaml
@@ -1,6 +1,6 @@
 run: |
-  esc env edit test
-  esc env get test
+  esc env edit default/test
+  esc env get default/test
 process:
   environ:
     EDITOR: my-editor
@@ -12,9 +12,9 @@ environments:
     values:
       foo: bar
 stdout: |+
-  > esc env edit test
+  > esc env edit default/test
   Environment updated.
-  > esc env get test
+  > esc env get default/test
   # Value
   ```json
   {
@@ -29,5 +29,5 @@ stdout: |+
   ```
 
 stderr: |
-  > esc env edit test
-  > esc env get test
+  > esc env edit default/test
+  > esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-env-not-found.yaml
+++ b/cmd/esc/cli/testdata/env-edit-env-not-found.yaml
@@ -1,4 +1,4 @@
-run: esc env edit test
+run: esc env edit default/test
 error: exit status 1
 process:
   environ:
@@ -6,7 +6,7 @@ process:
   commands:
     my-editor: exit 1
 stdout: |
-  > esc env edit test
+  > esc env edit default/test
 stderr: |
-  > esc env edit test
+  > esc env edit default/test
   Error: getting environment definition: not found

--- a/cmd/esc/cli/testdata/env-edit-file.yaml
+++ b/cmd/esc/cli/testdata/env-edit-file.yaml
@@ -1,17 +1,17 @@
 run: |
-  echo '{"values":{"foo":"baz"}}' | esc env edit test -f=-
-  esc env get test
+  echo '{"values":{"foo":"baz"}}' | esc env edit default/test -f=-
+  esc env get default/test
   echo '{"values":{"foo":"qux"}}' >def.yaml
-  esc env edit test -f=def.yaml
-  esc env get test
+  esc env edit default/test -f=def.yaml
+  esc env get default/test
 environments:
   test-user/default/test:
     values:
       foo: bar
 stdout: |+
-  > esc env edit test -f=-
+  > esc env edit default/test -f=-
   Environment updated.
-  > esc env get test
+  > esc env get default/test
   # Value
   ```json
   {
@@ -24,9 +24,9 @@ stdout: |+
 
   ```
 
-  > esc env edit test -f=def.yaml
+  > esc env edit default/test -f=def.yaml
   Environment updated.
-  > esc env get test
+  > esc env get default/test
   # Value
   ```json
   {
@@ -40,7 +40,7 @@ stdout: |+
   ```
 
 stderr: |
-  > esc env edit test -f=-
-  > esc env get test
-  > esc env edit test -f=def.yaml
-  > esc env get test
+  > esc env edit default/test -f=-
+  > esc env get default/test
+  > esc env edit default/test -f=def.yaml
+  > esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-flag-code-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-code-ok.yaml
@@ -1,6 +1,6 @@
 run: |
-  esc env edit test --editor code
-  esc env get test
+  esc env edit default/test --editor code
+  esc env get default/test
 process:
   commands:
     code: |
@@ -11,9 +11,9 @@ environments:
     values:
       foo: bar
 stdout: |+
-  > esc env edit test --editor code
+  > esc env edit default/test --editor code
   Environment updated.
-  > esc env get test
+  > esc env get default/test
   # Value
   ```json
   {
@@ -28,5 +28,5 @@ stdout: |+
   ```
 
 stderr: |
-  > esc env edit test --editor code
-  > esc env get test
+  > esc env edit default/test --editor code
+  > esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-flag-editor-args.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-editor-args.yaml
@@ -1,6 +1,6 @@
 run: |
-  esc env edit test --editor 'editor --some-flag --other-flag="a\"b"'
-  esc env get test
+  esc env edit default/test --editor 'editor --some-flag --other-flag="a\"b"'
+  esc env get default/test
 process:
   commands:
     editor: |
@@ -12,9 +12,9 @@ environments:
     values:
       foo: bar
 stdout: |+
-  > esc env edit test --editor editor --some-flag --other-flag="a\"b"
+  > esc env edit default/test --editor editor --some-flag --other-flag="a\"b"
   Environment updated.
-  > esc env get test
+  > esc env get default/test
   # Value
   ```json
   {
@@ -29,5 +29,5 @@ stdout: |+
   ```
 
 stderr: |
-  > esc env edit test --editor editor --some-flag --other-flag="a\"b"
-  > esc env get test
+  > esc env edit default/test --editor editor --some-flag --other-flag="a\"b"
+  > esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-flag-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-ok.yaml
@@ -1,6 +1,6 @@
 run: |
-  esc env edit test --editor my-editor
-  esc env get test
+  esc env edit default/test --editor my-editor
+  esc env get default/test
 process:
   commands:
     my-editor: |
@@ -10,9 +10,9 @@ environments:
     values:
       foo: bar
 stdout: |+
-  > esc env edit test --editor my-editor
+  > esc env edit default/test --editor my-editor
   Environment updated.
-  > esc env get test
+  > esc env get default/test
   # Value
   ```json
   {
@@ -27,5 +27,5 @@ stdout: |+
   ```
 
 stderr: |
-  > esc env edit test --editor my-editor
-  > esc env get test
+  > esc env edit default/test --editor my-editor
+  > esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-none-not-found.yaml
+++ b/cmd/esc/cli/testdata/env-edit-none-not-found.yaml
@@ -1,7 +1,7 @@
-run: esc env edit test
+run: esc env edit default/test
 error: exit status 1
 stdout: |
-  > esc env edit test
+  > esc env edit default/test
 stderr: |
-  > esc env edit test
+  > esc env edit default/test
   Error: No available editor. Please use the --editor flag or set one of the VISUAL or EDITOR environment variables.

--- a/cmd/esc/cli/testdata/env-edit-none-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-none-ok.yaml
@@ -1,6 +1,6 @@
 run: |
-  esc env edit test
-  esc env get test
+  esc env edit default/test
+  esc env get default/test
 process:
   commands:
     vi: |
@@ -10,9 +10,9 @@ environments:
     values:
       foo: bar
 stdout: |+
-  > esc env edit test
+  > esc env edit default/test
   Environment updated.
-  > esc env get test
+  > esc env get default/test
   # Value
   ```json
   {
@@ -27,5 +27,5 @@ stdout: |+
   ```
 
 stderr: |
-  > esc env edit test
-  > esc env get test
+  > esc env edit default/test
+  > esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-edit-revision-or-tag.yaml
@@ -1,6 +1,6 @@
 run: |
-  (esc env edit test@1 --editor my-editor || exit 0)
-  esc env edit test@foo --editor my-editor
+  (esc env edit default/test@1 --editor my-editor || exit 0)
+  esc env edit default/test@foo --editor my-editor
 error: exit status 1
 process:
   commands:
@@ -11,10 +11,10 @@ environments:
     values:
       foo: bar
 stdout: |
-  > esc env edit test@1 --editor my-editor
-  > esc env edit test@foo --editor my-editor
+  > esc env edit default/test@1 --editor my-editor
+  > esc env edit default/test@foo --editor my-editor
 stderr: |
-  > esc env edit test@1 --editor my-editor
+  > esc env edit default/test@1 --editor my-editor
   Error: the edit command does not accept versions
-  > esc env edit test@foo --editor my-editor
+  > esc env edit default/test@foo --editor my-editor
   Error: the edit command does not accept versions

--- a/cmd/esc/cli/testdata/env-edit-visual-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-visual-ok.yaml
@@ -1,6 +1,6 @@
 run: |
-  esc env edit test
-  esc env get test
+  esc env edit default/test
+  esc env get default/test
 process:
   environ:
     VISUAL: my-editor
@@ -12,9 +12,9 @@ environments:
     values:
       foo: bar
 stdout: |+
-  > esc env edit test
+  > esc env edit default/test
   Environment updated.
-  > esc env get test
+  > esc env get default/test
   # Value
   ```json
   {
@@ -29,5 +29,5 @@ stdout: |+
   ```
 
 stderr: |
-  > esc env edit test
-  > esc env get test
+  > esc env edit default/test
+  > esc env get default/test

--- a/cmd/esc/cli/testdata/env-get-all-value-dotenv.yaml
+++ b/cmd/esc/cli/testdata/env-get-all-value-dotenv.yaml
@@ -1,6 +1,6 @@
 run: |
-  esc env get test --value=dotenv
-  esc env get test --value=dotenv --show-secrets
+  esc env get default/test --value=dotenv
+  esc env get default/test --value=dotenv --show-secrets
 environments:
   test-user/default/a: {}
   test-user/default/b: {}
@@ -31,7 +31,7 @@ environments:
       files:
         FILE: ${string}
 stdout: |
-  > esc env get test --value=dotenv
+  > esc env get default/test --value=dotenv
   BOOLEAN="true"
   NULLV=""
   NUMBER="3.14"
@@ -39,7 +39,7 @@ stdout: |
   SECRET="[secret]"
   STRING="esc"
   FILE="[unknown]"
-  > esc env get test --value=dotenv --show-secrets
+  > esc env get default/test --value=dotenv --show-secrets
   BOOLEAN="true"
   NULLV=""
   NUMBER="3.14"
@@ -48,5 +48,5 @@ stdout: |
   STRING="esc"
   FILE="[unknown]"
 stderr: |
-  > esc env get test --value=dotenv
-  > esc env get test --value=dotenv --show-secrets
+  > esc env get default/test --value=dotenv
+  > esc env get default/test --value=dotenv --show-secrets

--- a/cmd/esc/cli/testdata/env-get-all-value-shell.yaml
+++ b/cmd/esc/cli/testdata/env-get-all-value-shell.yaml
@@ -1,6 +1,6 @@
 run: |
-  esc env get test --value=shell
-  esc env get test --value=shell --show-secrets
+  esc env get default/test --value=shell
+  esc env get default/test --value=shell --show-secrets
 environments:
   test-user/default/a: {}
   test-user/default/b: {}
@@ -31,7 +31,7 @@ environments:
       files:
         FILE: ${string}
 stdout: |
-  > esc env get test --value=shell
+  > esc env get default/test --value=shell
   export BOOLEAN="true"
   export NULLV=""
   export NUMBER="3.14"
@@ -39,7 +39,7 @@ stdout: |
   export SECRET="[secret]"
   export STRING="esc"
   export FILE="[unknown]"
-  > esc env get test --value=shell --show-secrets
+  > esc env get default/test --value=shell --show-secrets
   export BOOLEAN="true"
   export NULLV=""
   export NUMBER="3.14"
@@ -48,5 +48,5 @@ stdout: |
   export STRING="esc"
   export FILE="[unknown]"
 stderr: |
-  > esc env get test --value=shell
-  > esc env get test --value=shell --show-secrets
+  > esc env get default/test --value=shell
+  > esc env get default/test --value=shell --show-secrets

--- a/cmd/esc/cli/testdata/env-get-all.yaml
+++ b/cmd/esc/cli/testdata/env-get-all.yaml
@@ -1,11 +1,11 @@
 run: |
-  esc env get test
-  esc env get test@latest
-  esc env get test@stable
-  esc env get test@1
-  esc env get test@2
-  esc env get test@3
-  esc env get test@latest --show-secrets
+  esc env get default/test
+  esc env get default/test@latest
+  esc env get default/test@stable
+  esc env get default/test@1
+  esc env get default/test@2
+  esc env get default/test@3
+  esc env get default/test@latest --show-secrets
 environments:
   test-user/default/a: {}
   test-user/default/b:
@@ -38,7 +38,7 @@ environments:
               fn::secret:
                 ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
 stdout: |+
-  > esc env get test
+  > esc env get default/test
   # Value
   ```json
   {
@@ -79,7 +79,7 @@ stdout: |+
 
   ```
 
-  > esc env get test@latest
+  > esc env get default/test@latest
   # Value
   ```json
   {
@@ -120,7 +120,7 @@ stdout: |+
 
   ```
 
-  > esc env get test@stable
+  > esc env get default/test@stable
   # Value
   ```json
   {
@@ -134,9 +134,9 @@ stdout: |+
 
   ```
 
-  > esc env get test@1
+  > esc env get default/test@1
 
-  > esc env get test@2
+  > esc env get default/test@2
   # Value
   ```json
   {
@@ -150,7 +150,7 @@ stdout: |+
 
   ```
 
-  > esc env get test@3
+  > esc env get default/test@3
   # Value
   ```json
   {
@@ -191,7 +191,7 @@ stdout: |+
 
   ```
 
-  > esc env get test@latest --show-secrets
+  > esc env get default/test@latest --show-secrets
   # Value
   ```json
   {
@@ -232,10 +232,10 @@ stdout: |+
   ```
 
 stderr: |
-  > esc env get test
-  > esc env get test@latest
-  > esc env get test@stable
-  > esc env get test@1
-  > esc env get test@2
-  > esc env get test@3
-  > esc env get test@latest --show-secrets
+  > esc env get default/test
+  > esc env get default/test@latest
+  > esc env get default/test@stable
+  > esc env get default/test@1
+  > esc env get default/test@2
+  > esc env get default/test@3
+  > esc env get default/test@latest --show-secrets

--- a/cmd/esc/cli/testdata/env-get-each-import.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-import.yaml
@@ -1,7 +1,7 @@
 run: |
-  esc env get test imports
-  esc env get test 'imports[0]'
-  esc env get test 'imports[1]'
+  esc env get default/test imports
+  esc env get default/test 'imports[0]'
+  esc env get default/test 'imports[1]'
 environments:
   test-user/default/a:
     values:
@@ -26,7 +26,7 @@ environments:
         fn::open::test:
           foo: bar
 stdout: |+
-  > esc env get test imports
+  > esc env get default/test imports
   # Definition
   ```yaml
   - a
@@ -34,14 +34,14 @@ stdout: |+
 
   ```
 
-  > esc env get test imports[0]
+  > esc env get default/test imports[0]
   # Definition
   ```yaml
   a
 
   ```
 
-  > esc env get test imports[1]
+  > esc env get default/test imports[1]
   # Definition
   ```yaml
   b
@@ -49,6 +49,6 @@ stdout: |+
   ```
 
 stderr: |
-  > esc env get test imports
-  > esc env get test imports[0]
-  > esc env get test imports[1]
+  > esc env get default/test imports
+  > esc env get default/test imports[0]
+  > esc env get default/test imports[1]

--- a/cmd/esc/cli/testdata/env-get-each-value-detailed.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-value-detailed.yaml
@@ -1,15 +1,15 @@
 run: |
-  esc env get test --value detailed null
-  esc env get test --value detailed boolean
-  esc env get test --value detailed number
-  esc env get test --value detailed string
-  esc env get test --value detailed array
-  esc env get test --value detailed 'array[0]'
-  esc env get test --value detailed 'array[1]'
-  esc env get test --value detailed object
-  esc env get test --value detailed object.hello
-  esc env get test --value detailed object.goodbye
-  esc env get test --value detailed open
+  esc env get default/test --value detailed null
+  esc env get default/test --value detailed boolean
+  esc env get default/test --value detailed number
+  esc env get default/test --value detailed string
+  esc env get default/test --value detailed array
+  esc env get default/test --value detailed 'array[0]'
+  esc env get default/test --value detailed 'array[1]'
+  esc env get default/test --value detailed object
+  esc env get default/test --value detailed object.hello
+  esc env get default/test --value detailed object.goodbye
+  esc env get default/test --value detailed open
 environments:
   test-user/default/a:
     values:
@@ -33,7 +33,7 @@ environments:
       open:
         fn::open::test: echo
 stdout: |
-  > esc env get test --value detailed null
+  > esc env get default/test --value detailed null
   {
     "trace": {
       "def": {
@@ -51,7 +51,7 @@ stdout: |
       }
     }
   }
-  > esc env get test --value detailed boolean
+  > esc env get default/test --value detailed boolean
   {
     "value": true,
     "trace": {
@@ -70,7 +70,7 @@ stdout: |
       }
     }
   }
-  > esc env get test --value detailed number
+  > esc env get default/test --value detailed number
   {
     "value": 42,
     "trace": {
@@ -89,7 +89,7 @@ stdout: |
       }
     }
   }
-  > esc env get test --value detailed string
+  > esc env get default/test --value detailed string
   {
     "value": "esc",
     "trace": {
@@ -126,7 +126,7 @@ stdout: |
       }
     }
   }
-  > esc env get test --value detailed array
+  > esc env get default/test --value detailed array
   {
     "value": [
       {
@@ -182,7 +182,7 @@ stdout: |
       }
     }
   }
-  > esc env get test --value detailed array[0]
+  > esc env get default/test --value detailed array[0]
   {
     "value": "hello",
     "trace": {
@@ -201,7 +201,7 @@ stdout: |
       }
     }
   }
-  > esc env get test --value detailed array[1]
+  > esc env get default/test --value detailed array[1]
   {
     "value": "world",
     "trace": {
@@ -220,7 +220,7 @@ stdout: |
       }
     }
   }
-  > esc env get test --value detailed object
+  > esc env get default/test --value detailed object
   {
     "value": {
       "goodbye": {
@@ -440,7 +440,7 @@ stdout: |
       }
     }
   }
-  > esc env get test --value detailed object.hello
+  > esc env get default/test --value detailed object.hello
   {
     "value": "world",
     "trace": {
@@ -477,7 +477,7 @@ stdout: |
       }
     }
   }
-  > esc env get test --value detailed object.goodbye
+  > esc env get default/test --value detailed object.goodbye
   {
     "value": "all",
     "trace": {
@@ -514,7 +514,7 @@ stdout: |
       }
     }
   }
-  > esc env get test --value detailed open
+  > esc env get default/test --value detailed open
   {
     "unknown": true,
     "trace": {
@@ -534,14 +534,14 @@ stdout: |
     }
   }
 stderr: |
-  > esc env get test --value detailed null
-  > esc env get test --value detailed boolean
-  > esc env get test --value detailed number
-  > esc env get test --value detailed string
-  > esc env get test --value detailed array
-  > esc env get test --value detailed array[0]
-  > esc env get test --value detailed array[1]
-  > esc env get test --value detailed object
-  > esc env get test --value detailed object.hello
-  > esc env get test --value detailed object.goodbye
-  > esc env get test --value detailed open
+  > esc env get default/test --value detailed null
+  > esc env get default/test --value detailed boolean
+  > esc env get default/test --value detailed number
+  > esc env get default/test --value detailed string
+  > esc env get default/test --value detailed array
+  > esc env get default/test --value detailed array[0]
+  > esc env get default/test --value detailed array[1]
+  > esc env get default/test --value detailed object
+  > esc env get default/test --value detailed object.hello
+  > esc env get default/test --value detailed object.goodbye
+  > esc env get default/test --value detailed open

--- a/cmd/esc/cli/testdata/env-get-each-value-json.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-value-json.yaml
@@ -1,15 +1,15 @@
 run: |
-  esc env get test --value json null
-  esc env get test --value json boolean
-  esc env get test --value json number
-  esc env get test --value json string
-  esc env get test --value json array
-  esc env get test --value json 'array[0]'
-  esc env get test --value json 'array[1]'
-  esc env get test --value json object
-  esc env get test --value json object.hello
-  esc env get test --value json object.goodbye
-  esc env get test --value json open
+  esc env get default/test --value json null
+  esc env get default/test --value json boolean
+  esc env get default/test --value json number
+  esc env get default/test --value json string
+  esc env get default/test --value json array
+  esc env get default/test --value json 'array[0]'
+  esc env get default/test --value json 'array[1]'
+  esc env get default/test --value json object
+  esc env get default/test --value json object.hello
+  esc env get default/test --value json object.goodbye
+  esc env get default/test --value json open
 environments:
   test-user/default/a:
     values:
@@ -33,43 +33,43 @@ environments:
       open:
         fn::open::test: echo
 stdout: |
-  > esc env get test --value json null
+  > esc env get default/test --value json null
   null
-  > esc env get test --value json boolean
+  > esc env get default/test --value json boolean
   true
-  > esc env get test --value json number
+  > esc env get default/test --value json number
   42
-  > esc env get test --value json string
+  > esc env get default/test --value json string
   "esc"
-  > esc env get test --value json array
+  > esc env get default/test --value json array
   [
     "hello",
     "world"
   ]
-  > esc env get test --value json array[0]
+  > esc env get default/test --value json array[0]
   "hello"
-  > esc env get test --value json array[1]
+  > esc env get default/test --value json array[1]
   "world"
-  > esc env get test --value json object
+  > esc env get default/test --value json object
   {
     "goodbye": "all",
     "hello": "world"
   }
-  > esc env get test --value json object.hello
+  > esc env get default/test --value json object.hello
   "world"
-  > esc env get test --value json object.goodbye
+  > esc env get default/test --value json object.goodbye
   "all"
-  > esc env get test --value json open
+  > esc env get default/test --value json open
   "[unknown]"
 stderr: |
-  > esc env get test --value json null
-  > esc env get test --value json boolean
-  > esc env get test --value json number
-  > esc env get test --value json string
-  > esc env get test --value json array
-  > esc env get test --value json array[0]
-  > esc env get test --value json array[1]
-  > esc env get test --value json object
-  > esc env get test --value json object.hello
-  > esc env get test --value json object.goodbye
-  > esc env get test --value json open
+  > esc env get default/test --value json null
+  > esc env get default/test --value json boolean
+  > esc env get default/test --value json number
+  > esc env get default/test --value json string
+  > esc env get default/test --value json array
+  > esc env get default/test --value json array[0]
+  > esc env get default/test --value json array[1]
+  > esc env get default/test --value json object
+  > esc env get default/test --value json object.hello
+  > esc env get default/test --value json object.goodbye
+  > esc env get default/test --value json open

--- a/cmd/esc/cli/testdata/env-get-each-value-string.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-value-string.yaml
@@ -1,15 +1,15 @@
 run: |
-  echo \"$(esc env get test --value string null)\"
-  esc env get test --value string boolean
-  esc env get test --value string number
-  esc env get test --value string string
-  esc env get test --value string array
-  esc env get test --value string 'array[0]'
-  esc env get test --value string 'array[1]'
-  esc env get test --value string object
-  esc env get test --value string object.hello
-  esc env get test --value string object.goodbye
-  esc env get test --value string open
+  echo \"$(esc env get default/test --value string null)\"
+  esc env get default/test --value string boolean
+  esc env get default/test --value string number
+  esc env get default/test --value string string
+  esc env get default/test --value string array
+  esc env get default/test --value string 'array[0]'
+  esc env get default/test --value string 'array[1]'
+  esc env get default/test --value string object
+  esc env get default/test --value string object.hello
+  esc env get default/test --value string object.goodbye
+  esc env get default/test --value string open
 environments:
   test-user/default/a:
     values:
@@ -33,36 +33,36 @@ environments:
       open:
         fn::open::test: echo
 stdout: |
-  "> esc env get test --value string null"
-  > esc env get test --value string boolean
+  "> esc env get default/test --value string null"
+  > esc env get default/test --value string boolean
   true
-  > esc env get test --value string number
+  > esc env get default/test --value string number
   42
-  > esc env get test --value string string
+  > esc env get default/test --value string string
   esc
-  > esc env get test --value string array
+  > esc env get default/test --value string array
   "hello","world"
-  > esc env get test --value string array[0]
+  > esc env get default/test --value string array[0]
   hello
-  > esc env get test --value string array[1]
+  > esc env get default/test --value string array[1]
   world
-  > esc env get test --value string object
+  > esc env get default/test --value string object
   "goodbye"="all","hello"="world"
-  > esc env get test --value string object.hello
+  > esc env get default/test --value string object.hello
   world
-  > esc env get test --value string object.goodbye
+  > esc env get default/test --value string object.goodbye
   all
-  > esc env get test --value string open
+  > esc env get default/test --value string open
   [unknown]
 stderr: |
-  > esc env get test --value string null
-  > esc env get test --value string boolean
-  > esc env get test --value string number
-  > esc env get test --value string string
-  > esc env get test --value string array
-  > esc env get test --value string array[0]
-  > esc env get test --value string array[1]
-  > esc env get test --value string object
-  > esc env get test --value string object.hello
-  > esc env get test --value string object.goodbye
-  > esc env get test --value string open
+  > esc env get default/test --value string null
+  > esc env get default/test --value string boolean
+  > esc env get default/test --value string number
+  > esc env get default/test --value string string
+  > esc env get default/test --value string array
+  > esc env get default/test --value string array[0]
+  > esc env get default/test --value string array[1]
+  > esc env get default/test --value string object
+  > esc env get default/test --value string object.hello
+  > esc env get default/test --value string object.goodbye
+  > esc env get default/test --value string open

--- a/cmd/esc/cli/testdata/env-get-each.yaml
+++ b/cmd/esc/cli/testdata/env-get-each.yaml
@@ -1,17 +1,17 @@
 run: |
-  esc env get test null
-  esc env get test boolean
-  esc env get test number
-  esc env get test string
-  esc env get test array
-  esc env get test 'array[0]'
-  esc env get test 'array[1]'
-  esc env get test object
-  esc env get test object.hello
-  esc env get test object.goodbye
-  esc env get test open
-  esc env get test 'open["fn::open::test"]'
-  esc env get test 'open["fn::open::test"].foo'
+  esc env get default/test null
+  esc env get default/test boolean
+  esc env get default/test number
+  esc env get default/test string
+  esc env get default/test array
+  esc env get default/test 'array[0]'
+  esc env get default/test 'array[1]'
+  esc env get default/test object
+  esc env get default/test object.hello
+  esc env get default/test object.goodbye
+  esc env get default/test open
+  esc env get default/test 'open["fn::open::test"]'
+  esc env get default/test 'open["fn::open::test"].foo'
 environments:
   test-user/default/a:
     values:
@@ -36,7 +36,7 @@ environments:
         fn::open::test:
           foo: bar
 stdout: |+
-  > esc env get test null
+  > esc env get default/test null
   # Value
   ```json
   null
@@ -50,7 +50,7 @@ stdout: |+
   # Defined at
   - test:6:13
 
-  > esc env get test boolean
+  > esc env get default/test boolean
   # Value
   ```json
   true
@@ -64,7 +64,7 @@ stdout: |+
   # Defined at
   - test:7:14
 
-  > esc env get test number
+  > esc env get default/test number
   # Value
   ```json
   42
@@ -78,7 +78,7 @@ stdout: |+
   # Defined at
   - test:8:13
 
-  > esc env get test string
+  > esc env get default/test string
   # Value
   ```json
   "esc"
@@ -93,7 +93,7 @@ stdout: |+
   - test:9:13
   - b:2:13
 
-  > esc env get test array
+  > esc env get default/test array
   # Value
   ```json
   [
@@ -110,7 +110,7 @@ stdout: |+
   # Defined at
   - test:10:12
 
-  > esc env get test array[0]
+  > esc env get default/test array[0]
   # Value
   ```json
   "hello"
@@ -124,7 +124,7 @@ stdout: |+
   # Defined at
   - test:10:13
 
-  > esc env get test array[1]
+  > esc env get default/test array[1]
   # Value
   ```json
   "world"
@@ -138,7 +138,7 @@ stdout: |+
   # Defined at
   - test:10:20
 
-  > esc env get test object
+  > esc env get default/test object
   # Value
   ```json
   {
@@ -156,7 +156,7 @@ stdout: |+
   - test:11:13
   - b:3:13
 
-  > esc env get test object.hello
+  > esc env get default/test object.hello
   # Value
   ```json
   "world"
@@ -171,7 +171,7 @@ stdout: |+
   - test:11:21
   - a:2:21
 
-  > esc env get test object.goodbye
+  > esc env get default/test object.goodbye
   # Value
   ```json
   "all"
@@ -181,7 +181,7 @@ stdout: |+
   - b:3:23
   - a:2:35
 
-  > esc env get test open
+  > esc env get default/test open
   # Value
   ```json
   "[unknown]"
@@ -196,7 +196,7 @@ stdout: |+
   # Defined at
   - test:13:9
 
-  > esc env get test open["fn::open::test"]
+  > esc env get default/test open["fn::open::test"]
   # Definition
   ```yaml
   foo: bar
@@ -206,7 +206,7 @@ stdout: |+
   # Defined at
   - test:14:13
 
-  > esc env get test open["fn::open::test"].foo
+  > esc env get default/test open["fn::open::test"].foo
   # Definition
   ```yaml
   bar
@@ -217,16 +217,16 @@ stdout: |+
   - test:14:18
 
 stderr: |
-  > esc env get test null
-  > esc env get test boolean
-  > esc env get test number
-  > esc env get test string
-  > esc env get test array
-  > esc env get test array[0]
-  > esc env get test array[1]
-  > esc env get test object
-  > esc env get test object.hello
-  > esc env get test object.goodbye
-  > esc env get test open
-  > esc env get test open["fn::open::test"]
-  > esc env get test open["fn::open::test"].foo
+  > esc env get default/test null
+  > esc env get default/test boolean
+  > esc env get default/test number
+  > esc env get default/test string
+  > esc env get default/test array
+  > esc env get default/test array[0]
+  > esc env get default/test array[1]
+  > esc env get default/test object
+  > esc env get default/test object.hello
+  > esc env get default/test object.goodbye
+  > esc env get default/test open
+  > esc env get default/test open["fn::open::test"]
+  > esc env get default/test open["fn::open::test"].foo

--- a/cmd/esc/cli/testdata/env-init-conflict.yaml
+++ b/cmd/esc/cli/testdata/env-init-conflict.yaml
@@ -1,9 +1,9 @@
-run: esc env init dup
+run: esc env init default/dup
 error: exit status 1
 environments:
   test-user/default/dup: arbitrary
 stdout: |
-  > esc env init dup
+  > esc env init default/dup
 stderr: |
-  > esc env init dup
+  > esc env init default/dup
   Error: creating environment: already exists

--- a/cmd/esc/cli/testdata/env-init-diags.yaml
+++ b/cmd/esc/cli/testdata/env-init-diags.yaml
@@ -1,12 +1,12 @@
 run: |
-  echo '{"values":{"foo":"${bar}"}}' | esc env init test-stdin -f=-
-  esc env get test-stdin
+  echo '{"values":{"foo":"${bar}"}}' | esc env init default/test-stdin -f=-
+  esc env get default/test-stdin
 error: exit status 1
 stdout: |
-  > esc env init test-stdin -f=-
+  > esc env init default/test-stdin -f=-
   Environment created: test-user/default/test-stdin
 stderr: |
-  > esc env init test-stdin -f=-
+  > esc env init default/test-stdin -f=-
   Error: unknown property "bar"
 
     on test-stdin line 1:

--- a/cmd/esc/cli/testdata/env-init-ok.yaml
+++ b/cmd/esc/cli/testdata/env-init-ok.yaml
@@ -1,19 +1,19 @@
 run: |
-  esc env init test-env
-  esc env get test-env
-  echo '{"values":{"foo":"bar"}}' | esc env init test-stdin -f=-
-  esc env get test-stdin
+  esc env init default/test-env
+  esc env get default/test-env
+  echo '{"values":{"foo":"bar"}}' | esc env init default/test-stdin -f=-
+  esc env get default/test-stdin
   echo '{"values":{"foo":"bar"}}' >def.yaml
-  esc env init test-file -f def.yaml
-  esc env get test-file
+  esc env init default/test-file -f def.yaml
+  esc env get default/test-file
 stdout: |+
-  > esc env init test-env
+  > esc env init default/test-env
   Environment created: test-user/default/test-env
-  > esc env get test-env
+  > esc env get default/test-env
 
-  > esc env init test-stdin -f=-
+  > esc env init default/test-stdin -f=-
   Environment created: test-user/default/test-stdin
-  > esc env get test-stdin
+  > esc env get default/test-stdin
   # Value
   ```json
   {
@@ -26,9 +26,9 @@ stdout: |+
 
   ```
 
-  > esc env init test-file -f def.yaml
+  > esc env init default/test-file -f def.yaml
   Environment created: test-user/default/test-file
-  > esc env get test-file
+  > esc env get default/test-file
   # Value
   ```json
   {
@@ -42,9 +42,9 @@ stdout: |+
   ```
 
 stderr: |
-  > esc env init test-env
-  > esc env get test-env
-  > esc env init test-stdin -f=-
-  > esc env get test-stdin
-  > esc env init test-file -f def.yaml
-  > esc env get test-file
+  > esc env init default/test-env
+  > esc env get default/test-env
+  > esc env init default/test-stdin -f=-
+  > esc env get default/test-stdin
+  > esc env init default/test-file -f def.yaml
+  > esc env get default/test-file

--- a/cmd/esc/cli/testdata/env-init-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-init-revision-or-tag.yaml
@@ -1,12 +1,12 @@
 run: |
-  (esc env init test-env@1 || exit 0)
-  esc env init test-env@foo
+  (esc env init default/test-env@1 || exit 0)
+  esc env init default/test-env@foo
 error: exit status 1
 stdout: |
-  > esc env init test-env@1
-  > esc env init test-env@foo
+  > esc env init default/test-env@1
+  > esc env init default/test-env@foo
 stderr: |
-  > esc env init test-env@1
+  > esc env init default/test-env@1
   Error: the init command does not accept versions
-  > esc env init test-env@foo
+  > esc env init default/test-env@foo
   Error: the init command does not accept versions

--- a/cmd/esc/cli/testdata/env-init-warning.yaml
+++ b/cmd/esc/cli/testdata/env-init-warning.yaml
@@ -1,0 +1,9 @@
+run: |
+  esc env init test-env
+stdout: |+
+  > esc env init test-env
+  Environment created: test-user/default/test-env
+stderr: |
+  > esc env init test-env
+  Warning: Referring to an environment name ('test-env') without a project is deprecated.
+  Please use 'test-user/default/test-env' or 'default/test-env' instead.

--- a/cmd/esc/cli/testdata/env-login-gh100.yaml
+++ b/cmd/esc/cli/testdata/env-login-gh100.yaml
@@ -1,4 +1,4 @@
-# This is a regression test for #100 that aims to capture issues logging in when no existing Pulumi
+# This is a regression default/test for #100 that aims to capture issues logging in when no existing Pulumi
 # credentials exist.
 run: |
   esc logout --all

--- a/cmd/esc/cli/testdata/env-rm-each.yaml
+++ b/cmd/esc/cli/testdata/env-rm-each.yaml
@@ -1,15 +1,15 @@
 run: |
-  esc env rm test null && esc env get test
-  esc env rm test boolean && esc env get test
-  esc env rm test number && esc env get test
-  esc env rm test string && esc env get test
-  esc env rm test 'array[1]' && esc env get test
-  esc env rm test 'array[0]' && esc env get test
-  esc env rm test array && esc env get test
-  esc env rm test object.hello && esc env get test
-  esc env rm test object && esc env get test
-  esc env rm test 'open["fn::open::test"].foo' && esc env get test
-  esc env rm test open && esc env get test
+  esc env rm default/test null && esc env get default/test
+  esc env rm default/test boolean && esc env get default/test
+  esc env rm default/test number && esc env get default/test
+  esc env rm default/test string && esc env get default/test
+  esc env rm default/test 'array[1]' && esc env get default/test
+  esc env rm default/test 'array[0]' && esc env get default/test
+  esc env rm default/test array && esc env get default/test
+  esc env rm default/test object.hello && esc env get default/test
+  esc env rm default/test object && esc env get default/test
+  esc env rm default/test 'open["fn::open::test"].foo' && esc env get default/test
+  esc env rm default/test open && esc env get default/test
 environments:
   test-user/default/a:
     values:
@@ -35,8 +35,8 @@ environments:
           foo: bar
           baz: qux
 stdout: |+
-  > esc env rm test null
-  > esc env get test
+  > esc env rm default/test null
+  > esc env get default/test
   # Value
   ```json
   {
@@ -72,8 +72,8 @@ stdout: |+
 
   ```
 
-  > esc env rm test boolean
-  > esc env get test
+  > esc env rm default/test boolean
+  > esc env get default/test
   # Value
   ```json
   {
@@ -107,8 +107,8 @@ stdout: |+
 
   ```
 
-  > esc env rm test number
-  > esc env get test
+  > esc env rm default/test number
+  > esc env get default/test
   # Value
   ```json
   {
@@ -140,8 +140,8 @@ stdout: |+
 
   ```
 
-  > esc env rm test string
-  > esc env get test
+  > esc env rm default/test string
+  > esc env get default/test
   # Value
   ```json
   {
@@ -172,8 +172,8 @@ stdout: |+
 
   ```
 
-  > esc env rm test array[1]
-  > esc env get test
+  > esc env rm default/test array[1]
+  > esc env get default/test
   # Value
   ```json
   {
@@ -203,8 +203,8 @@ stdout: |+
 
   ```
 
-  > esc env rm test array[0]
-  > esc env get test
+  > esc env rm default/test array[0]
+  > esc env get default/test
   # Value
   ```json
   {
@@ -232,8 +232,8 @@ stdout: |+
 
   ```
 
-  > esc env rm test array
-  > esc env get test
+  > esc env rm default/test array
+  > esc env get default/test
   # Value
   ```json
   {
@@ -259,8 +259,8 @@ stdout: |+
 
   ```
 
-  > esc env rm test object.hello
-  > esc env get test
+  > esc env rm default/test object.hello
+  > esc env get default/test
   # Value
   ```json
   {
@@ -286,8 +286,8 @@ stdout: |+
 
   ```
 
-  > esc env rm test object
-  > esc env get test
+  > esc env rm default/test object
+  > esc env get default/test
   # Value
   ```json
   {
@@ -312,8 +312,8 @@ stdout: |+
 
   ```
 
-  > esc env rm test open["fn::open::test"].foo
-  > esc env get test
+  > esc env rm default/test open["fn::open::test"].foo
+  > esc env get default/test
   # Value
   ```json
   {
@@ -337,8 +337,8 @@ stdout: |+
 
   ```
 
-  > esc env rm test open
-  > esc env get test
+  > esc env rm default/test open
+  > esc env get default/test
   # Value
   ```json
   {
@@ -359,25 +359,25 @@ stdout: |+
   ```
 
 stderr: |
-  > esc env rm test null
-  > esc env get test
-  > esc env rm test boolean
-  > esc env get test
-  > esc env rm test number
-  > esc env get test
-  > esc env rm test string
-  > esc env get test
-  > esc env rm test array[1]
-  > esc env get test
-  > esc env rm test array[0]
-  > esc env get test
-  > esc env rm test array
-  > esc env get test
-  > esc env rm test object.hello
-  > esc env get test
-  > esc env rm test object
-  > esc env get test
-  > esc env rm test open["fn::open::test"].foo
-  > esc env get test
-  > esc env rm test open
-  > esc env get test
+  > esc env rm default/test null
+  > esc env get default/test
+  > esc env rm default/test boolean
+  > esc env get default/test
+  > esc env rm default/test number
+  > esc env get default/test
+  > esc env rm default/test string
+  > esc env get default/test
+  > esc env rm default/test array[1]
+  > esc env get default/test
+  > esc env rm default/test array[0]
+  > esc env get default/test
+  > esc env rm default/test array
+  > esc env get default/test
+  > esc env rm default/test object.hello
+  > esc env get default/test
+  > esc env rm default/test object
+  > esc env get default/test
+  > esc env rm default/test open["fn::open::test"].foo
+  > esc env get default/test
+  > esc env rm default/test open
+  > esc env get default/test

--- a/cmd/esc/cli/testdata/env-rm-not-found.yaml
+++ b/cmd/esc/cli/testdata/env-rm-not-found.yaml
@@ -1,7 +1,7 @@
-run: esc env rm dup -y
+run: esc env rm default/dup -y
 error: exit status 1
 stdout: |
-  > esc env rm dup -y
+  > esc env rm default/dup -y
 stderr: |
-  > esc env rm dup -y
+  > esc env rm default/dup -y
   Error: not found

--- a/cmd/esc/cli/testdata/env-rm-ok.yaml
+++ b/cmd/esc/cli/testdata/env-rm-ok.yaml
@@ -1,8 +1,8 @@
-run: esc env rm dup -y
+run: esc env rm default/dup -y
 environments:
   test-user/default/dup: arbitrary
 stdout: |
-  > esc env rm dup -y
+  > esc env rm default/dup -y
   Environment "test-user/default/dup" has been removed!
 stderr: |
-  > esc env rm dup -y
+  > esc env rm default/dup -y

--- a/cmd/esc/cli/testdata/env-rm-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-rm-revision-or-tag.yaml
@@ -1,12 +1,12 @@
 run: |
-  (esc env rm dup@1 -y || exit 0)
-  esc env rm dup@foo -y
+  (esc env rm default/dup@1 -y || exit 0)
+  esc env rm default/dup@foo -y
 error: exit status 1
 stdout: |
-  > esc env rm dup@1 -y
-  > esc env rm dup@foo -y
+  > esc env rm default/dup@1 -y
+  > esc env rm default/dup@foo -y
 stderr: |
-  > esc env rm dup@1 -y
+  > esc env rm default/dup@1 -y
   Error: the rm command does not accept versions
-  > esc env rm dup@foo -y
+  > esc env rm default/dup@foo -y
   Error: the rm command does not accept versions

--- a/cmd/esc/cli/testdata/env-set-invalid.yaml
+++ b/cmd/esc/cli/testdata/env-set-invalid.yaml
@@ -1,28 +1,28 @@
 run: |
-  esc env init test
-  esc env set test string foo
-  esc env set test object '{}'
-  esc env set test array '[]'
-  esc env set test string.bar baz || echo -n ""
-  esc env set test 'object[0]' foo || echo -n ""
-  esc env set test array.foo bar || echo -n ""
+  esc env init default/test
+  esc env set default/test string foo
+  esc env set default/test object '{}'
+  esc env set default/test array '[]'
+  esc env set default/test string.bar baz || echo -n ""
+  esc env set default/test 'object[0]' foo || echo -n ""
+  esc env set default/test array.foo bar || echo -n ""
 stdout: |
-  > esc env init test
+  > esc env init default/test
   Environment created: test-user/default/test
-  > esc env set test string foo
-  > esc env set test object {}
-  > esc env set test array []
-  > esc env set test string.bar baz
-  > esc env set test object[0] foo
-  > esc env set test array.foo bar
+  > esc env set default/test string foo
+  > esc env set default/test object {}
+  > esc env set default/test array []
+  > esc env set default/test string.bar baz
+  > esc env set default/test object[0] foo
+  > esc env set default/test array.foo bar
 stderr: |
-  > esc env init test
-  > esc env set test string foo
-  > esc env set test object {}
-  > esc env set test array []
-  > esc env set test string.bar baz
+  > esc env init default/test
+  > esc env set default/test string foo
+  > esc env set default/test object {}
+  > esc env set default/test array []
+  > esc env set default/test string.bar baz
   Error: string.bar: expected an array or an object
-  > esc env set test object[0] foo
+  > esc env set default/test object[0] foo
   Error: object[0]: key for a map must be a string
-  > esc env set test array.foo bar
+  > esc env set default/test array.foo bar
   Error: array.foo: key for an array must be an int

--- a/cmd/esc/cli/testdata/env-set-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-set-revision-or-tag.yaml
@@ -1,12 +1,12 @@
 run: |
-  (esc env set test@1 string foo || exit 0)
-  esc env set test@foo string foo
+  (esc env set default/test@1 string foo || exit 0)
+  esc env set default/test@foo string foo
 error: exit status 1
 stdout: |
-  > esc env set test@1 string foo
-  > esc env set test@foo string foo
+  > esc env set default/test@1 string foo
+  > esc env set default/test@foo string foo
 stderr: |
-  > esc env set test@1 string foo
+  > esc env set default/test@1 string foo
   Error: the set command does not accept versions
-  > esc env set test@foo string foo
+  > esc env set default/test@foo string foo
   Error: the set command does not accept versions

--- a/cmd/esc/cli/testdata/env-set-secret-error.yaml
+++ b/cmd/esc/cli/testdata/env-set-secret-error.yaml
@@ -1,12 +1,12 @@
 run: |
-  esc env init test
-  esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+  esc env init default/test
+  esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
 error: exit status 1
 stdout: |
-  > esc env init test
+  > esc env init default/test
   Environment created: test-user/default/test
-  > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
 stderr: |
-  > esc env init test
-  > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+  > esc env init default/test
+  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
   Error: value looks like a secret; rerun with --secret to mark it as such, or --plaintext if you meant to leave it as plaintext

--- a/cmd/esc/cli/testdata/env-set-secret.yaml
+++ b/cmd/esc/cli/testdata/env-set-secret.yaml
@@ -1,29 +1,29 @@
 run: |
-  esc env init test
-  esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= || echo OK
-  esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret
-  esc env get test
-  esc env get test password
-  esc env get test --show-secrets
-  esc env get test password --show-secrets
-  esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
-  esc env get test
-  esc env set test password 1234 --secret
-  esc env get test
-  esc env set test password 123.4 --secret
-  esc env get test
-  esc env set test password false --secret
-  esc env get test
-  esc env set test password true --secret
-  esc env get test
-  esc env set test password '[]' --secret || echo OK
+  esc env init default/test
+  esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= || echo OK
+  esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret
+  esc env get default/test
+  esc env get default/test password
+  esc env get default/test --show-secrets
+  esc env get default/test password --show-secrets
+  esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
+  esc env get default/test
+  esc env set default/test password 1234 --secret
+  esc env get default/test
+  esc env set default/test password 123.4 --secret
+  esc env get default/test
+  esc env set default/test password false --secret
+  esc env get default/test
+  esc env set default/test password true --secret
+  esc env get default/test
+  esc env set default/test password '[]' --secret || echo OK
 stdout: |
-  > esc env init test
+  > esc env init default/test
   Environment created: test-user/default/test
-  > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
   OK
-  > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret
-  > esc env get test
+  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret
+  > esc env get default/test
   # Value
   ```json
   {
@@ -39,7 +39,7 @@ stdout: |
 
   ```
 
-  > esc env get test password
+  > esc env get default/test password
   # Value
   ```json
   "[secret]"
@@ -54,7 +54,7 @@ stdout: |
   # Defined at
   - test:3:5
 
-  > esc env get test --show-secrets
+  > esc env get default/test --show-secrets
   # Value
   ```json
   {
@@ -69,7 +69,7 @@ stdout: |
 
   ```
 
-  > esc env get test password --show-secrets
+  > esc env get default/test password --show-secrets
   # Value
   ```json
   "YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M="
@@ -83,8 +83,8 @@ stdout: |
   # Defined at
   - test:3:5
 
-  > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
-  > esc env get test
+  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
+  > esc env get default/test
   # Value
   ```json
   {
@@ -98,8 +98,8 @@ stdout: |
 
   ```
 
-  > esc env set test password 1234 --secret
-  > esc env get test
+  > esc env set default/test password 1234 --secret
+  > esc env get default/test
   # Value
   ```json
   {
@@ -115,8 +115,8 @@ stdout: |
 
   ```
 
-  > esc env set test password 123.4 --secret
-  > esc env get test
+  > esc env set default/test password 123.4 --secret
+  > esc env get default/test
   # Value
   ```json
   {
@@ -132,8 +132,8 @@ stdout: |
 
   ```
 
-  > esc env set test password false --secret
-  > esc env get test
+  > esc env set default/test password false --secret
+  > esc env get default/test
   # Value
   ```json
   {
@@ -149,8 +149,8 @@ stdout: |
 
   ```
 
-  > esc env set test password true --secret
-  > esc env get test
+  > esc env set default/test password true --secret
+  > esc env get default/test
   # Value
   ```json
   {
@@ -166,25 +166,25 @@ stdout: |
 
   ```
 
-  > esc env set test password [] --secret
+  > esc env set default/test password [] --secret
 stderr: |
-  > esc env init test
-  > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+  > esc env init default/test
+  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
   Error: value looks like a secret; rerun with --secret to mark it as such, or --plaintext if you meant to leave it as plaintext
-  > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret
-  > esc env get test
-  > esc env get test password
-  > esc env get test --show-secrets
-  > esc env get test password --show-secrets
-  > esc env set test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
-  > esc env get test
-  > esc env set test password 1234 --secret
-  > esc env get test
-  > esc env set test password 123.4 --secret
-  > esc env get test
-  > esc env set test password false --secret
-  > esc env get test
-  > esc env set test password true --secret
-  > esc env get test
-  > esc env set test password [] --secret
+  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret
+  > esc env get default/test
+  > esc env get default/test password
+  > esc env get default/test --show-secrets
+  > esc env get default/test password --show-secrets
+  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
+  > esc env get default/test
+  > esc env set default/test password 1234 --secret
+  > esc env get default/test
+  > esc env set default/test password 123.4 --secret
+  > esc env get default/test
+  > esc env set default/test password false --secret
+  > esc env get default/test
+  > esc env set default/test password true --secret
+  > esc env get default/test
+  > esc env set default/test password [] --secret
   test:3:21: secret values must be string literals

--- a/cmd/esc/cli/testdata/env-set.yaml
+++ b/cmd/esc/cli/testdata/env-set.yaml
@@ -1,25 +1,25 @@
 run: |
-  esc env init test
-  esc env set test foo.bar.baz qux && esc env get test
-  esc env set test foo.bar.alpha zed && esc env get test
-  esc env set test 'foo.beta[0]' gamma && esc env get test
-  esc env set test 'foo.beta[1]' 42 && esc env get test
-  esc env set test open '{"fn::open::test": "esc"}' && esc env get test
-  esc env set test 'open["fn::open::test"]' cse && esc env get test
-  esc env set test array '[hello, world]' && esc env get test
-  esc env set test 'array[1]' esc && esc env get test
-  esc env set test 'array[2]' '{}' && esc env get test
-  esc env set test 'array[2].foo' bar && esc env get test
-  esc env set test 'array[2].foo' '' && esc env get test
-  esc env init test2
-  esc env set test 'imports[0]' test2 && esc env get test
-  esc env init test3
-  esc env set test 'imports[1]' test3 && esc env get test
+  esc env init default/test
+  esc env set default/test foo.bar.baz qux && esc env get default/test
+  esc env set default/test foo.bar.alpha zed && esc env get default/test
+  esc env set default/test 'foo.beta[0]' gamma && esc env get default/test
+  esc env set default/test 'foo.beta[1]' 42 && esc env get default/test
+  esc env set default/test open '{"fn::open::test": "esc"}' && esc env get default/test
+  esc env set default/test 'open["fn::open::test"]' cse && esc env get default/test
+  esc env set default/test array '[hello, world]' && esc env get default/test
+  esc env set default/test 'array[1]' esc && esc env get default/test
+  esc env set default/test 'array[2]' '{}' && esc env get default/test
+  esc env set default/test 'array[2].foo' bar && esc env get default/test
+  esc env set default/test 'array[2].foo' '' && esc env get default/test
+  esc env init default/test2
+  esc env set default/test 'imports[0]' default/test2 && esc env get default/test
+  esc env init default/test3
+  esc env set default/test 'imports[1]' default/test3 && esc env get default/test
 stdout: |+
-  > esc env init test
+  > esc env init default/test
   Environment created: test-user/default/test
-  > esc env set test foo.bar.baz qux
-  > esc env get test
+  > esc env set default/test foo.bar.baz qux
+  > esc env get default/test
   # Value
   ```json
   {
@@ -39,8 +39,8 @@ stdout: |+
 
   ```
 
-  > esc env set test foo.bar.alpha zed
-  > esc env get test
+  > esc env set default/test foo.bar.alpha zed
+  > esc env get default/test
   # Value
   ```json
   {
@@ -62,8 +62,8 @@ stdout: |+
 
   ```
 
-  > esc env set test foo.beta[0] gamma
-  > esc env get test
+  > esc env set default/test foo.beta[0] gamma
+  > esc env get default/test
   # Value
   ```json
   {
@@ -90,8 +90,8 @@ stdout: |+
 
   ```
 
-  > esc env set test foo.beta[1] 42
-  > esc env get test
+  > esc env set default/test foo.beta[1] 42
+  > esc env get default/test
   # Value
   ```json
   {
@@ -120,8 +120,8 @@ stdout: |+
 
   ```
 
-  > esc env set test open {"fn::open::test": "esc"}
-  > esc env get test
+  > esc env set default/test open {"fn::open::test": "esc"}
+  > esc env get default/test
   # Value
   ```json
   {
@@ -153,8 +153,8 @@ stdout: |+
 
   ```
 
-  > esc env set test open["fn::open::test"] cse
-  > esc env get test
+  > esc env set default/test open["fn::open::test"] cse
+  > esc env get default/test
   # Value
   ```json
   {
@@ -186,8 +186,8 @@ stdout: |+
 
   ```
 
-  > esc env set test array [hello, world]
-  > esc env get test
+  > esc env set default/test array [hello, world]
+  > esc env get default/test
   # Value
   ```json
   {
@@ -226,8 +226,8 @@ stdout: |+
 
   ```
 
-  > esc env set test array[1] esc
-  > esc env get test
+  > esc env set default/test array[1] esc
+  > esc env get default/test
   # Value
   ```json
   {
@@ -266,8 +266,8 @@ stdout: |+
 
   ```
 
-  > esc env set test array[2] {}
-  > esc env get test
+  > esc env set default/test array[2] {}
+  > esc env get default/test
   # Value
   ```json
   {
@@ -308,8 +308,8 @@ stdout: |+
 
   ```
 
-  > esc env set test array[2].foo bar
-  > esc env get test
+  > esc env set default/test array[2].foo bar
+  > esc env get default/test
   # Value
   ```json
   {
@@ -352,8 +352,8 @@ stdout: |+
 
   ```
 
-  > esc env set test array[2].foo 
-  > esc env get test
+  > esc env set default/test array[2].foo 
+  > esc env get default/test
   # Value
   ```json
   {
@@ -396,10 +396,10 @@ stdout: |+
 
   ```
 
-  > esc env init test2
+  > esc env init default/test2
   Environment created: test-user/default/test2
-  > esc env set test imports[0] test2
-  > esc env get test
+  > esc env set default/test imports[0] default/test2
+  > esc env get default/test
   # Value
   ```json
   {
@@ -440,14 +440,14 @@ stdout: |+
       - esc
       - {foo: ""}
   imports:
-    - test2
+    - default/test2
 
   ```
 
-  > esc env init test3
+  > esc env init default/test3
   Environment created: test-user/default/test3
-  > esc env set test imports[1] test3
-  > esc env get test
+  > esc env set default/test imports[1] default/test3
+  > esc env get default/test
   # Value
   ```json
   {
@@ -488,38 +488,38 @@ stdout: |+
       - esc
       - {foo: ""}
   imports:
-    - test2
-    - test3
+    - default/test2
+    - default/test3
 
   ```
 
 stderr: |
-  > esc env init test
-  > esc env set test foo.bar.baz qux
-  > esc env get test
-  > esc env set test foo.bar.alpha zed
-  > esc env get test
-  > esc env set test foo.beta[0] gamma
-  > esc env get test
-  > esc env set test foo.beta[1] 42
-  > esc env get test
-  > esc env set test open {"fn::open::test": "esc"}
-  > esc env get test
-  > esc env set test open["fn::open::test"] cse
-  > esc env get test
-  > esc env set test array [hello, world]
-  > esc env get test
-  > esc env set test array[1] esc
-  > esc env get test
-  > esc env set test array[2] {}
-  > esc env get test
-  > esc env set test array[2].foo bar
-  > esc env get test
-  > esc env set test array[2].foo 
-  > esc env get test
-  > esc env init test2
-  > esc env set test imports[0] test2
-  > esc env get test
-  > esc env init test3
-  > esc env set test imports[1] test3
-  > esc env get test
+  > esc env init default/test
+  > esc env set default/test foo.bar.baz qux
+  > esc env get default/test
+  > esc env set default/test foo.bar.alpha zed
+  > esc env get default/test
+  > esc env set default/test foo.beta[0] gamma
+  > esc env get default/test
+  > esc env set default/test foo.beta[1] 42
+  > esc env get default/test
+  > esc env set default/test open {"fn::open::test": "esc"}
+  > esc env get default/test
+  > esc env set default/test open["fn::open::test"] cse
+  > esc env get default/test
+  > esc env set default/test array [hello, world]
+  > esc env get default/test
+  > esc env set default/test array[1] esc
+  > esc env get default/test
+  > esc env set default/test array[2] {}
+  > esc env get default/test
+  > esc env set default/test array[2].foo bar
+  > esc env get default/test
+  > esc env set default/test array[2].foo 
+  > esc env get default/test
+  > esc env init default/test2
+  > esc env set default/test imports[0] default/test2
+  > esc env get default/test
+  > esc env init default/test3
+  > esc env set default/test imports[1] default/test3
+  > esc env get default/test

--- a/cmd/esc/cli/testdata/env-version-history.yaml
+++ b/cmd/esc/cli/testdata/env-version-history.yaml
@@ -1,11 +1,11 @@
 run: |
-  esc env version history test --utc
-  esc env version history test@latest --utc
-  esc env version history test@stable --utc
-  esc env version history test@1 --utc
-  esc env version history test@2 --utc
-  esc env version history test@3 --utc
-  esc env version history test@4 --utc
+  esc env version history default/test --utc
+  esc env version history default/test@latest --utc
+  esc env version history default/test@stable --utc
+  esc env version history default/test@1 --utc
+  esc env version history default/test@2 --utc
+  esc env version history default/test@3 --utc
+  esc env version history default/test@4 --utc
 environments:
   test-user/default/a: {}
   test-user/default/b: {}
@@ -42,7 +42,7 @@ environments:
               fn::secret:
                 ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
 stdout: |+
-  > esc env version history test --utc
+  > esc env version history default/test --utc
   revision 5
   Author: Test Tester <test-tester>
   Date:   1970-01-01 05:00:00 +0000 UTC
@@ -67,7 +67,7 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
-  > esc env version history test@latest --utc
+  > esc env version history default/test@latest --utc
   revision 5
   Author: Test Tester <test-tester>
   Date:   1970-01-01 05:00:00 +0000 UTC
@@ -92,7 +92,7 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
-  > esc env version history test@stable --utc
+  > esc env version history default/test@stable --utc
   revision 4 (tag: stable)
   Author: Test Tester <test-tester>
   Date:   1970-01-01 04:00:00 +0000 UTC
@@ -113,12 +113,12 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
-  > esc env version history test@1 --utc
+  > esc env version history default/test@1 --utc
   revision 1
   Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
-  > esc env version history test@2 --utc
+  > esc env version history default/test@2 --utc
   revision 2
   Author: Test Tester <test-tester>
   Date:   1970-01-01 02:00:00 +0000 UTC
@@ -127,7 +127,7 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
-  > esc env version history test@3 --utc
+  > esc env version history default/test@3 --utc
   revision 3 (retracted)
   Author: Test Tester <test-tester>
   Date:   1970-01-01 03:00:00 +0000 UTC
@@ -144,7 +144,7 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
-  > esc env version history test@4 --utc
+  > esc env version history default/test@4 --utc
   revision 4 (tag: stable)
   Author: Test Tester <test-tester>
   Date:   1970-01-01 04:00:00 +0000 UTC
@@ -166,10 +166,10 @@ stdout: |+
   Date:   1970-01-01 01:00:00 +0000 UTC
 
 stderr: |
-  > esc env version history test --utc
-  > esc env version history test@latest --utc
-  > esc env version history test@stable --utc
-  > esc env version history test@1 --utc
-  > esc env version history test@2 --utc
-  > esc env version history test@3 --utc
-  > esc env version history test@4 --utc
+  > esc env version history default/test --utc
+  > esc env version history default/test@latest --utc
+  > esc env version history default/test@stable --utc
+  > esc env version history default/test@1 --utc
+  > esc env version history default/test@2 --utc
+  > esc env version history default/test@3 --utc
+  > esc env version history default/test@4 --utc

--- a/cmd/esc/cli/testdata/env-version-retract.yaml
+++ b/cmd/esc/cli/testdata/env-version-retract.yaml
@@ -1,11 +1,11 @@
 run: |
-  esc env version history test --utc
-  esc env version retract test@2 --reason "plaintext secret" --replace-with @3
-  esc env version history test --utc
-  esc env version retract test@3 --reason "test retraction" --replace-with @latest
-  esc env version history test --utc
-  esc env version retract test@4
-  esc env version history test --utc
+  esc env version history default/test --utc
+  esc env version retract default/test@2 --reason "plaintext secret" --replace-with @3
+  esc env version history default/test --utc
+  esc env version retract default/test@3 --reason "test retraction" --replace-with @latest
+  esc env version history default/test --utc
+  esc env version retract default/test@4
+  esc env version history default/test --utc
 environments:
   test-user/default/test:
     revisions:
@@ -22,7 +22,7 @@ environments:
           vaues:
             goodbye: cruel world
 stdout: |+
-  > esc env version history test --utc
+  > esc env version history default/test --utc
   revision 5
   Author: Test Tester <test-tester>
   Date:   1970-01-01 05:00:00 +0000 UTC
@@ -43,8 +43,8 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
-  > esc env version retract test@2 --reason plaintext secret --replace-with @3
-  > esc env version history test --utc
+  > esc env version retract default/test@2 --reason plaintext secret --replace-with @3
+  > esc env version history default/test --utc
   revision 5
   Author: Test Tester <test-tester>
   Date:   1970-01-01 05:00:00 +0000 UTC
@@ -69,8 +69,8 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
-  > esc env version retract test@3 --reason test retraction --replace-with @latest
-  > esc env version history test --utc
+  > esc env version retract default/test@3 --reason test retraction --replace-with @latest
+  > esc env version history default/test --utc
   revision 5
   Author: Test Tester <test-tester>
   Date:   1970-01-01 05:00:00 +0000 UTC
@@ -99,8 +99,8 @@ stdout: |+
   Author: Test Tester <test-tester>
   Date:   1970-01-01 01:00:00 +0000 UTC
 
-  > esc env version retract test@4
-  > esc env version history test --utc
+  > esc env version retract default/test@4
+  > esc env version history default/test --utc
   revision 5
   Author: Test Tester <test-tester>
   Date:   1970-01-01 05:00:00 +0000 UTC
@@ -132,10 +132,10 @@ stdout: |+
   Date:   1970-01-01 01:00:00 +0000 UTC
 
 stderr: |
-  > esc env version history test --utc
-  > esc env version retract test@2 --reason plaintext secret --replace-with @3
-  > esc env version history test --utc
-  > esc env version retract test@3 --reason test retraction --replace-with @latest
-  > esc env version history test --utc
-  > esc env version retract test@4
-  > esc env version history test --utc
+  > esc env version history default/test --utc
+  > esc env version retract default/test@2 --reason plaintext secret --replace-with @3
+  > esc env version history default/test --utc
+  > esc env version retract default/test@3 --reason test retraction --replace-with @latest
+  > esc env version history default/test --utc
+  > esc env version retract default/test@4
+  > esc env version history default/test --utc

--- a/cmd/esc/cli/testdata/env-version-rollback.yaml
+++ b/cmd/esc/cli/testdata/env-version-rollback.yaml
@@ -1,7 +1,7 @@
 run: |
-  esc env version rollback test@stable
-  esc env get test
-  esc env version rollback test@2
+  esc env version rollback default/test@stable
+  esc env get default/test
+  esc env version rollback default/test@2
 error: exit status 1
 environments:
   test-user/default/a: {}
@@ -35,9 +35,9 @@ environments:
               fn::secret:
                 ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
 stdout: |
-  > esc env version rollback test@stable
+  > esc env version rollback default/test@stable
   Environment updated.
-  > esc env get test
+  > esc env get default/test
   # Value
   ```json
   {
@@ -51,11 +51,11 @@ stdout: |
 
   ```
 
-  > esc env version rollback test@2
+  > esc env version rollback default/test@2
 stderr: |
-  > esc env version rollback test@stable
-  > esc env get test
-  > esc env version rollback test@2
+  > esc env version rollback default/test@stable
+  > esc env get default/test
+  > esc env version rollback default/test@2
   Error: not found
 
     on test line 2:

--- a/cmd/esc/cli/testdata/env-version-tag.yaml
+++ b/cmd/esc/cli/testdata/env-version-tag.yaml
@@ -1,16 +1,16 @@
 run: |
-  esc env version tag test@stable 2
-  esc env version test@stable --utc
-  esc env version tag test@stable 3
-  esc env version test@stable --utc
-  esc env version tag test@stable
-  esc env version test@stable --utc
-  esc env version test@latest --utc
-  esc env version tag ls test --utc
-  esc env version tag test@initial 1
-  esc env version tag ls test --utc
-  esc env version tag rm test@initial
-  esc env version tag ls test --utc
+  esc env version tag default/test@stable 2
+  esc env version default/test@stable --utc
+  esc env version tag default/test@stable 3
+  esc env version default/test@stable --utc
+  esc env version tag default/test@stable
+  esc env version default/test@stable --utc
+  esc env version default/test@latest --utc
+  esc env version tag ls default/test --utc
+  esc env version tag default/test@initial 1
+  esc env version tag ls default/test --utc
+  esc env version tag rm default/test@initial
+  esc env version tag ls default/test --utc
 environments:
   test-user/default/a: {}
   test-user/default/b: {}
@@ -39,26 +39,26 @@ environments:
               fn::secret:
                 ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
 stdout: |+
-  > esc env version tag test@stable 2
-  > esc env version test@stable --utc
+  > esc env version tag default/test@stable 2
+  > esc env version default/test@stable --utc
   stable
   Revision 2
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
-  > esc env version tag test@stable 3
-  > esc env version test@stable --utc
+  > esc env version tag default/test@stable 3
+  > esc env version default/test@stable --utc
   stable
   Revision 3
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
-  > esc env version tag test@stable
-  > esc env version test@stable --utc
+  > esc env version tag default/test@stable
+  > esc env version default/test@stable --utc
   stable
   Revision 4
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
-  > esc env version test@latest --utc
+  > esc env version default/test@latest --utc
   latest
   Revision 4
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
-  > esc env version tag ls test --utc
+  > esc env version tag ls default/test --utc
   latest
   Revision 4
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
@@ -67,8 +67,8 @@ stdout: |+
   Revision 4
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
-  > esc env version tag test@initial 1
-  > esc env version tag ls test --utc
+  > esc env version tag default/test@initial 1
+  > esc env version tag ls default/test --utc
   initial
   Revision 1
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
@@ -81,8 +81,8 @@ stdout: |+
   Revision 4
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
-  > esc env version tag rm test@initial
-  > esc env version tag ls test --utc
+  > esc env version tag rm default/test@initial
+  > esc env version tag ls default/test --utc
   latest
   Revision 4
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
@@ -92,15 +92,15 @@ stdout: |+
   Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
 stderr: |
-  > esc env version tag test@stable 2
-  > esc env version test@stable --utc
-  > esc env version tag test@stable 3
-  > esc env version test@stable --utc
-  > esc env version tag test@stable
-  > esc env version test@stable --utc
-  > esc env version test@latest --utc
-  > esc env version tag ls test --utc
-  > esc env version tag test@initial 1
-  > esc env version tag ls test --utc
-  > esc env version tag rm test@initial
-  > esc env version tag ls test --utc
+  > esc env version tag default/test@stable 2
+  > esc env version default/test@stable --utc
+  > esc env version tag default/test@stable 3
+  > esc env version default/test@stable --utc
+  > esc env version tag default/test@stable
+  > esc env version default/test@stable --utc
+  > esc env version default/test@latest --utc
+  > esc env version tag ls default/test --utc
+  > esc env version tag default/test@initial 1
+  > esc env version tag ls default/test --utc
+  > esc env version tag rm default/test@initial
+  > esc env version tag ls default/test --utc

--- a/cmd/esc/cli/testdata/open-detailed.yaml
+++ b/cmd/esc/cli/testdata/open-detailed.yaml
@@ -1,4 +1,4 @@
-run: esc open test --format detailed
+run: esc open default/test --format detailed
 environments:
   test-user/default/test:
     imports:
@@ -10,7 +10,7 @@ environments:
       foo: baz
       hello: world
 stdout: |
-  > esc open test --format detailed
+  > esc open default/test --format detailed
   {
     "value": {
       "foo": {
@@ -84,4 +84,4 @@ stdout: |
     }
   }
 stderr: |
-  > esc open test --format detailed
+  > esc open default/test --format detailed

--- a/cmd/esc/cli/testdata/open-dotenv.yaml
+++ b/cmd/esc/cli/testdata/open-dotenv.yaml
@@ -1,4 +1,4 @@
-run: esc open test --format dotenv
+run: esc open default/test --format dotenv
 environments:
   test-user/default/test:
     imports:
@@ -23,7 +23,7 @@ environments:
       files:
         FILE: bar
 stdout: |
-  > esc open test --format dotenv
+  > esc open default/test --format dotenv
   BOOL="true"
   FOO="bar"
   HELLO="world"
@@ -32,4 +32,4 @@ stdout: |
   FILE="temp/esc-temp-1"
   NUM_FILE="temp/esc-temp-2"
 stderr: |
-  > esc open test --format dotenv
+  > esc open default/test --format dotenv

--- a/cmd/esc/cli/testdata/open-invalid.yaml
+++ b/cmd/esc/cli/testdata/open-invalid.yaml
@@ -1,7 +1,7 @@
-run: esc open test --format=flat
+run: esc open default/test --format=flat
 error: exit status 1
 stdout: |
-  > esc open test --format=flat
+  > esc open default/test --format=flat
 stderr: |
-  > esc open test --format=flat
+  > esc open default/test --format=flat
   Error: unknown output format "flat"

--- a/cmd/esc/cli/testdata/open-json-error.yaml
+++ b/cmd/esc/cli/testdata/open-json-error.yaml
@@ -1,4 +1,4 @@
-run: esc open test --format json
+run: esc open default/test --format json
 environments:
   test-user/default/test:
     values:
@@ -6,8 +6,8 @@ environments:
       missing: ${foo}
       invalid: {'fn::toBase64': "${object}"}
 stdout: |
-  > esc open test --format json
+  > esc open default/test --format json
 stderr: |
-  > esc open test --format json
+  > esc open default/test --format json
   test:3:16: unknown property "foo"
   test:4:31: expected string, got object

--- a/cmd/esc/cli/testdata/open-json.yaml
+++ b/cmd/esc/cli/testdata/open-json.yaml
@@ -1,10 +1,10 @@
 run: |
-  esc open test --format json
-  esc open test@stable
-  esc open test@latest
-  esc open test@1
-  esc open test@2
-  esc open test@3
+  esc open default/test --format json
+  esc open default/test@stable
+  esc open default/test@latest
+  esc open default/test@1
+  esc open default/test@2
+  esc open default/test@3
 environments:
   test-user/default/test:
     revisions:
@@ -23,34 +23,34 @@ environments:
       foo: baz
       hello: world
 stdout: |
-  > esc open test --format json
+  > esc open default/test --format json
   {
     "foo": "bar",
     "hello": "world"
   }
-  > esc open test@stable
+  > esc open default/test@stable
   {
     "foo": "bar"
   }
-  > esc open test@latest
+  > esc open default/test@latest
   {
     "foo": "bar",
     "hello": "world"
   }
-  > esc open test@1
-  > esc open test@2
+  > esc open default/test@1
+  > esc open default/test@2
   {
     "foo": "bar"
   }
-  > esc open test@3
+  > esc open default/test@3
   {
     "foo": "bar",
     "hello": "world"
   }
 stderr: |
-  > esc open test --format json
-  > esc open test@stable
-  > esc open test@latest
-  > esc open test@1
-  > esc open test@2
-  > esc open test@3
+  > esc open default/test --format json
+  > esc open default/test@stable
+  > esc open default/test@latest
+  > esc open default/test@1
+  > esc open default/test@2
+  > esc open default/test@3

--- a/cmd/esc/cli/testdata/open-shell.yaml
+++ b/cmd/esc/cli/testdata/open-shell.yaml
@@ -1,4 +1,4 @@
-run: esc open test --format shell
+run: esc open default/test --format shell
 environments:
   test-user/default/test:
     imports:
@@ -23,7 +23,7 @@ environments:
       files:
         FILE: bar
 stdout: |
-  > esc open test --format shell
+  > esc open default/test --format shell
   export BOOL="true"
   export FOO="bar"
   export HELLO="world"
@@ -32,4 +32,4 @@ stdout: |
   export FILE="temp/esc-temp-1"
   export NUM_FILE="temp/esc-temp-2"
 stderr: |
-  > esc open test --format shell
+  > esc open default/test --format shell

--- a/cmd/esc/cli/testdata/open-string.yaml
+++ b/cmd/esc/cli/testdata/open-string.yaml
@@ -1,4 +1,4 @@
-run: esc open test --format string
+run: esc open default/test --format string
 environments:
   test-user/default/test:
     imports:
@@ -10,7 +10,7 @@ environments:
       foo: baz
       hello: world
 stdout: |
-  > esc open test --format string
+  > esc open default/test --format string
   "foo"="bar","hello"="world"
 stderr: |
-  > esc open test --format string
+  > esc open default/test --format string

--- a/cmd/esc/cli/testdata/open-yaml.yaml
+++ b/cmd/esc/cli/testdata/open-yaml.yaml
@@ -1,4 +1,4 @@
-run: esc open test --format yaml
+run: esc open default/test --format yaml
 environments:
   test-user/default/test:
     imports:
@@ -10,8 +10,8 @@ environments:
       foo: baz
       hello: world
 stdout: |
-  > esc open test --format yaml
+  > esc open default/test --format yaml
   foo: bar
   hello: world
 stderr: |
-  > esc open test --format yaml
+  > esc open default/test --format yaml

--- a/cmd/esc/cli/testdata/run.yaml
+++ b/cmd/esc/cli/testdata/run.yaml
@@ -1,12 +1,12 @@
 run: |
-  esc env run test dump-env
-  esc env run -i test dump-env
-  esc env run test echo "secret: \${secret}, plain: \${plain}"
-  esc env run -i test echo "secret: \${secret}, plain: \${plain}"
-  esc env run test source-file
-  esc env run -i test source-file
-  esc env run test -- echo -n hunter2
-  esc env run test -i -- echo -n hunter2
+  esc env run default/test dump-env
+  esc env run -i default/test dump-env
+  esc env run default/test echo "secret: \${secret}, plain: \${plain}"
+  esc env run -i default/test echo "secret: \${secret}, plain: \${plain}"
+  esc env run default/test source-file
+  esc env run -i default/test source-file
+  esc env run default/test -- echo -n hunter2
+  esc env run default/test -i -- echo -n hunter2
 process:
   commands:
     dump-env: |
@@ -35,27 +35,27 @@ environments:
         BOOL_FILE: ${yup}
         NUM_FILE: ${pi}
 stdout: |-
-  > esc env run test dump-env
+  > esc env run default/test dump-env
   secret: [secret], plain: plaintext, bool: true, num: 3.14, file: temp/esc-temp-1, boolFile: temp/esc-temp-0, numFile: temp/esc-temp-2
-  > esc env run -i test dump-env
+  > esc env run -i default/test dump-env
   secret: hunter2, plain: plaintext, bool: true, num: 3.14, file: temp/esc-temp-1, boolFile: temp/esc-temp-0, numFile: temp/esc-temp-2
-  > esc env run test echo secret: ${secret}, plain: ${plain}
+  > esc env run default/test echo secret: ${secret}, plain: ${plain}
   secret: [secret], plain: plaintext
-  > esc env run -i test echo secret: ${secret}, plain: ${plain}
+  > esc env run -i default/test echo secret: ${secret}, plain: ${plain}
   secret: hunter2, plain: plaintext
-  > esc env run test source-file
+  > esc env run default/test source-file
   secret: [secret], plain: plaintext
-  > esc env run -i test source-file
+  > esc env run -i default/test source-file
   secret: hunter2, plain: plaintext
-  > esc env run test -- echo -n hunter2
-  [secret]> esc env run test -i -- echo -n hunter2
+  > esc env run default/test -- echo -n hunter2
+  [secret]> esc env run default/test -i -- echo -n hunter2
   hunter2
 stderr: |
-  > esc env run test dump-env
-  > esc env run -i test dump-env
-  > esc env run test echo secret: ${secret}, plain: ${plain}
-  > esc env run -i test echo secret: ${secret}, plain: ${plain}
-  > esc env run test source-file
-  > esc env run -i test source-file
-  > esc env run test -- echo -n hunter2
-  > esc env run test -i -- echo -n hunter2
+  > esc env run default/test dump-env
+  > esc env run -i default/test dump-env
+  > esc env run default/test echo secret: ${secret}, plain: ${plain}
+  > esc env run -i default/test echo secret: ${secret}, plain: ${plain}
+  > esc env run default/test source-file
+  > esc env run -i default/test source-file
+  > esc env run default/test -- echo -n hunter2
+  > esc env run default/test -i -- echo -n hunter2


### PR DESCRIPTION
With the introduction of projects, referring to environments without the project name is deprecated. Adds a warning message that looks like this:
![Screenshot 2024-09-04 at 1 45 02 PM](https://github.com/user-attachments/assets/0663b179-48f0-464a-9c1a-5cb156ae74e5)

This message is printed to stderr so that parsing stdout for commands still works, such as `esc env open ... | jq`


## Testing
env open
```bash
# Shows warning when using single name without project
❯ go run ./cmd/esc env open env1
Warning: Referring to an environment name ('env1') without a project is deprecated.
Please use 'syeh2/default/env1' or 'default/env1' instead.
{}

# warning when using org/env without project
❯ go run ./cmd/esc env open syeh2/env1
Warning: Referring to an environment name ('syeh2/env1') without a project is deprecated.
Please use 'syeh2/default/env1' or 'default/env1' instead.
{}

# no warning when using project/env
❯ go run ./cmd/esc env open asdf/env1
{
  "a": "12345"
}

❯ go run ./cmd/esc env open default/env1
{}
```
same for env init
```bash
❯ go run ./cmd/esc env init hello
Warning: Referring to an environment name ('hello') without a project is deprecated.
Please use 'syeh2/default/hello' or 'default/hello' instead.
Environment created: syeh2/default/hello

❯ go run ./cmd/esc env init syeh2/hello2
Warning: Referring to an environment name ('syeh2/hello2') without a project is deprecated.
Please use 'syeh2/default/hello2' or 'default/hello2' instead.
Environment created: syeh2/default/hello2

❯ go run ./cmd/esc env init asdf/hello2
Environment created: syeh2/asdf/hello2
```

Works for other commands (but does not trigger for "relative" env names, such as `@2`)
```bash
❯ go run ./cmd/esc env diff env1@1 @2
Warning: Referring to an environment name ('env1@1') without a project is deprecated.
Please use 'syeh2/default/env1@1' or 'default/env1@1' instead.

# No warning for relative envs
❯ go run ./cmd/esc env diff default/env1@1 @2
```