### PR TITLE
Add rotate command

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,8 @@
 - Fix diagnostic messages when updating environment with invalid definition
   [#422](https://github.com/pulumi/esc/pull/422)
 - Introduce support for rotating static credentials via `fn::rotate` providers [432](https://github.com/pulumi/esc/pull/432)
+- Add the `rotate` CLI command
+  [#433](https://github.com/pulumi/esc/pull/433)
 
 ### Bug Fixes
 

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -677,6 +677,16 @@ func (c *testPulumiClient) OpenEnvironment(
 	return c.openEnvironment(ctx, orgName, envName, env.yaml)
 }
 
+func (c *testPulumiClient) RotateEnvironment(
+	ctx context.Context,
+	orgName string,
+	projectName string,
+	envName string,
+	duration time.Duration,
+) (string, []client.EnvironmentDiagnostic, error) {
+	return c.OpenEnvironment(ctx, orgName, projectName, envName, "", duration)
+}
+
 func (c *testPulumiClient) CheckYAMLEnvironment(
 	ctx context.Context,
 	orgName string,

--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -74,6 +74,7 @@ func newEnvCmd(esc *escCommand) *cobra.Command {
 	cmd.AddCommand(newEnvTagCmd((env)))
 	cmd.AddCommand(newEnvRmCmd(env))
 	cmd.AddCommand(newEnvOpenCmd(env))
+	cmd.AddCommand(newEnvRotateCmd(env))
 	cmd.AddCommand(newEnvRunCmd(env))
 
 	return cmd

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -40,7 +40,6 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			_ = args
 
 			var path resource.PropertyPath
 			if len(args) == 1 {

--- a/cmd/esc/cli/env_rotate.go
+++ b/cmd/esc/cli/env_rotate.go
@@ -1,0 +1,88 @@
+// Copyright 2025, Pulumi Corporation.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pulumi/esc"
+	"github.com/pulumi/esc/cmd/esc/cli/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/spf13/cobra"
+)
+
+func newEnvRotateCmd(envcmd *envCommand) *cobra.Command {
+	var duration time.Duration
+	var format string
+
+	cmd := &cobra.Command{
+		Use:   "rotate [<org-name>/][<project-name>/]<environment-name>",
+		Short: "Rotate secrets and open the environment",
+		Long: "Rotate secrets and open the environment\n" +
+			"\n" +
+			"This command opens the environment with the given name. The result is written to\n" +
+			"stdout as JSON.\n",
+		SilenceUsage: true,
+		Hidden:       true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			if err := envcmd.esc.getCachedClient(ctx); err != nil {
+				return err
+			}
+
+			ref, _, err := envcmd.getExistingEnvRef(ctx, args)
+			if err != nil {
+				return err
+			}
+
+			if ref.version != "" {
+				return fmt.Errorf("the rotate command does not accept environments at specific versions")
+			}
+
+			switch format {
+			case "detailed", "json", "yaml", "string", "dotenv", "shell":
+				// OK
+			default:
+				return fmt.Errorf("unknown output format %q", format)
+			}
+
+			env, diags, err := envcmd.rotateEnvironment(ctx, ref, duration)
+			if err != nil {
+				return err
+			}
+			if len(diags) != 0 {
+				return envcmd.writePropertyEnvironmentDiagnostics(envcmd.esc.stderr, diags)
+			}
+
+			return envcmd.renderValue(envcmd.esc.stdout, env, resource.PropertyPath{}, format, false, true)
+		},
+	}
+
+	cmd.Flags().DurationVarP(
+		&duration, "lifetime", "l", 2*time.Hour,
+		"the lifetime of the opened environment in the form HhMm (e.g. 2h, 1h30m, 15m)")
+	cmd.Flags().StringVarP(
+		&format, "format", "f", "json",
+		"the output format to use. May be 'dotenv', 'json', 'yaml', 'detailed', or 'shell'")
+
+	return cmd
+}
+
+func (env *envCommand) rotateEnvironment(
+	ctx context.Context,
+	ref environmentRef,
+	duration time.Duration,
+) (*esc.Environment, []client.EnvironmentDiagnostic, error) {
+	envID, diags, err := env.esc.client.RotateEnvironment(ctx, ref.orgName, ref.projectName, ref.envName, duration)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(diags) != 0 {
+		return nil, diags, err
+	}
+	open, err := env.esc.client.GetOpenEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName, envID)
+	return open, nil, err
+}


### PR DESCRIPTION
## Testing

`go run ./cmd/esc env rotate temp2/abc/rotate`
Rotated and opened the env. Also tested with various `-f` options

Does not accept `@version`
```
❯ go run ./cmd/esc env rotate temp2/abc/yo@asdf
Error: the rotate command does not accept environments at specific versions
exit status 1
```