### PR TITLE
schema: rotateOnly flag is now represented as a list of property names

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -601,7 +601,7 @@ func (e *evalContext) evaluateExpr(x *expr, accept *schema.Schema) *value {
 		panic(fmt.Sprintf("fatal: invalid expr type %T", repr))
 	}
 
-	if accept.RotateOnly {
+	if accept.IsRotateOnly() {
 		val.rotateOnly = true
 	}
 	if x.secret {
@@ -628,7 +628,7 @@ func (e *evalContext) evaluateSkippedExpr(x *expr, accept *schema.Schema) (*valu
 	//
 	// thus, we want to skip evaluation if in a rotateOnly context and opening the root environment
 	// or if this is an imported env
-	if skipEval := accept.RotateOnly && (!e.rotating && !e.validating || !e.isRootEnv); skipEval {
+	if skipEval := accept.IsRotateOnly() && (!e.rotating && !e.validating || !e.isRootEnv); skipEval {
 		return &value{def: newMissingExpr(x.path, x.base), schema: schema.Always(), unknown: true, rotateOnly: true}, true
 	}
 

--- a/eval/testdata/eval/inline-reference-rotateOnly/expected.json
+++ b/eval/testdata/eval/inline-reference-rotateOnly/expected.json
@@ -74,12 +74,14 @@
                             "inputs": {
                                 "properties": {
                                     "next": {
-                                        "type": "string",
-                                        "rotateOnly": true
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object",
                                 "required": [
+                                    "next"
+                                ],
+                                "rotateOnly": [
                                     "next"
                                 ]
                             },
@@ -696,12 +698,14 @@
                             "inputs": {
                                 "properties": {
                                     "next": {
-                                        "type": "string",
-                                        "rotateOnly": true
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object",
                                 "required": [
+                                    "next"
+                                ],
+                                "rotateOnly": [
                                     "next"
                                 ]
                             },
@@ -1384,12 +1388,14 @@
                             "inputs": {
                                 "properties": {
                                     "next": {
-                                        "type": "string",
-                                        "rotateOnly": true
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object",
                                 "required": [
+                                    "next"
+                                ],
+                                "rotateOnly": [
                                     "next"
                                 ]
                             },

--- a/eval/testdata/eval/rotate-state/expected.json
+++ b/eval/testdata/eval/rotate-state/expected.json
@@ -120,12 +120,14 @@
                             "inputs": {
                                 "properties": {
                                     "next": {
-                                        "type": "string",
-                                        "rotateOnly": true
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object",
                                 "required": [
+                                    "next"
+                                ],
+                                "rotateOnly": [
                                     "next"
                                 ]
                             },
@@ -390,12 +392,14 @@
                             "inputs": {
                                 "properties": {
                                     "next": {
-                                        "type": "string",
-                                        "rotateOnly": true
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object",
                                 "required": [
+                                    "next"
+                                ],
+                                "rotateOnly": [
                                     "next"
                                 ]
                             },
@@ -622,12 +626,14 @@
                             "inputs": {
                                 "properties": {
                                     "next": {
-                                        "type": "string",
-                                        "rotateOnly": true
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object",
                                 "required": [
+                                    "next"
+                                ],
+                                "rotateOnly": [
                                     "next"
                                 ]
                             },
@@ -808,12 +814,14 @@
                             "inputs": {
                                 "properties": {
                                     "next": {
-                                        "type": "string",
-                                        "rotateOnly": true
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object",
                                 "required": [
+                                    "next"
+                                ],
+                                "rotateOnly": [
                                     "next"
                                 ]
                             },
@@ -1453,12 +1461,14 @@
                             "inputs": {
                                 "properties": {
                                     "next": {
-                                        "type": "string",
-                                        "rotateOnly": true
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object",
                                 "required": [
+                                    "next"
+                                ],
+                                "rotateOnly": [
                                     "next"
                                 ]
                             },
@@ -1720,12 +1730,14 @@
                             "inputs": {
                                 "properties": {
                                     "next": {
-                                        "type": "string",
-                                        "rotateOnly": true
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object",
                                 "required": [
+                                    "next"
+                                ],
+                                "rotateOnly": [
                                     "next"
                                 ]
                             },
@@ -1938,12 +1950,14 @@
                             "inputs": {
                                 "properties": {
                                     "next": {
-                                        "type": "string",
-                                        "rotateOnly": true
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object",
                                 "required": [
+                                    "next"
+                                ],
+                                "rotateOnly": [
                                     "next"
                                 ]
                             },
@@ -2119,12 +2133,14 @@
                             "inputs": {
                                 "properties": {
                                     "next": {
-                                        "type": "string",
-                                        "rotateOnly": true
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object",
                                 "required": [
+                                    "next"
+                                ],
+                                "rotateOnly": [
                                     "next"
                                 ]
                             },
@@ -2823,12 +2839,14 @@
                             "inputs": {
                                 "properties": {
                                     "next": {
-                                        "type": "string",
-                                        "rotateOnly": true
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object",
                                 "required": [
+                                    "next"
+                                ],
+                                "rotateOnly": [
                                     "next"
                                 ]
                             },
@@ -3093,12 +3111,14 @@
                             "inputs": {
                                 "properties": {
                                     "next": {
-                                        "type": "string",
-                                        "rotateOnly": true
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object",
                                 "required": [
+                                    "next"
+                                ],
+                                "rotateOnly": [
                                     "next"
                                 ]
                             },
@@ -3327,12 +3347,14 @@
                             "inputs": {
                                 "properties": {
                                     "next": {
-                                        "type": "string",
-                                        "rotateOnly": true
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object",
                                 "required": [
+                                    "next"
+                                ],
+                                "rotateOnly": [
                                     "next"
                                 ]
                             },
@@ -3516,12 +3538,14 @@
                             "inputs": {
                                 "properties": {
                                     "next": {
-                                        "type": "string",
-                                        "rotateOnly": true
+                                        "type": "string"
                                     }
                                 },
                                 "type": "object",
                                 "required": [
+                                    "next"
+                                ],
+                                "rotateOnly": [
                                     "next"
                                 ]
                             },

--- a/schema/objects.go
+++ b/schema/objects.go
@@ -23,8 +23,7 @@ import (
 )
 
 type ObjectBuilder struct {
-	s                    Schema
-	rotateOnlyProperties []string
+	s Schema
 }
 
 func Object() *ObjectBuilder {
@@ -116,14 +115,11 @@ func (b *ObjectBuilder) Examples(vals ...map[string]any) *ObjectBuilder {
 }
 
 func (b *ObjectBuilder) RotateOnly(names ...string) *ObjectBuilder {
-	b.rotateOnlyProperties = names
+	b.s.RotateOnly = names
 	return b
 }
 
 func (b *ObjectBuilder) Schema() *Schema {
 	b.s.Type = "object"
-	for _, name := range b.rotateOnlyProperties {
-		b.s.Properties[name].RotateOnly = true
-	}
 	return &b.s
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -120,8 +120,8 @@ type Schema struct {
 	Examples    []any  `json:"examples,omitempty"`
 
 	// Environments extensions
-	Secret     bool `json:"secret,omitempty"`
-	RotateOnly bool `json:"rotateOnly,omitempty"`
+	Secret     bool     `json:"secret,omitempty"`
+	RotateOnly []string `json:"rotateOnly,omitempty"`
 
 	ref              *Schema
 	multipleOf       *big.Float
@@ -136,6 +136,7 @@ type Schema struct {
 	minItems         *uint
 	maxProperties    *uint
 	minProperties    *uint
+	rotateOnly       bool
 
 	compiled bool
 }
@@ -217,6 +218,10 @@ func (s *Schema) Property(name string) *Schema {
 	return union(oneOf)
 }
 
+func (s *Schema) IsRotateOnly() bool {
+	return s.rotateOnly
+}
+
 func (s *Schema) GetRef() *Schema                 { return s.ref }
 func (s *Schema) GetMultipleOf() *big.Float       { return s.multipleOf }
 func (s *Schema) GetMaximum() *big.Float          { return s.maximum }
@@ -280,6 +285,12 @@ func (s *Schema) compile(root *Schema) error {
 	for _, v := range s.Properties {
 		if err := v.compile(root); err != nil {
 			return err
+		}
+	}
+	for _, name := range s.RotateOnly {
+		// need to push the rotateOnly flag down onto the actual properties, so it is available to the evaluator while evaluating object properties
+		if p, ok := s.Properties[name]; ok {
+			p.rotateOnly = true
 		}
 	}
 
@@ -406,7 +417,7 @@ func union(oneOf []*Schema) *Schema {
 	for _, s := range oneOf {
 		if s != nil && !s.Never {
 			oneOf[n] = s
-			rotateOnly = rotateOnly && s.RotateOnly
+			rotateOnly = rotateOnly && s.rotateOnly
 			n++
 		}
 	}
@@ -421,6 +432,6 @@ func union(oneOf []*Schema) *Schema {
 		return oneOf[0]
 	default:
 		// Otherwise, return a OneOf.
-		return &Schema{OneOf: oneOf, RotateOnly: rotateOnly}
+		return &Schema{OneOf: oneOf, rotateOnly: rotateOnly}
 	}
 }


### PR DESCRIPTION
The rotateOnly flag is now represented by a list of property names on the parent object schema, similar to `required`.

During schema compilation, the flag is internally pushed down onto the properties, and is accessible via their IsRotateOnly() method.