### PR TITLE
Add --definition to get to print definition

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
+- Add `--definition` flag to `esc env get` to output definition
+  [#416](https://github.com/pulumi/esc/pull/416)
+
 ### Bug Fixes
 
 ### Breaking changes

--- a/cmd/esc/cli/env_get.go
+++ b/cmd/esc/cli/env_get.go
@@ -33,6 +33,7 @@ type envGetCommand struct {
 
 func newEnvGetCmd(env *envCommand) *cobra.Command {
 	var value string
+	var defOnly bool
 	var showSecrets bool
 
 	get := &envGetCommand{env: env}
@@ -67,6 +68,10 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 				}
 			}
 
+			if defOnly && value != "" {
+				return fmt.Errorf("`--value` and `--definition` flags cannot be used together")
+			}
+
 			switch value {
 			case "":
 				// OK
@@ -94,6 +99,11 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 				return nil
 			}
 
+			if defOnly {
+				fmt.Fprint(get.env.esc.stdout, data.Definition)
+				return nil
+			}
+
 			var markdown bytes.Buffer
 			if err := envGetTemplate.Execute(&markdown, data); err != nil {
 				return fmt.Errorf("internal error: rendering: %w", err)
@@ -117,9 +127,12 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVar(
+		&defOnly, "definition", false,
+		"Set to print just the definition.")
 	cmd.Flags().StringVar(
 		&value, "value", "",
-		"set to print just the value in the given format. may be 'dotenv', 'json', 'detailed', or 'shell'")
+		"Set to print just the value in the given format. May be 'dotenv', 'json', 'detailed', or 'shell'")
 	cmd.Flags().BoolVar(
 		&showSecrets, "show-secrets", false,
 		"Show static secrets in plaintext rather than ciphertext")

--- a/cmd/esc/cli/testdata/env-get-definition-error.yaml
+++ b/cmd/esc/cli/testdata/env-get-definition-error.yaml
@@ -1,0 +1,7 @@
+run: esc env get default/test --definition --value=json
+error: exit status 1
+stdout: |
+  > esc env get default/test --definition --value=json
+stderr: |
+  > esc env get default/test --definition --value=json
+  Error: `--value` and `--definition` flags cannot be used together

--- a/cmd/esc/cli/testdata/env-get-definition.yaml
+++ b/cmd/esc/cli/testdata/env-get-definition.yaml
@@ -1,0 +1,22 @@
+run: |
+  esc env get default/test --definition
+environments:
+  test-user/default/test:
+    imports:
+      - a
+    values:
+      # comment
+      string: esc
+      files:
+        FILE: ${string}
+stdout: |
+  > esc env get default/test --definition
+  imports:
+    - a
+  values:
+    # comment
+    string: esc
+    files:
+      FILE: ${string}
+stderr: |
+  > esc env get default/test --definition


### PR DESCRIPTION
Fixes https://github.com/pulumi/esc/issues/415

Adds a `--definition` flag to the get command. we already have a `--value` command to only output the value, so I figured the `--definition` flag makes sense. open to other suggestions though

## Testing

```
❯ go run ./cmd/esc env get temp2/abc/importer --definition --value json
Error: `--value` and `--definition` flags cannot be used together
exit status 1

❯ go run ./cmd/esc env get temp2/abc/importer --definition
imports:
  - abc/envvars
...
```