### PR TITLE
ast: syntax errors for invalid fn invocation

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,3 +17,6 @@
 ### Bug Fixes
 
 ### Breaking changes
+
+- It is now a syntax error to call a builtin function incorrectly.
+  [449](https://github.com/pulumi/esc/pull/449)

--- a/ast/environment.go
+++ b/ast/environment.go
@@ -128,6 +128,9 @@ func (d *MapDecl[T]) parse(name string, node syntax.Node) syntax.Diagnostics {
 
 		var v T
 		vname := name + "." + kvp.Key.Value()
+		if strings.HasPrefix(kvp.Key.Value(), "fn::") {
+			diags.Extend(syntax.NodeError(kvp.Key, "fn expression not allowed at the top level"))
+		}
 		vdiags := parseNode(vname, &v, kvp.Value)
 		diags.Extend(vdiags...)
 

--- a/ast/environment.go
+++ b/ast/environment.go
@@ -129,7 +129,7 @@ func (d *MapDecl[T]) parse(name string, node syntax.Node) syntax.Diagnostics {
 		var v T
 		vname := name + "." + kvp.Key.Value()
 		if strings.HasPrefix(kvp.Key.Value(), "fn::") {
-			diags.Extend(syntax.NodeError(kvp.Key, "fn expression not allowed at the top level"))
+			diags.Extend(syntax.NodeError(kvp.Key, fmt.Sprintf("builtin function call %q not allowed at the top level", kvp.Key.Value())))
 		}
 		vdiags := parseNode(vname, &v, kvp.Value)
 		diags.Extend(vdiags...)

--- a/ast/expr.go
+++ b/ast/expr.go
@@ -634,7 +634,6 @@ func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) 
 			}
 		}
 		return nil, diags, false
-		return nil, nil, false
 	}
 
 	kvp := node.Index(0)

