### PR TITLE
Use cobra args functions instead of cmdutil

### DIFF
--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/pulumi/esc/cmd/esc/cli/client"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
 type ambiguousIdentifierError struct {
@@ -56,7 +55,7 @@ func newEnvCmd(esc *escCommand) *cobra.Command {
 			"\n" +
 			"For more information, please visit the project page: https://www.pulumi.com/docs/esc",
 
-		Args: cmdutil.NoArgs,
+		Args: cobra.NoArgs,
 	}
 
 	env := &envCommand{esc: esc}

--- a/cmd/esc/cli/gen_docs.go
+++ b/cmd/esc/cli/gen_docs.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
-
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
 // Used to replace the `## <command>` line in generated markdown files.
@@ -27,10 +25,10 @@ var h3Pattern = regexp.MustCompile(`(?m)^###\s`)
 func newGenDocsCmd(root *cobra.Command) *cobra.Command {
 	return &cobra.Command{
 		Use:    "gen-docs <DIR>",
-		Args:   cmdutil.ExactArgs(1),
+		Args:   cobra.ExactArgs(1),
 		Short:  "Generate ESC CLI documentation as Markdown (one file per command)",
 		Hidden: true,
-		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var files []string
 
 			// filePrepender is used to add front matter to each file, and to keep track of all
@@ -84,6 +82,6 @@ func newGenDocsCmd(root *cobra.Command) *cobra.Command {
 			}
 
 			return nil
-		}),
+		},
 	}
 }


### PR DESCRIPTION
Looks like most of the commands in ESC already just use the cobra args functions and RunE. But `env` was using `cmdutil.NoArgs` and `gen-docs` was using `cmdutil.ExactArgs` and `Run` instead of `RunE`.