### PR TITLE
Fix diagnostic messages on update environment

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,7 +1,7 @@
 ### Improvements
 
-- Add `--definition` flag to `esc env get` to output definition
-  [#416](https://github.com/pulumi/esc/pull/416)
+- Fix diagnostic messages when updating environment with invalid definition
+  [#422](https://github.com/pulumi/esc/pull/422)
 
 ### Bug Fixes
 

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -560,7 +560,7 @@ func (pc *client) UpdateEnvironmentWithRevision(
 	})
 	if err != nil {
 		var diags *EnvironmentErrorResponse
-		if errors.As(err, &diags) && diags.Code == http.StatusBadRequest && len(diags.Diagnostics) != 0 {
+		if errors.As(err, &diags) && len(diags.Diagnostics) != 0 {
 			return diags.Diagnostics, 0, nil
 		}
 		return nil, 0, err


### PR DESCRIPTION
Fixes https://github.com/pulumi/esc/issues/370

When updating an env with an invalid definition, `UpdateEnvironmentWithRevision` should return no error but with diagnostics

## Testing

Because of this issue, we previously wouldn't reach [here](https://github.com/pulumi/esc/blob/0a8fc4100f4cce21f9b45faa9ef379d100718696/cmd/esc/cli/env_edit.go#L127) (which requires non-error but with diagnostics), but with this change, now we can, because `UpdateEnvironmentWithRevision` will now return no error but with diagnostics on invalid definitions

When updating an env with an invalid definition:

Before:
```
❯ go run ./cmd/esc env edit test3/abc/ghi
Error: updating environment definition: [0]
Diags: yaml: line 2: mapping values are not allowed in this context

exit status 1
```

Now:
```
❯ go run ./cmd/esc env edit test3/abc/ghi
Error: yaml: line 2: mapping values are not allowed in this context

Press ENTER to continue editing or ^D to exit
```
