### PR TITLE
Remove dependency on `pulumi` `sdk/go/common/env`

### DIFF
--- a/cmd/esc/cli/env_rm.go
+++ b/cmd/esc/cli/env_rm.go
@@ -6,15 +6,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
 	"github.com/pulumi/esc/syntax/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
-	pulumienv "github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
+
+// PulumiSkipConfirmationsEnvVar is an environment variable that can be used to skip confirmation prompts. This matches
+// the variable used by the core Pulumi CLI.
+const PulumiSkipConfirmationsEnvVar = "PULUMI_SKIP_CONFIRMATIONS"
 
 func newEnvRmCmd(env *envCommand) *cobra.Command {
 	var yes bool
@@ -33,7 +38,7 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 
-			yes = yes || pulumienv.SkipConfirmations.Value()
+			yes = yes || cmdutil.IsTruthy(os.Getenv(PulumiSkipConfirmationsEnvVar))
 
 			if err := env.esc.getCachedClient(ctx); err != nil {
 				return err


### PR DESCRIPTION
This is the only use of `sdk/go/common/env` outside of `pulumi/pulumi`, and it's easily removed by inlining the name of the relevant environment variable. Since we already do this in a few other places (e.g. backend URL lookup), this commit makes the change and breaks the dependency.