### PR TITLE
teach evaluator to conditionally retry provider invocation

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -1089,7 +1089,8 @@ func asObjectOrNil(v any) map[string]esc.Value {
 	return cast
 }
 
-// retryProvider implements a default retryProvider policy that retries invoking a provider function on temporary error.
+// retryProvider implements a default retry policy that retries invoking a provider function on temporary error.
+// temporary errors indicated by being wrapped by esc.RetryableError
 func (e *evalContext) retryProvider(fn func() (esc.Value, error)) (esc.Value, error) {
 	_, result, err := retry.Until(e.ctx, retry.Acceptor{
 		Accept: func(try int, _ time.Duration) (bool, interface{}, error) {

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -1096,10 +1095,10 @@ func (e *evalContext) retryProvider(fn func() (esc.Value, error)) (esc.Value, er
 		Accept: func(try int, _ time.Duration) (bool, interface{}, error) {
 			result, err := fn()
 
-			if errors.As(err, &esc.RetryableError{}) && try < 3 {
+			if esc.IsRetryableError(err) && try < 3 {
 				// temporary error, we can retry
 				return false, nil, nil
-			} else if errors.As(err, &esc.RetryableError{}) {
+			} else if esc.IsRetryableError(err) {
 				// ran out of retries
 				return false, nil, fmt.Errorf("gave up after %d attempts: %w", try, err)
 			} else if err != nil {

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -214,7 +214,7 @@ func (errorRotator) Open(ctx context.Context, inputs, state map[string]esc.Value
 
 func (errorRotator) Rotate(ctx context.Context, inputs, state map[string]esc.Value, context esc.EnvExecContext) (esc.Value, error) {
 	if inputs["temporary"].Value.(bool) {
-		return esc.Value{}, esc.RetryableError{Err: fmt.Errorf("temporary error")}
+		return esc.Value{}, esc.RetryableError(fmt.Errorf("temporary error"))
 	}
 	return esc.Value{}, fmt.Errorf("permanent error")
 }

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -213,14 +213,9 @@ func (errorRotator) Open(ctx context.Context, inputs, state map[string]esc.Value
 }
 
 func (errorRotator) Rotate(ctx context.Context, inputs, state map[string]esc.Value, context esc.EnvExecContext) (esc.Value, error) {
-	if state == nil {
-		state = map[string]esc.Value{}
-	}
-
 	if inputs["temporary"].Value.(bool) {
-		return esc.Value{}, esc.RetryableError{fmt.Errorf("temporary error")}
+		return esc.Value{}, esc.RetryableError{Err: fmt.Errorf("temporary error")}
 	}
-
 	return esc.Value{}, fmt.Errorf("permanent error")
 }
 

--- a/eval/testdata/eval/rotate-retry/env.yaml
+++ b/eval/testdata/eval/rotate-retry/env.yaml
@@ -1,0 +1,12 @@
+values:
+  # this should result in a rotateDiag indicating rotation wasn't retried
+  dead:
+    fn::rotate::error:
+      inputs:
+        temporary: false
+
+  # this should result in a rotateDiag indicating the rotation was retried before giving up
+  mostlyDead:
+    fn::rotate::error:
+      inputs:
+        temporary: true

--- a/eval/testdata/eval/rotate-retry/expected.json
+++ b/eval/testdata/eval/rotate-retry/expected.json
@@ -1,0 +1,1751 @@
+{
+    "check": {
+        "exprs": {
+            "dead": {
+                "range": {
+                    "environment": "rotate-retry",
+                    "begin": {
+                        "line": 4,
+                        "column": 5,
+                        "byte": 94
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 25,
+                        "byte": 151
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::rotate::error",
+                    "nameRange": {
+                        "environment": "rotate-retry",
+                        "begin": {
+                            "line": 4,
+                            "column": 5,
+                            "byte": 94
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 22,
+                            "byte": 111
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": {
+                                "properties": {
+                                    "temporary": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "temporary"
+                                ]
+                            },
+                            "state": {
+                                "oneOf": [
+                                    false,
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "type": ""
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "state"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 9,
+                                        "byte": 135
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 25,
+                                        "byte": 151
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "temporary": {
+                                            "type": "boolean",
+                                            "const": false
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "temporary"
+                                    ]
+                                },
+                                "keyRanges": {
+                                    "temporary": {
+                                        "environment": "rotate-retry",
+                                        "begin": {
+                                            "line": 6,
+                                            "column": 9,
+                                            "byte": 135
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 18,
+                                            "byte": 144
+                                        }
+                                    }
+                                },
+                                "object": {
+                                    "temporary": {
+                                        "range": {
+                                            "environment": "rotate-retry",
+                                            "begin": {
+                                                "line": 6,
+                                                "column": 20,
+                                                "byte": 146
+                                            },
+                                            "end": {
+                                                "line": 6,
+                                                "column": 25,
+                                                "byte": 151
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "boolean",
+                                            "const": false
+                                        },
+                                        "literal": false
+                                    }
+                                }
+                            },
+                            "state": {
+                                "range": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": {
+                                    "type": "null"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "mostlyDead": {
+                "range": {
+                    "environment": "rotate-retry",
+                    "begin": {
+                        "line": 10,
+                        "column": 5,
+                        "byte": 263
+                    },
+                    "end": {
+                        "line": 12,
+                        "column": 24,
+                        "byte": 319
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::rotate::error",
+                    "nameRange": {
+                        "environment": "rotate-retry",
+                        "begin": {
+                            "line": 10,
+                            "column": 5,
+                            "byte": 263
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 22,
+                            "byte": 280
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": {
+                                "properties": {
+                                    "temporary": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "temporary"
+                                ]
+                            },
+                            "state": {
+                                "oneOf": [
+                                    false,
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "type": ""
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "state"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 9,
+                                        "byte": 304
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 24,
+                                        "byte": 319
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "temporary": {
+                                            "type": "boolean",
+                                            "const": true
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "temporary"
+                                    ]
+                                },
+                                "keyRanges": {
+                                    "temporary": {
+                                        "environment": "rotate-retry",
+                                        "begin": {
+                                            "line": 12,
+                                            "column": 9,
+                                            "byte": 304
+                                        },
+                                        "end": {
+                                            "line": 12,
+                                            "column": 18,
+                                            "byte": 313
+                                        }
+                                    }
+                                },
+                                "object": {
+                                    "temporary": {
+                                        "range": {
+                                            "environment": "rotate-retry",
+                                            "begin": {
+                                                "line": 12,
+                                                "column": 20,
+                                                "byte": 315
+                                            },
+                                            "end": {
+                                                "line": 12,
+                                                "column": 24,
+                                                "byte": 319
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "boolean",
+                                            "const": true
+                                        },
+                                        "literal": true
+                                    }
+                                }
+                            },
+                            "state": {
+                                "range": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": {
+                                    "type": "null"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "dead": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "rotate-retry",
+                        "begin": {
+                            "line": 4,
+                            "column": 5,
+                            "byte": 94
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 25,
+                            "byte": 151
+                        }
+                    }
+                }
+            },
+            "mostlyDead": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "rotate-retry",
+                        "begin": {
+                            "line": 10,
+                            "column": 5,
+                            "byte": 263
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 24,
+                            "byte": 319
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "dead": true,
+                "mostlyDead": true
+            },
+            "type": "object",
+            "required": [
+                "dead",
+                "mostlyDead"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "rotate-retry",
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate-retry",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "rotate-retry",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate-retry",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "rotate-retry",
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate-retry",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "rotate-retry"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "rotate-retry"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "checkJson": {
+        "dead": "[unknown]",
+        "mostlyDead": "[unknown]"
+    },
+    "eval": {
+        "exprs": {
+            "dead": {
+                "range": {
+                    "environment": "rotate-retry",
+                    "begin": {
+                        "line": 4,
+                        "column": 5,
+                        "byte": 94
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 25,
+                        "byte": 151
+                    }
+                },
+                "schema": {
+                    "type": "object"
+                },
+                "builtin": {
+                    "name": "fn::rotate::error",
+                    "nameRange": {
+                        "environment": "rotate-retry",
+                        "begin": {
+                            "line": 4,
+                            "column": 5,
+                            "byte": 94
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 22,
+                            "byte": 111
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": {
+                                "properties": {
+                                    "temporary": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "temporary"
+                                ]
+                            },
+                            "state": {
+                                "oneOf": [
+                                    false,
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "type": ""
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "state"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 9,
+                                        "byte": 135
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 25,
+                                        "byte": 151
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "temporary": {
+                                            "type": "boolean",
+                                            "const": false
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "temporary"
+                                    ]
+                                },
+                                "keyRanges": {
+                                    "temporary": {
+                                        "environment": "rotate-retry",
+                                        "begin": {
+                                            "line": 6,
+                                            "column": 9,
+                                            "byte": 135
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 18,
+                                            "byte": 144
+                                        }
+                                    }
+                                },
+                                "object": {
+                                    "temporary": {
+                                        "range": {
+                                            "environment": "rotate-retry",
+                                            "begin": {
+                                                "line": 6,
+                                                "column": 20,
+                                                "byte": 146
+                                            },
+                                            "end": {
+                                                "line": 6,
+                                                "column": 25,
+                                                "byte": 151
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "boolean",
+                                            "const": false
+                                        },
+                                        "literal": false
+                                    }
+                                }
+                            },
+                            "state": {
+                                "range": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": {
+                                    "type": "null"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "mostlyDead": {
+                "range": {
+                    "environment": "rotate-retry",
+                    "begin": {
+                        "line": 10,
+                        "column": 5,
+                        "byte": 263
+                    },
+                    "end": {
+                        "line": 12,
+                        "column": 24,
+                        "byte": 319
+                    }
+                },
+                "schema": {
+                    "type": "object"
+                },
+                "builtin": {
+                    "name": "fn::rotate::error",
+                    "nameRange": {
+                        "environment": "rotate-retry",
+                        "begin": {
+                            "line": 10,
+                            "column": 5,
+                            "byte": 263
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 22,
+                            "byte": 280
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": {
+                                "properties": {
+                                    "temporary": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "temporary"
+                                ]
+                            },
+                            "state": {
+                                "oneOf": [
+                                    false,
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "type": ""
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "state"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 9,
+                                        "byte": 304
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 24,
+                                        "byte": 319
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "temporary": {
+                                            "type": "boolean",
+                                            "const": true
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "temporary"
+                                    ]
+                                },
+                                "keyRanges": {
+                                    "temporary": {
+                                        "environment": "rotate-retry",
+                                        "begin": {
+                                            "line": 12,
+                                            "column": 9,
+                                            "byte": 304
+                                        },
+                                        "end": {
+                                            "line": 12,
+                                            "column": 18,
+                                            "byte": 313
+                                        }
+                                    }
+                                },
+                                "object": {
+                                    "temporary": {
+                                        "range": {
+                                            "environment": "rotate-retry",
+                                            "begin": {
+                                                "line": 12,
+                                                "column": 20,
+                                                "byte": 315
+                                            },
+                                            "end": {
+                                                "line": 12,
+                                                "column": 24,
+                                                "byte": 319
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "boolean",
+                                            "const": true
+                                        },
+                                        "literal": true
+                                    }
+                                }
+                            },
+                            "state": {
+                                "range": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": {
+                                    "type": "null"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "dead": {
+                "value": {},
+                "trace": {
+                    "def": {
+                        "environment": "rotate-retry",
+                        "begin": {
+                            "line": 4,
+                            "column": 5,
+                            "byte": 94
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 25,
+                            "byte": 151
+                        }
+                    }
+                }
+            },
+            "mostlyDead": {
+                "value": {},
+                "trace": {
+                    "def": {
+                        "environment": "rotate-retry",
+                        "begin": {
+                            "line": 10,
+                            "column": 5,
+                            "byte": 263
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 24,
+                            "byte": 319
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "dead": {
+                    "type": "object"
+                },
+                "mostlyDead": {
+                    "type": "object"
+                }
+            },
+            "type": "object",
+            "required": [
+                "dead",
+                "mostlyDead"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "rotate-retry",
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate-retry",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "rotate-retry",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate-retry",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "rotate-retry",
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate-retry",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "rotate-retry"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "rotate-retry"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "evalJsonRedacted": {
+        "dead": {},
+        "mostlyDead": {}
+    },
+    "evalJSONRevealed": {
+        "dead": {},
+        "mostlyDead": {}
+    },
+    "rotateDiags": [
+        {
+            "Severity": 1,
+            "Summary": "rotate: permanent error",
+            "Detail": "",
+            "Subject": {
+                "Filename": "rotate-retry",
+                "Start": {
+                    "Line": 4,
+                    "Column": 5,
+                    "Byte": 94
+                },
+                "End": {
+                    "Line": 6,
+                    "Column": 25,
+                    "Byte": 151
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.dead"
+        },
+        {
+            "Severity": 1,
+            "Summary": "rotate: gave up after 3 attempts: temporary error",
+            "Detail": "",
+            "Subject": {
+                "Filename": "rotate-retry",
+                "Start": {
+                    "Line": 10,
+                    "Column": 5,
+                    "Byte": 263
+                },
+                "End": {
+                    "Line": 12,
+                    "Column": 24,
+                    "Byte": 319
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.mostlyDead"
+        }
+    ],
+    "rotate": {
+        "exprs": {
+            "dead": {
+                "range": {
+                    "environment": "rotate-retry",
+                    "begin": {
+                        "line": 4,
+                        "column": 5,
+                        "byte": 94
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 25,
+                        "byte": 151
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::rotate::error",
+                    "nameRange": {
+                        "environment": "rotate-retry",
+                        "begin": {
+                            "line": 4,
+                            "column": 5,
+                            "byte": 94
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 22,
+                            "byte": 111
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": {
+                                "properties": {
+                                    "temporary": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "temporary"
+                                ]
+                            },
+                            "state": {
+                                "oneOf": [
+                                    false,
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "type": ""
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "state"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 9,
+                                        "byte": 135
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 25,
+                                        "byte": 151
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "temporary": {
+                                            "type": "boolean",
+                                            "const": false
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "temporary"
+                                    ]
+                                },
+                                "keyRanges": {
+                                    "temporary": {
+                                        "environment": "rotate-retry",
+                                        "begin": {
+                                            "line": 6,
+                                            "column": 9,
+                                            "byte": 135
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 18,
+                                            "byte": 144
+                                        }
+                                    }
+                                },
+                                "object": {
+                                    "temporary": {
+                                        "range": {
+                                            "environment": "rotate-retry",
+                                            "begin": {
+                                                "line": 6,
+                                                "column": 20,
+                                                "byte": 146
+                                            },
+                                            "end": {
+                                                "line": 6,
+                                                "column": 25,
+                                                "byte": 151
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "boolean",
+                                            "const": false
+                                        },
+                                        "literal": false
+                                    }
+                                }
+                            },
+                            "state": {
+                                "range": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": {
+                                    "type": "null"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "mostlyDead": {
+                "range": {
+                    "environment": "rotate-retry",
+                    "begin": {
+                        "line": 10,
+                        "column": 5,
+                        "byte": 263
+                    },
+                    "end": {
+                        "line": 12,
+                        "column": 24,
+                        "byte": 319
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::rotate::error",
+                    "nameRange": {
+                        "environment": "rotate-retry",
+                        "begin": {
+                            "line": 10,
+                            "column": 5,
+                            "byte": 263
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 22,
+                            "byte": 280
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": {
+                                "properties": {
+                                    "temporary": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "temporary"
+                                ]
+                            },
+                            "state": {
+                                "oneOf": [
+                                    false,
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "type": ""
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "state"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 9,
+                                        "byte": 304
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 24,
+                                        "byte": 319
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "temporary": {
+                                            "type": "boolean",
+                                            "const": true
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "temporary"
+                                    ]
+                                },
+                                "keyRanges": {
+                                    "temporary": {
+                                        "environment": "rotate-retry",
+                                        "begin": {
+                                            "line": 12,
+                                            "column": 9,
+                                            "byte": 304
+                                        },
+                                        "end": {
+                                            "line": 12,
+                                            "column": 18,
+                                            "byte": 313
+                                        }
+                                    }
+                                },
+                                "object": {
+                                    "temporary": {
+                                        "range": {
+                                            "environment": "rotate-retry",
+                                            "begin": {
+                                                "line": 12,
+                                                "column": 20,
+                                                "byte": 315
+                                            },
+                                            "end": {
+                                                "line": 12,
+                                                "column": 24,
+                                                "byte": 319
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "boolean",
+                                            "const": true
+                                        },
+                                        "literal": true
+                                    }
+                                }
+                            },
+                            "state": {
+                                "range": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": {
+                                    "type": "null"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "dead": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "rotate-retry",
+                        "begin": {
+                            "line": 4,
+                            "column": 5,
+                            "byte": 94
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 25,
+                            "byte": 151
+                        }
+                    }
+                }
+            },
+            "mostlyDead": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "rotate-retry",
+                        "begin": {
+                            "line": 10,
+                            "column": 5,
+                            "byte": 263
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 24,
+                            "byte": 319
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "dead": true,
+                "mostlyDead": true
+            },
+            "type": "object",
+            "required": [
+                "dead",
+                "mostlyDead"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "rotate-retry",
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate-retry",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "rotate-retry",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate-retry",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "rotate-retry",
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate-retry",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate-retry",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "rotate-retry"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "rotate-retry"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "rotateJson": {
+        "dead": "[unknown]",
+        "mostlyDead": "[unknown]"
+    }
+}

--- a/eval/testdata/eval/rotate-retry/overrides.json
+++ b/eval/testdata/eval/rotate-retry/overrides.json
@@ -1,0 +1,1 @@
+{"rotate": true}

--- a/provider.go
+++ b/provider.go
@@ -42,3 +42,17 @@ type Rotator interface {
 	// Rotate rotates the provider's secret, and returns the rotator's new state to be persisted.
 	Rotate(ctx context.Context, inputs, state map[string]Value, executionContext EnvExecContext) (Value, error)
 }
+
+// RetryableError indicates a temporary error was encountered by a provider.
+// Providers can wrap an error with this type  to indicate to the evaluator that it may retry calling the provider.
+type RetryableError struct {
+	Err error
+}
+
+func (e RetryableError) Error() string {
+	return e.Err.Error()
+}
+
+func (e RetryableError) Unwrap() error {
+	return e.Err
+}


### PR DESCRIPTION
Adds a `RetryableError` error that providers can return to opt into being retried by the evaluator when they encounter a temporary error (such as a timeout).

Closes https://github.com/pulumi/pulumi-service/issues/25444