### PR TITLE
fix panic when evaluating cyclic environment references

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -402,6 +402,10 @@ func (e *evalContext) isReserveTopLevelKey(k string) bool {
 
 // evaluate drives the evaluation of the evalContext's environment.
 func (e *evalContext) evaluate() (*value, syntax.Diagnostics) {
+	mine := &imported{evaluating: true}
+	defer func() { mine.evaluating = false }()
+	e.imports[e.name] = mine
+
 	// Evaluate context. We prepare the context values to later evaluate interpolations.
 	e.evaluateContext()
 	// Evaluate imports. We do this prior to declaration so that we can plumb base values as part of declaration.
@@ -444,10 +448,6 @@ func (e *evalContext) evaluateContext() {
 
 // evaluateImports evaluates an environment's imports.
 func (e *evalContext) evaluateImports() {
-	mine := &imported{evaluating: true}
-	defer func() { mine.evaluating = false }()
-	e.imports[e.name] = mine
-
 	myImports := map[string]*value{}
 	for _, entry := range e.env.Imports.GetElements() {
 		// If the import does not have a name, there's nothing we can do. This can happen for environments

--- a/eval/testdata/eval/inline-reference-cycle/bad/bad.yaml
+++ b/eval/testdata/eval/inline-reference-cycle/bad/bad.yaml
@@ -1,0 +1,2 @@
+values:
+  cycle: ${environments.bad.bad.cycle}

--- a/eval/testdata/eval/inline-reference-cycle/env.yaml
+++ b/eval/testdata/eval/inline-reference-cycle/env.yaml
@@ -1,0 +1,2 @@
+imports:
+  - bad/bad

--- a/eval/testdata/eval/inline-reference-cycle/expected.json
+++ b/eval/testdata/eval/inline-reference-cycle/expected.json
@@ -1,0 +1,499 @@
+{
+    "checkDiags": [
+        {
+            "Severity": 1,
+            "Summary": "cyclic import of bad/bad",
+            "Detail": "",
+            "Subject": {
+                "Filename": "bad/bad",
+                "Start": {
+                    "Line": 2,
+                    "Column": 10,
+                    "Byte": 0
+                },
+                "End": {
+                    "Line": 2,
+                    "Column": 39,
+                    "Byte": 0
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.cycle"
+        }
+    ],
+    "check": {
+        "properties": {
+            "cycle": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "bad/bad",
+                        "begin": {
+                            "line": 2,
+                            "column": 10,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 39,
+                            "byte": 0
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "cycle": true
+            },
+            "type": "object",
+            "required": [
+                "cycle"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "inline-reference-cycle",
+                            "trace": {
+                                "def": {
+                                    "environment": "inline-reference-cycle",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "inline-reference-cycle",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "inline-reference-cycle",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "inline-reference-cycle",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "inline-reference-cycle",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "inline-reference-cycle",
+                            "trace": {
+                                "def": {
+                                    "environment": "inline-reference-cycle",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "inline-reference-cycle",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "inline-reference-cycle"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "inline-reference-cycle"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "checkJson": {
+        "cycle": "[unknown]"
+    },
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "cyclic import of bad/bad",
+            "Detail": "",
+            "Subject": {
+                "Filename": "bad/bad",
+                "Start": {
+                    "Line": 2,
+                    "Column": 10,
+                    "Byte": 0
+                },
+                "End": {
+                    "Line": 2,
+                    "Column": 39,
+                    "Byte": 0
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.cycle"
+        }
+    ],
+    "eval": {
+        "properties": {
+            "cycle": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "bad/bad",
+                        "begin": {
+                            "line": 2,
+                            "column": 10,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 39,
+                            "byte": 0
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "cycle": true
+            },
+            "type": "object",
+            "required": [
+                "cycle"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "inline-reference-cycle",
+                            "trace": {
+                                "def": {
+                                    "environment": "inline-reference-cycle",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "inline-reference-cycle",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "inline-reference-cycle",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "inline-reference-cycle",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "inline-reference-cycle",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "inline-reference-cycle",
+                            "trace": {
+                                "def": {
+                                    "environment": "inline-reference-cycle",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "inline-reference-cycle",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "inline-reference-cycle"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "inline-reference-cycle"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "evalJsonRedacted": {
+        "cycle": "[unknown]"
+    },
+    "evalJSONRevealed": {
+        "cycle": "[unknown]"
+    }
+}


### PR DESCRIPTION
We track the lifetime of each environments import evaluations to detect cyclic imports.  Right now this is tracked while we're evaluating the imports decl.

However, #443 introduced a way to import environment values inline.  Once we've started evaluating the environment values root, we currently stop tracking whether the environment is evaluating because we're done with all the imports.

The result of this is that a cyclic environment reference will look up the environment name in the imports map and won't detect that it is still evaluating.  Since the cached value in the imports map hasn't been set yet (since the environment hasn't finished evaluating) we return nil as the value.  This results in a panic when we try to actually access the value.

To fix this, I'm just hoisting the evaluation lifetime tracking to the evaluation root, rather than just the imports node, so it'll correctly detect cycles for inline references.

Fixes https://github.com/pulumi/pulumi-service/issues/26277