### PR TITLE
fix installation instructions for pulumi esc

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For a hands-on, self-paced tutorial see our Pulumi ESC [Getting Started](https:/
     [installation instructions](https://www.pulumi.com/docs/install/esc/?utm_campaign=pulumi-esc-github-repo&utm_source=github.com&utm_medium=getting-started-install) for additional installation options):
 
     ```bash
-    $ curl -fsSL https://get.pulumi.com/ | sh
+    $ curl -fsSL https://get.pulumi.com/esc/install.sh | sh
     ```
 
 ### Building the ESC CLI Locally


### PR DESCRIPTION
Just using curl get.pulumi.com will install the pulumi CLI.  While that embeds esc as `pulumi env` it's not what we want to direct users to when they look at esc, especially as the guide linked above refers to plain `esc`.