### PR TITLE
inline environment references

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,8 @@
   [#433](https://github.com/pulumi/esc/pull/433)
 - Add ability to pass specific paths to rotate with the `rotate` CLI command
   [#440](https://github.com/pulumi/esc/pull/440)
+- Introduce inline environment reference syntax
+  [#443](https://github.com/pulumi/esc/pull/443)
 
 ### Bug Fixes
 

--- a/eval/testdata/eval/inline-reference/env.yaml
+++ b/eval/testdata/eval/inline-reference/env.yaml
@@ -1,0 +1,6 @@
+values:
+  reference: ${environments.foo.bar.some_value}
+
+  invalid1: ${environments}
+  invalid2: ${environments.foo}
+  invalid3: ${environments.foo.unknown}

--- a/eval/testdata/eval/inline-reference/expected.json
+++ b/eval/testdata/eval/inline-reference/expected.json
@@ -4,12 +4,24 @@
             "Severity": 1,
             "Summary": "open testdata/eval/inline-reference/foo/unknown.yaml: no such file or directory",
             "Detail": "",
-            "Subject": null,
+            "Subject": {
+                "Filename": "inline-reference",
+                "Start": {
+                    "Line": 6,
+                    "Column": 13,
+                    "Byte": 129
+                },
+                "End": {
+                    "Line": 6,
+                    "Column": 40,
+                    "Byte": 156
+                }
+            },
             "Context": null,
             "Expression": null,
             "EvalContext": null,
             "Extra": null,
-            "Path": ""
+            "Path": "values.invalid3"
         }
     ],
     "check": {
@@ -672,12 +684,24 @@
             "Severity": 1,
             "Summary": "open testdata/eval/inline-reference/foo/unknown.yaml: no such file or directory",
             "Detail": "",
-            "Subject": null,
+            "Subject": {
+                "Filename": "inline-reference",
+                "Start": {
+                    "Line": 6,
+                    "Column": 13,
+                    "Byte": 129
+                },
+                "End": {
+                    "Line": 6,
+                    "Column": 40,
+                    "Byte": 156
+                }
+            },
             "Context": null,
             "Expression": null,
             "EvalContext": null,
             "Extra": null,
-            "Path": ""
+            "Path": "values.invalid3"
         }
     ],
     "eval": {

--- a/eval/testdata/eval/inline-reference/expected.json
+++ b/eval/testdata/eval/inline-reference/expected.json
@@ -1,0 +1,1344 @@
+{
+    "checkDiags": [
+        {
+            "Severity": 1,
+            "Summary": "open testdata/eval/inline-reference/foo/unknown.yaml: no such file or directory",
+            "Detail": "",
+            "Subject": null,
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": ""
+        }
+    ],
+    "check": {
+        "exprs": {
+            "invalid1": {
+                "range": {
+                    "environment": "inline-reference",
+                    "begin": {
+                        "line": 4,
+                        "column": 13,
+                        "byte": 69
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 28,
+                        "byte": 84
+                    }
+                },
+                "schema": true,
+                "symbol": [
+                    {
+                        "key": "environments",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 4,
+                                "column": 15,
+                                "byte": 71
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 27,
+                                "byte": 83
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 4,
+                                "column": 13,
+                                "byte": 69
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 28,
+                                "byte": 84
+                            }
+                        }
+                    }
+                ]
+            },
+            "invalid2": {
+                "range": {
+                    "environment": "inline-reference",
+                    "begin": {
+                        "line": 5,
+                        "column": 13,
+                        "byte": 97
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 32,
+                        "byte": 116
+                    }
+                },
+                "schema": true,
+                "symbol": [
+                    {
+                        "key": "environments",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 5,
+                                "column": 15,
+                                "byte": 99
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 27,
+                                "byte": 111
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 5,
+                                "column": 13,
+                                "byte": 97
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 32,
+                                "byte": 116
+                            }
+                        }
+                    },
+                    {
+                        "key": "foo",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 5,
+                                "column": 27,
+                                "byte": 111
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 31,
+                                "byte": 115
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 5,
+                                "column": 13,
+                                "byte": 97
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 32,
+                                "byte": 116
+                            }
+                        }
+                    }
+                ]
+            },
+            "invalid3": {
+                "range": {
+                    "environment": "inline-reference",
+                    "begin": {
+                        "line": 6,
+                        "column": 13,
+                        "byte": 129
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 40,
+                        "byte": 156
+                    }
+                },
+                "schema": true,
+                "symbol": [
+                    {
+                        "key": "environments",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 6,
+                                "column": 15,
+                                "byte": 131
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 27,
+                                "byte": 143
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 6,
+                                "column": 13,
+                                "byte": 129
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 40,
+                                "byte": 156
+                            }
+                        }
+                    },
+                    {
+                        "key": "foo",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 6,
+                                "column": 27,
+                                "byte": 143
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 31,
+                                "byte": 147
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 6,
+                                "column": 13,
+                                "byte": 129
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 40,
+                                "byte": 156
+                            }
+                        }
+                    },
+                    {
+                        "key": "unknown",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 6,
+                                "column": 31,
+                                "byte": 147
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 39,
+                                "byte": 155
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                ]
+            },
+            "reference": {
+                "range": {
+                    "environment": "inline-reference",
+                    "begin": {
+                        "line": 2,
+                        "column": 14,
+                        "byte": 21
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 48,
+                        "byte": 55
+                    }
+                },
+                "schema": {
+                    "type": "number",
+                    "const": 42
+                },
+                "symbol": [
+                    {
+                        "key": "environments",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 2,
+                                "column": 16,
+                                "byte": 23
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 28,
+                                "byte": 35
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 2,
+                                "column": 14,
+                                "byte": 21
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 48,
+                                "byte": 55
+                            }
+                        }
+                    },
+                    {
+                        "key": "foo",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 2,
+                                "column": 28,
+                                "byte": 35
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 32,
+                                "byte": 39
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 2,
+                                "column": 14,
+                                "byte": 21
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 48,
+                                "byte": 55
+                            }
+                        }
+                    },
+                    {
+                        "key": "bar",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 2,
+                                "column": 32,
+                                "byte": 39
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 36,
+                                "byte": 43
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    },
+                    {
+                        "key": "some_value",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 2,
+                                "column": 36,
+                                "byte": 43
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 47,
+                                "byte": 54
+                            }
+                        },
+                        "value": {
+                            "environment": "foo/bar",
+                            "begin": {
+                                "line": 2,
+                                "column": 15,
+                                "byte": 22
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 17,
+                                "byte": 24
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "properties": {
+            "invalid1": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "inline-reference",
+                        "begin": {
+                            "line": 4,
+                            "column": 13,
+                            "byte": 69
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 28,
+                            "byte": 84
+                        }
+                    }
+                }
+            },
+            "invalid2": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "inline-reference",
+                        "begin": {
+                            "line": 5,
+                            "column": 13,
+                            "byte": 97
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 32,
+                            "byte": 116
+                        }
+                    }
+                }
+            },
+            "invalid3": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "inline-reference",
+                        "begin": {
+                            "line": 6,
+                            "column": 13,
+                            "byte": 129
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 40,
+                            "byte": 156
+                        }
+                    }
+                }
+            },
+            "reference": {
+                "value": 42,
+                "trace": {
+                    "def": {
+                        "environment": "inline-reference",
+                        "begin": {
+                            "line": 2,
+                            "column": 14,
+                            "byte": 21
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 48,
+                            "byte": 55
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "invalid1": true,
+                "invalid2": true,
+                "invalid3": true,
+                "reference": {
+                    "type": "number",
+                    "const": 42
+                }
+            },
+            "type": "object",
+            "required": [
+                "invalid1",
+                "invalid2",
+                "invalid3",
+                "reference"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "inline-reference",
+                            "trace": {
+                                "def": {
+                                    "environment": "inline-reference",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "inline-reference",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "inline-reference",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "inline-reference",
+                            "trace": {
+                                "def": {
+                                    "environment": "inline-reference",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "inline-reference"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "inline-reference"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "checkJson": {
+        "invalid1": "[unknown]",
+        "invalid2": "[unknown]",
+        "invalid3": "[unknown]",
+        "reference": 42
+    },
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "open testdata/eval/inline-reference/foo/unknown.yaml: no such file or directory",
+            "Detail": "",
+            "Subject": null,
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": ""
+        }
+    ],
+    "eval": {
+        "exprs": {
+            "invalid1": {
+                "range": {
+                    "environment": "inline-reference",
+                    "begin": {
+                        "line": 4,
+                        "column": 13,
+                        "byte": 69
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 28,
+                        "byte": 84
+                    }
+                },
+                "schema": true,
+                "symbol": [
+                    {
+                        "key": "environments",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 4,
+                                "column": 15,
+                                "byte": 71
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 27,
+                                "byte": 83
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 4,
+                                "column": 13,
+                                "byte": 69
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 28,
+                                "byte": 84
+                            }
+                        }
+                    }
+                ]
+            },
+            "invalid2": {
+                "range": {
+                    "environment": "inline-reference",
+                    "begin": {
+                        "line": 5,
+                        "column": 13,
+                        "byte": 97
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 32,
+                        "byte": 116
+                    }
+                },
+                "schema": true,
+                "symbol": [
+                    {
+                        "key": "environments",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 5,
+                                "column": 15,
+                                "byte": 99
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 27,
+                                "byte": 111
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 5,
+                                "column": 13,
+                                "byte": 97
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 32,
+                                "byte": 116
+                            }
+                        }
+                    },
+                    {
+                        "key": "foo",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 5,
+                                "column": 27,
+                                "byte": 111
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 31,
+                                "byte": 115
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 5,
+                                "column": 13,
+                                "byte": 97
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 32,
+                                "byte": 116
+                            }
+                        }
+                    }
+                ]
+            },
+            "invalid3": {
+                "range": {
+                    "environment": "inline-reference",
+                    "begin": {
+                        "line": 6,
+                        "column": 13,
+                        "byte": 129
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 40,
+                        "byte": 156
+                    }
+                },
+                "schema": true,
+                "symbol": [
+                    {
+                        "key": "environments",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 6,
+                                "column": 15,
+                                "byte": 131
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 27,
+                                "byte": 143
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 6,
+                                "column": 13,
+                                "byte": 129
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 40,
+                                "byte": 156
+                            }
+                        }
+                    },
+                    {
+                        "key": "foo",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 6,
+                                "column": 27,
+                                "byte": 143
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 31,
+                                "byte": 147
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 6,
+                                "column": 13,
+                                "byte": 129
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 40,
+                                "byte": 156
+                            }
+                        }
+                    },
+                    {
+                        "key": "unknown",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 6,
+                                "column": 31,
+                                "byte": 147
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 39,
+                                "byte": 155
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                ]
+            },
+            "reference": {
+                "range": {
+                    "environment": "inline-reference",
+                    "begin": {
+                        "line": 2,
+                        "column": 14,
+                        "byte": 21
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 48,
+                        "byte": 55
+                    }
+                },
+                "schema": {
+                    "type": "number",
+                    "const": 42
+                },
+                "symbol": [
+                    {
+                        "key": "environments",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 2,
+                                "column": 16,
+                                "byte": 23
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 28,
+                                "byte": 35
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 2,
+                                "column": 14,
+                                "byte": 21
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 48,
+                                "byte": 55
+                            }
+                        }
+                    },
+                    {
+                        "key": "foo",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 2,
+                                "column": 28,
+                                "byte": 35
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 32,
+                                "byte": 39
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 2,
+                                "column": 14,
+                                "byte": 21
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 48,
+                                "byte": 55
+                            }
+                        }
+                    },
+                    {
+                        "key": "bar",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 2,
+                                "column": 32,
+                                "byte": 39
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 36,
+                                "byte": 43
+                            }
+                        },
+                        "value": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    },
+                    {
+                        "key": "some_value",
+                        "range": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 2,
+                                "column": 36,
+                                "byte": 43
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 47,
+                                "byte": 54
+                            }
+                        },
+                        "value": {
+                            "environment": "foo/bar",
+                            "begin": {
+                                "line": 2,
+                                "column": 15,
+                                "byte": 22
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 17,
+                                "byte": 24
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "properties": {
+            "invalid1": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "inline-reference",
+                        "begin": {
+                            "line": 4,
+                            "column": 13,
+                            "byte": 69
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 28,
+                            "byte": 84
+                        }
+                    }
+                }
+            },
+            "invalid2": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "inline-reference",
+                        "begin": {
+                            "line": 5,
+                            "column": 13,
+                            "byte": 97
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 32,
+                            "byte": 116
+                        }
+                    }
+                }
+            },
+            "invalid3": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "inline-reference",
+                        "begin": {
+                            "line": 6,
+                            "column": 13,
+                            "byte": 129
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 40,
+                            "byte": 156
+                        }
+                    }
+                }
+            },
+            "reference": {
+                "value": 42,
+                "trace": {
+                    "def": {
+                        "environment": "inline-reference",
+                        "begin": {
+                            "line": 2,
+                            "column": 14,
+                            "byte": 21
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 48,
+                            "byte": 55
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "invalid1": true,
+                "invalid2": true,
+                "invalid3": true,
+                "reference": {
+                    "type": "number",
+                    "const": 42
+                }
+            },
+            "type": "object",
+            "required": [
+                "invalid1",
+                "invalid2",
+                "invalid3",
+                "reference"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "inline-reference",
+                            "trace": {
+                                "def": {
+                                    "environment": "inline-reference",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "inline-reference",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "inline-reference",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "inline-reference",
+                            "trace": {
+                                "def": {
+                                    "environment": "inline-reference",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "inline-reference",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "inline-reference"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "inline-reference"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "evalJsonRedacted": {
+        "invalid1": "[unknown]",
+        "invalid2": "[unknown]",
+        "invalid3": "[unknown]",
+        "reference": 42
+    },
+    "evalJSONRevealed": {
+        "invalid1": "[unknown]",
+        "invalid2": "[unknown]",
+        "invalid3": "[unknown]",
+        "reference": 42
+    }
+}

--- a/eval/testdata/eval/inline-reference/foo/bar.yaml
+++ b/eval/testdata/eval/inline-reference/foo/bar.yaml
@@ -1,0 +1,3 @@
+values:
+  some_value: 42
+  unreferenced_value: "this shouldn't be merged into env"


### PR DESCRIPTION
The `environments` top level key is now reserved for inline environment references. This allows you to implicitly import and reference a value in another environment by accessing `${environments.$project.$env...}`. This desugars into something like `${imports["$project/$env"]...}` and behaves as if the environment was imported with merge:false.

This is followed up by #444