### PR TITLE
eval: containsObservableUnknowns is incorrect for non-rotateOnly inputs

### DIFF
--- a/eval/value.go
+++ b/eval/value.go
@@ -91,7 +91,10 @@ func (v *value) containsObservableUnknowns(rotating bool) bool {
 		return false
 	}
 	if v.unknown {
-		return v.rotateOnly && rotating
+		if v.rotateOnly && !rotating {
+			return false // this unknown value will not be observed
+		}
+		return true
 	}
 	switch repr := v.repr.(type) {
 	case []*value:


### PR DESCRIPTION
The intent of `containsObservableUnknowns` is to allow `evaluateBuiltinRotate` tolerate rotateOnly values being unknown when not rotating.  RotateOnly indicates that `open` will not read those values, so it's okay for them to be unknown.  

During rotation, `rotate` will read all inputs, so all inputs must be known at that time.

Unfortunately the equality isn't correct, because it's returning false for unknown, non-rotateOnly values, which allows for an unknown value to be unexpectedly passed into the provider's Rotate method.

Fixes https://github.com/pulumi/pulumi-service/issues/26101