--- a/ast/expr.go
+++ b/ast/expr.go
@@ -625,14 +625,20 @@ func FromBase64(value Expr) *FromBase64Expr {
 }
 
 func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) {
+	var diags syntax.Diagnostics
 	if node.Len() != 1 {
+		for i := 0; i < node.Len(); i++ {
+			if strings.HasPrefix(node.Index(i).Key.Value(), "fn::") {
+				diags = append(diags, syntax.NodeError(node, "fn:: expression must be the only key within object"))
+				return nil, diags, false
+			}
+		}
 		return nil, nil, false
 	}
 
 	kvp := node.Index(0)
 
 	var parse func(node *syntax.ObjectNode, name *StringExpr, args Expr) (Expr, syntax.Diagnostics)
-	var diags syntax.Diagnostics
 	switch kvp.Key.Value() {
 	case "fn::fromJSON":
 		parse = parseFromJSON

--- a/ast/expr.go
+++ b/ast/expr.go
@@ -628,11 +628,12 @@ func tryParseFunction(node *syntax.ObjectNode) (Expr, syntax.Diagnostics, bool) 
 	var diags syntax.Diagnostics
 	if node.Len() != 1 {
 		for i := 0; i < node.Len(); i++ {
-			if strings.HasPrefix(node.Index(i).Key.Value(), "fn::") {
-				diags = append(diags, syntax.NodeError(node, "fn:: expression must be the only key within object"))
-				return nil, diags, false
+			if k := node.Index(i).Key.Value(); strings.HasPrefix(k, "fn::") {
+				diags = append(diags, syntax.NodeError(node, fmt.Sprintf("illegal call to builtin function: %q must be the only key within its containing object", k)))
+
 			}
 		}
+		return nil, diags, false
 		return nil, nil, false
 	}
 

--- a/ast/testdata/parse/invalid-invocation/env.yaml
+++ b/ast/testdata/parse/invalid-invocation/env.yaml
@@ -1,0 +1,6 @@
+values:
+  multiple-keys:
+    fn::rotate::provider:
+      inputs: {}
+    state:
+      ohno: true

--- a/ast/testdata/parse/invalid-invocation/expected.json
+++ b/ast/testdata/parse/invalid-invocation/expected.json
@@ -1,0 +1,78 @@
+{
+    "decl": {
+        "Description": null,
+        "Imports": null,
+        "Values": {
+            "Entries": [
+                {
+                    "Key": {
+                        "Value": "multiple-keys"
+                    },
+                    "Value": {
+                        "Entries": [
+                            {
+                                "Key": {
+                                    "Value": "fn::rotate::provider"
+                                },
+                                "Value": {
+                                    "Entries": [
+                                        {
+                                            "Key": {
+                                                "Value": "inputs"
+                                            },
+                                            "Value": {
+                                                "Entries": []
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "Key": {
+                                    "Value": "state"
+                                },
+                                "Value": {
+                                    "Entries": [
+                                        {
+                                            "Key": {
+                                                "Value": "ohno"
+                                            },
+                                            "Value": {
+                                                "Value": true
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "diags": [
+        {
+            "Severity": 1,
+            "Summary": "fn:: expression must be the only key within object",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-invocation",
+                "Start": {
+                    "Line": 3,
+                    "Column": 5,
+                    "Byte": 29
+                },
+                "End": {
+                    "Line": 6,
+                    "Column": 17,
+                    "Byte": 95
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values[\"multiple-keys\"]"
+        }
+    ]
+}

--- a/ast/testdata/parse/invalid-invocation/expected.json
+++ b/ast/testdata/parse/invalid-invocation/expected.json
@@ -53,7 +53,7 @@
     "diags": [
         {
             "Severity": 1,
-            "Summary": "fn:: expression must be the only key within object",
+            "Summary": "illegal call to builtin function: \"fn::rotate::provider\" must be the only key within its containing object",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-invocation",

--- a/ast/testdata/parse/invalid-invocation2/env.yaml
+++ b/ast/testdata/parse/invalid-invocation2/env.yaml
@@ -1,0 +1,2 @@
+values:
+  fn::secret: "hello"

--- a/ast/testdata/parse/invalid-invocation2/expected.json
+++ b/ast/testdata/parse/invalid-invocation2/expected.json
@@ -18,7 +18,7 @@
     "diags": [
         {
             "Severity": 1,
-            "Summary": "fn expression not allowed at the top level",
+            "Summary": "builtin function call \"fn::secret\" not allowed at the top level",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-invocation2",

--- a/ast/testdata/parse/invalid-invocation2/expected.json
+++ b/ast/testdata/parse/invalid-invocation2/expected.json
@@ -1,0 +1,43 @@
+{
+    "decl": {
+        "Description": null,
+        "Imports": null,
+        "Values": {
+            "Entries": [
+                {
+                    "Key": {
+                        "Value": "fn::secret"
+                    },
+                    "Value": {
+                        "Value": "hello"
+                    }
+                }
+            ]
+        }
+    },
+    "diags": [
+        {
+            "Severity": 1,
+            "Summary": "fn expression not allowed at the top level",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-invocation2",
+                "Start": {
+                    "Line": 2,
+                    "Column": 3,
+                    "Byte": 10
+                },
+                "End": {
+                    "Line": 2,
+                    "Column": 13,
+                    "Byte": 20
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values[\"fn::secret\"]"
+        }
+    ]
+}


### PR DESCRIPTION
Currently when a fn expr is invalid we fall back to parsing it as an object, which results in an object containing a `fn::` key, which is otherwise illegal, instead of the expected call.  This PR makes these incorrect usages emit syntax errors so that it's easier for the user to identify the mistake ahead of time, instead of after discovering that the function wasn't called.

Case 1 - having an additional key in a fn call:
```
values:
  foo:
    fn::builtin: ...
    anotherKey: "oops"
```

Case 2 - having a fn:: key as a toplevel key in values:
```
values:
  fn::open::provider: ...
```

Resolves #447