### PR TITLE
cli: add a --string flag to env set

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,18 +1,7 @@
 ### Improvements
 
-- Fix diagnostic messages when updating environment with invalid definition
-  [#422](https://github.com/pulumi/esc/pull/422)
-- Introduce support for rotating static credentials via `fn::rotate` providers [432](https://github.com/pulumi/esc/pull/432)
-- Add the `rotate` CLI command
-  [#433](https://github.com/pulumi/esc/pull/433)
-- Add ability to pass specific paths to rotate with the `rotate` CLI command
-  [#440](https://github.com/pulumi/esc/pull/440)
-- Introduce inline environment reference syntax
-  [#443](https://github.com/pulumi/esc/pull/443)
-- Introduce rotateOnly inputs
-  [#444](https://github.com/pulumi/esc/pull/444)
-- Release rotate environment CLI command
-  [#459](https://github.com/pulumi/esc/pull/459)
+- Add `--string` flag to `env set` to treat the given value as a string.
+  [#467](https://github.com/pulumi/esc/pull/467)
 
 ### Bug Fixes
 

--- a/cmd/esc/cli/testdata/env-set-string-error.yaml
+++ b/cmd/esc/cli/testdata/env-set-string-error.yaml
@@ -1,0 +1,12 @@
+run: |
+  esc env init default/test
+  esc env set default/test path "[a"
+error: exit status 1
+stdout: |
+  > esc env init default/test
+  Environment created: test-user/default/test
+  > esc env set default/test path [a
+stderr: |
+  > esc env init default/test
+  > esc env set default/test path [a
+  Error: invalid value: yaml: line 1: did not find expected ',' or ']'

--- a/cmd/esc/cli/testdata/env-set-string-error.yaml
+++ b/cmd/esc/cli/testdata/env-set-string-error.yaml
@@ -2,11 +2,13 @@ run: |
   esc env init default/test
   esc env set default/test path "[a"
 error: exit status 1
-stdout: |
-  > esc env init default/test
-  Environment created: test-user/default/test
-  > esc env set default/test path [a
-stderr: |
-  > esc env init default/test
-  > esc env set default/test path [a
-  Error: invalid value: yaml: line 1: did not find expected ',' or ']'
+
+---
+> esc env init default/test
+Environment created: test-user/default/test
+> esc env set default/test path [a
+
+---
+> esc env init default/test
+> esc env set default/test path [a
+Error: invalid value: yaml: line 1: did not find expected ',' or ']'

--- a/cmd/esc/cli/testdata/env-set-string.yaml
+++ b/cmd/esc/cli/testdata/env-set-string.yaml
@@ -1,14 +1,26 @@
 run: |
   esc env init default/test
   esc env set default/test path "[a" --string
-  esc env get default/test path --value string
-stdout: |
+  esc env get default/test
+stdout: |+
   > esc env init default/test
   Environment created: test-user/default/test
   > esc env set default/test path [a --string
-  > esc env get default/test path --value string
-  [a
+  > esc env get default/test
+  # Value
+  ```json
+  {
+    "path": "[a"
+  }
+  ```
+  # Definition
+  ```yaml
+  values:
+    path: '[a'
+
+  ```
+
 stderr: |
   > esc env init default/test
   > esc env set default/test path [a --string
-  > esc env get default/test path --value string
+  > esc env get default/test

--- a/cmd/esc/cli/testdata/env-set-string.yaml
+++ b/cmd/esc/cli/testdata/env-set-string.yaml
@@ -2,25 +2,46 @@ run: |
   esc env init default/test
   esc env set default/test path "[a" --string
   esc env get default/test
-stdout: |+
-  > esc env init default/test
-  Environment created: test-user/default/test
-  > esc env set default/test path [a --string
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "path": "[a"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    path: '[a'
+  esc env set default/test path hi$'\x05'world --string
+  esc env get default/test
 
-  ```
+---
+> esc env init default/test
+Environment created: test-user/default/test
+> esc env set default/test path [a --string
+> esc env get default/test
+# Value
+```json
+{
+  "path": "[a"
+}
+```
+# Definition
+```yaml
+values:
+  path: '[a'
 
-stderr: |
-  > esc env init default/test
-  > esc env set default/test path [a --string
-  > esc env get default/test
+```
+
+> esc env set default/test path hiworld --string
+> esc env get default/test
+# Value
+```json
+{
+  "path": "hi\u0005world"
+}
+```
+# Definition
+```yaml
+values:
+  path: "hi\x05world"
+
+```
+
+
+---
+> esc env init default/test
+> esc env set default/test path [a --string
+> esc env get default/test
+> esc env set default/test path hiworld --string
+> esc env get default/test

--- a/cmd/esc/cli/testdata/env-set-string.yaml
+++ b/cmd/esc/cli/testdata/env-set-string.yaml
@@ -1,0 +1,10 @@
+run: |
+  esc env init default/test
+  esc env set default/test path "[a" --string
+stdout: |
+  > esc env init default/test
+  Environment created: test-user/default/test
+  > esc env set default/test path [a --string
+stderr: |
+  > esc env init default/test
+  > esc env set default/test path [a --string

--- a/cmd/esc/cli/testdata/env-set-string.yaml
+++ b/cmd/esc/cli/testdata/env-set-string.yaml
@@ -1,10 +1,14 @@
 run: |
   esc env init default/test
   esc env set default/test path "[a" --string
+  esc env get default/test path --value string
 stdout: |
   > esc env init default/test
   Environment created: test-user/default/test
   > esc env set default/test path [a --string
+  > esc env get default/test path --value string
+  [a
 stderr: |
   > esc env init default/test
   > esc env set default/test path [a --string
+  > esc env get default/test path --value string


### PR DESCRIPTION
Add a `--string` flag to `env set` to treat given value as a string