### PR TITLE
 Adjust the link path used in generated CLI docs

### DIFF
--- a/cmd/esc/cli/gen_docs.go
+++ b/cmd/esc/cli/gen_docs.go
@@ -53,7 +53,7 @@ func newGenDocsCmd(root *cobra.Command) *cobra.Command {
 			// linkHandler emits pretty URL links.
 			linkHandler := func(s string) string {
 				link := strings.TrimSuffix(s, ".md")
-				return fmt.Sprintf("/docs/esc-cli/commands/%s/", link)
+				return fmt.Sprintf("/docs/esc/cli/commands/%s/", link)
 			}
 
 			// Generate the .md files.


### PR DESCRIPTION
Similar to https://github.com/pulumi/pulumi/pull/17536, this change adjusts the path used to generate links between ESC CLI docs to match their new location at `/docs/esc/cli`.