### PR TITLE
Make the value arg optional for set command

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,9 @@
 - Improve evaluation performance and memory footprint.
   [#392](https://github.com/pulumi/esc/pull/392)
 
+- Prompt for the value if the value arg is not passed.
+  [#394](https://github.com/pulumi/esc/pull/394)
+
 ### Bug Fixes
 
 ### Breaking changes

--- a/cmd/esc/cli/testdata/env-set-secret.yaml
+++ b/cmd/esc/cli/testdata/env-set-secret.yaml
@@ -16,6 +16,8 @@ run: |
   esc env get default/test
   esc env set default/test password true --secret
   esc env get default/test
+  echo 'mysecret' | esc env set default/test password --secret
+  esc env get default/test --show-secrets
   esc env set default/test password '[]' --secret || echo OK
 stdout: |
   > esc env init default/test
@@ -166,6 +168,22 @@ stdout: |
 
   ```
 
+  > esc env set default/test password --secret
+  > esc env get default/test --show-secrets
+  # Value
+  ```json
+  {
+    "password": "mysecret"
+  }
+  ```
+  # Definition
+  ```yaml
+  values:
+    password:
+      fn::secret: mysecret
+
+  ```
+
   > esc env set default/test password [] --secret
 stderr: |
   > esc env init default/test
@@ -186,5 +204,7 @@ stderr: |
   > esc env get default/test
   > esc env set default/test password true --secret
   > esc env get default/test
+  > esc env set default/test password --secret
+  > esc env get default/test --show-secrets
   > esc env set default/test password [] --secret
   test:3:21: secret values must be string literals


### PR DESCRIPTION
Fixes #340.

This PR uses the same code as Pulumi CLI to prompt the user for a value if no value is specificed when in interactive mode.

Although I updated the test, I couldn't get it to pass because the pipe command seems to not run correctly? I couldn't quite figure out what is going on and hope that one of you knows how to get the test to pass. FWIW, I built a local version of the CLI and have confirmed it to work with these changes, i.e. I can run `echo 'secret' | esc env set <workspace> <path> --secret` (as well as without `--secret`.)