### PR TITLE
Add paths to rotate

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,6 +5,8 @@
 - Introduce support for rotating static credentials via `fn::rotate` providers [432](https://github.com/pulumi/esc/pull/432)
 - Add the `rotate` CLI command
   [#433](https://github.com/pulumi/esc/pull/433)
+- Add ability to pass specific paths to rotate with the `rotate` CLI command
+  [#440](https://github.com/pulumi/esc/pull/440)
 
 ### Bug Fixes
 

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -683,6 +683,7 @@ func (c *testPulumiClient) RotateEnvironment(
 	projectName string,
 	envName string,
 	duration time.Duration,
+	rotationPaths []string,
 ) (string, []client.EnvironmentDiagnostic, error) {
 	return c.OpenEnvironment(ctx, orgName, projectName, envName, "", duration)
 }

--- a/cmd/esc/cli/client/client_test.go
+++ b/cmd/esc/cli/client/client_test.go
@@ -505,18 +505,24 @@ func TestOpenEnvironment(t *testing.T) {
 }
 
 func TestRotateEnvironment(t *testing.T) {
+	rotationPaths := []string{"a.b", "c"}
 	t.Run("OK", func(t *testing.T) {
 		const expectedID = "open-id"
 		duration := 2 * time.Hour
+		expectedBody := "{\"Paths\":[\"a.b\",\"c\"]}"
 
 		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/test-project/test-env/rotate", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, duration.String(), r.URL.Query().Get("duration"))
 
-			err := json.NewEncoder(w).Encode(map[string]any{"id": expectedID})
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			assert.Equal(t, expectedBody, string(body))
+
+			err = json.NewEncoder(w).Encode(map[string]any{"id": expectedID})
 			require.NoError(t, err)
 		})
 
-		id, diags, err := client.RotateEnvironment(context.Background(), "test-org", "test-project", "test-env", duration)
+		id, diags, err := client.RotateEnvironment(context.Background(), "test-org", "test-project", "test-env", duration, rotationPaths)
 		require.NoError(t, err)
 		assert.Equal(t, expectedID, id)
 		assert.Empty(t, diags)
@@ -553,7 +559,7 @@ func TestRotateEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		_, diags, err := client.RotateEnvironment(context.Background(), "test-org", "test-project", "test-env", 2*time.Hour)
+		_, diags, err := client.RotateEnvironment(context.Background(), "test-org", "test-project", "test-env", 2*time.Hour, rotationPaths)
 		require.NoError(t, err)
 		assert.Equal(t, expected, diags)
 	})
@@ -569,7 +575,7 @@ func TestRotateEnvironment(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		_, _, err := client.RotateEnvironment(context.Background(), "test-org", "test-project", "test-env", 2*time.Hour)
+		_, _, err := client.RotateEnvironment(context.Background(), "test-org", "test-project", "test-env", 2*time.Hour, rotationPaths)
 		assert.ErrorContains(t, err, "not found")
 	})
 }

--- a/cmd/esc/cli/env_rotate.go
+++ b/cmd/esc/cli/env_rotate.go
@@ -48,7 +48,7 @@ func newEnvRotateCmd(envcmd *envCommand) *cobra.Command {
 			for _, arg := range args[1:] {
 				_, err := resource.ParsePropertyPath(arg)
 				if err != nil {
-					return fmt.Errorf("invalid path: %w", err)
+					return fmt.Errorf("'%s' is an invalid property path: %w", arg, err)
 				}
 				rotationPaths = append(rotationPaths, arg)
 			}

--- a/cmd/esc/cli/env_rotate.go
+++ b/cmd/esc/cli/env_rotate.go
@@ -18,9 +18,11 @@ func newEnvRotateCmd(envcmd *envCommand) *cobra.Command {
 	var format string
 
 	cmd := &cobra.Command{
-		Use:   "rotate [<org-name>/][<project-name>/]<environment-name>",
+		Use:   "rotate [<org-name>/][<project-name>/]<environment-name> [path(s) to rotate]",
 		Short: "Rotate secrets and open the environment",
 		Long: "Rotate secrets and open the environment\n" +
+			"\n" +
+			"Optionally accepts any number of Property Paths as additional arguments. If given any paths, will only rotate secrets at those paths.\n" +
 			"\n" +
 			"This command opens the environment with the given name. The result is written to\n" +
 			"stdout as JSON.\n",
@@ -42,6 +44,15 @@ func newEnvRotateCmd(envcmd *envCommand) *cobra.Command {
 				return fmt.Errorf("the rotate command does not accept environments at specific versions")
 			}
 
+			rotationPaths := []string{}
+			for _, arg := range args[1:] {
+				_, err := resource.ParsePropertyPath(arg)
+				if err != nil {
+					return fmt.Errorf("invalid path: %w", err)
+				}
+				rotationPaths = append(rotationPaths, arg)
+			}
+
 			switch format {
 			case "detailed", "json", "yaml", "string", "dotenv", "shell":
 				// OK
@@ -49,7 +60,7 @@ func newEnvRotateCmd(envcmd *envCommand) *cobra.Command {
 				return fmt.Errorf("unknown output format %q", format)
 			}
 
-			env, diags, err := envcmd.rotateEnvironment(ctx, ref, duration)
+			env, diags, err := envcmd.rotateEnvironment(ctx, ref, duration, rotationPaths)
 			if err != nil {
 				return err
 			}
@@ -75,8 +86,9 @@ func (env *envCommand) rotateEnvironment(
 	ctx context.Context,
 	ref environmentRef,
 	duration time.Duration,
+	rotationPaths []string,
 ) (*esc.Environment, []client.EnvironmentDiagnostic, error) {
-	envID, diags, err := env.esc.client.RotateEnvironment(ctx, ref.orgName, ref.projectName, ref.envName, duration)
+	envID, diags, err := env.esc.client.RotateEnvironment(ctx, ref.orgName, ref.projectName, ref.envName, duration, rotationPaths)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Tested with passing paths
```
go run ./cmd/esc rotate delme/abc/yo ab cd
```

With invalid path
```
❯ go run ./cmd/esc env rotate delme/abc/yo abc ....
Error: '....' is an invalid property path: expected property path to start with a name or index
exit status 1

```