### PR TITLE
cli: reformat test YAML

### DIFF
--- a/cmd/esc/cli/testdata/env-clone-conflict.yaml
+++ b/cmd/esc/cli/testdata/env-clone-conflict.yaml
@@ -31,8 +31,10 @@ environments:
                 ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
     tags:
       team: pulumi
-stdout: |
-  > esc env clone default/src a
-stderr: |
-  > esc env clone default/src a
-  Error: cloning environment: already exists
+
+---
+> esc env clone default/src a
+
+---
+> esc env clone default/src a
+Error: cloning environment: already exists

--- a/cmd/esc/cli/testdata/env-clone-not-found.yaml
+++ b/cmd/esc/cli/testdata/env-clone-not-found.yaml
@@ -31,8 +31,10 @@ environments:
                 ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
     tags:
       team: pulumi
-stdout: |
-  > esc env clone not/found dest
-stderr: |
-  > esc env clone not/found dest
-  Error: cloning environment: source env not found
+
+---
+> esc env clone not/found dest
+
+---
+> esc env clone not/found dest
+Error: cloning environment: source env not found

--- a/cmd/esc/cli/testdata/env-clone-ok.yaml
+++ b/cmd/esc/cli/testdata/env-clone-ok.yaml
@@ -38,127 +38,129 @@ environments:
                 ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
     tags:
       team: pulumi
-stdout: |
-  > esc env clone default/src dest
-  Environment test-user/default/src cloned into test-user/default/dest.
-  > esc env get default/dest
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "world"
-    ],
-    "boolean": true,
-    "null": null,
-    "number": 42,
-    "object": {
-      "hello": "world"
-    },
-    "open": "[unknown]",
-    "secret": "[secret]",
-    "string": "esc"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    # comment
-    "null": null
-    boolean: true
-    number: 42
-    string: esc
-    array: [hello, world]
-    object: {hello: world}
-    open:
-      fn::open::test: echo
-    secret:
-      fn::secret:
-        ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
 
-  ```
+---
+> esc env clone default/src dest
+Environment test-user/default/src cloned into test-user/default/dest.
+> esc env get default/dest
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "world"
+  ],
+  "boolean": true,
+  "null": null,
+  "number": 42,
+  "object": {
+    "hello": "world"
+  },
+  "open": "[unknown]",
+  "secret": "[secret]",
+  "string": "esc"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  # comment
+  "null": null
+  boolean: true
+  number: 42
+  string: esc
+  array: [hello, world]
+  object: {hello: world}
+  open:
+    fn::open::test: echo
+  secret:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
 
-  > esc env version history default/dest --utc
-  revision 1
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 01:00:00 +0000 UTC
+```
 
-  > esc env tag ls default/dest --utc
-  > esc env clone default/src project/env
-  Environment test-user/default/src cloned into test-user/project/env.
-  > esc env get project/env
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "world"
-    ],
-    "boolean": true,
-    "null": null,
-    "number": 42,
-    "object": {
-      "hello": "world"
-    },
-    "open": "[unknown]",
-    "secret": "[secret]",
-    "string": "esc"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    # comment
-    "null": null
-    boolean: true
-    number: 42
-    string: esc
-    array: [hello, world]
-    object: {hello: world}
-    open:
-      fn::open::test: echo
-    secret:
-      fn::secret:
-        ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+> esc env version history default/dest --utc
+revision 1
+Author: Test Tester <test-tester>
+Date:   1970-01-01 01:00:00 +0000 UTC
 
-  ```
+> esc env tag ls default/dest --utc
+> esc env clone default/src project/env
+Environment test-user/default/src cloned into test-user/project/env.
+> esc env get project/env
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "world"
+  ],
+  "boolean": true,
+  "null": null,
+  "number": 42,
+  "object": {
+    "hello": "world"
+  },
+  "open": "[unknown]",
+  "secret": "[secret]",
+  "string": "esc"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  # comment
+  "null": null
+  boolean: true
+  number: 42
+  string: esc
+  array: [hello, world]
+  object: {hello: world}
+  open:
+    fn::open::test: echo
+  secret:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
 
-  > esc env clone default/src project/preserve --preserve-history --preserve-access --preserve-rev-tags --preserve-env-tags
-  Environment test-user/default/src cloned into test-user/project/preserve.
-  > esc env version history project/preserve --utc
-  revision 4
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 04:00:00 +0000 UTC
+```
 
-  revision 3 (tag: stable)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 03:00:00 +0000 UTC
+> esc env clone default/src project/preserve --preserve-history --preserve-access --preserve-rev-tags --preserve-env-tags
+Environment test-user/default/src cloned into test-user/project/preserve.
+> esc env version history project/preserve --utc
+revision 4
+Author: Test Tester <test-tester>
+Date:   1970-01-01 04:00:00 +0000 UTC
 
-  revision 2
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 02:00:00 +0000 UTC
+revision 3 (tag: stable)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 03:00:00 +0000 UTC
 
-  revision 1
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 01:00:00 +0000 UTC
+revision 2
+Author: Test Tester <test-tester>
+Date:   1970-01-01 02:00:00 +0000 UTC
 
-  > esc env tag ls project/preserve --utc
-  Name: team
-  Value: pulumi
-  Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-stderr: |
-  > esc env clone default/src dest
-  > esc env get default/dest
-  > esc env version history default/dest --utc
-  > esc env tag ls default/dest --utc
-  > esc env clone default/src project/env
-  > esc env get project/env
-  > esc env clone default/src project/preserve --preserve-history --preserve-access --preserve-rev-tags --preserve-env-tags
-  > esc env version history project/preserve --utc
-  > esc env tag ls project/preserve --utc
+revision 1
+Author: Test Tester <test-tester>
+Date:   1970-01-01 01:00:00 +0000 UTC
+
+> esc env tag ls project/preserve --utc
+Name: team
+Value: pulumi
+Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
+
+---
+> esc env clone default/src dest
+> esc env get default/dest
+> esc env version history default/dest --utc
+> esc env tag ls default/dest --utc
+> esc env clone default/src project/env
+> esc env get project/env
+> esc env clone default/src project/preserve --preserve-history --preserve-access --preserve-rev-tags --preserve-env-tags
+> esc env version history project/preserve --utc
+> esc env tag ls project/preserve --utc

--- a/cmd/esc/cli/testdata/env-diff.yaml
+++ b/cmd/esc/cli/testdata/env-diff.yaml
@@ -64,372 +64,374 @@ environments:
             environmentVariables:
               FOO: bar
               BAR: qux
-stdout: |
-  > esc env diff default/test
-  > esc env diff default/test@latest
-  > esc env diff default/test@stable
-  # Value
-  ```diff
-  --- test-user/default/test@stable
-  +++ test-user/default/test@latest
-  @@ -1,6 +1,19 @@
-   {
-  +  "array": [
-  +    "hello",
-  +    "world"
-  +  ],
-  +  "boolean": true,
-     "environmentVariables": {
-  -    "FOO": "bar"
-  +    "BAR": "qux",
-  +    "FOO": "baz"
-     },
-  -  "string": "hello, world!"
-  +  "null": null,
-  +  "number": 42,
-  +  "object": {
-  +    "hello": "world"
-  +  },
-  +  "open": "[unknown]",
-  +  "secret": "[secret]",
-  +  "string": "esc"
-   }
-  \ No newline at end of file
 
-  ```
-  # Definition
-  ```diff
-  --- test-user/default/test@stable
-  +++ test-user/default/test@latest
-  @@ -1,4 +1,19 @@
-  +imports:
-  +  - a
-  +  - b
-   values:
-  -  string: hello, world!
-  +  # comment
-  +  "null": null
-  +  boolean: true
-  +  number: 42
-  +  string: esc
-  +  array: [hello, world]
-  +  object: {hello: world}
-  +  open:
-  +    fn::open::test: echo
-  +  secret:
-  +    fn::secret:
-  +      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
-     environmentVariables:
-  -    FOO: bar
-  +    FOO: baz
-  +    BAR: qux
+---
+> esc env diff default/test
+> esc env diff default/test@latest
+> esc env diff default/test@stable
+# Value
+```diff
+--- test-user/default/test@stable
++++ test-user/default/test@latest
+@@ -1,6 +1,19 @@
+ {
++  "array": [
++    "hello",
++    "world"
++  ],
++  "boolean": true,
+   "environmentVariables": {
+-    "FOO": "bar"
++    "BAR": "qux",
++    "FOO": "baz"
+   },
+-  "string": "hello, world!"
++  "null": null,
++  "number": 42,
++  "object": {
++    "hello": "world"
++  },
++  "open": "[unknown]",
++  "secret": "[secret]",
++  "string": "esc"
+ }
+\ No newline at end of file
 
-  ```
-  > esc env diff default/test@1
-  # Value
-  ```diff
-  --- test-user/default/test@1
-  +++ test-user/default/test@latest
-  @@ -1 +1,19 @@
-  +{
-  +  "array": [
-  +    "hello",
-  +    "world"
-  +  ],
-  +  "boolean": true,
-  +  "environmentVariables": {
-  +    "BAR": "qux",
-  +    "FOO": "baz"
-  +  },
-  +  "null": null,
-  +  "number": 42,
-  +  "object": {
-  +    "hello": "world"
-  +  },
-  +  "open": "[unknown]",
-  +  "secret": "[secret]",
-  +  "string": "esc"
-  +}
-  \ No newline at end of file
+```
+# Definition
+```diff
+--- test-user/default/test@stable
++++ test-user/default/test@latest
+@@ -1,4 +1,19 @@
++imports:
++  - a
++  - b
+ values:
+-  string: hello, world!
++  # comment
++  "null": null
++  boolean: true
++  number: 42
++  string: esc
++  array: [hello, world]
++  object: {hello: world}
++  open:
++    fn::open::test: echo
++  secret:
++    fn::secret:
++      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+   environmentVariables:
+-    FOO: bar
++    FOO: baz
++    BAR: qux
 
-  ```
-  # Definition
-  ```diff
-  --- test-user/default/test@1
-  +++ test-user/default/test@latest
-  @@ -1 +1,19 @@
-  +imports:
-  +  - a
-  +  - b
-  +values:
-  +  # comment
-  +  "null": null
-  +  boolean: true
-  +  number: 42
-  +  string: esc
-  +  array: [hello, world]
-  +  object: {hello: world}
-  +  open:
-  +    fn::open::test: echo
-  +  secret:
-  +    fn::secret:
-  +      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
-  +  environmentVariables:
-  +    FOO: baz
-  +    BAR: qux
+```
+> esc env diff default/test@1
+# Value
+```diff
+--- test-user/default/test@1
++++ test-user/default/test@latest
+@@ -1 +1,19 @@
++{
++  "array": [
++    "hello",
++    "world"
++  ],
++  "boolean": true,
++  "environmentVariables": {
++    "BAR": "qux",
++    "FOO": "baz"
++  },
++  "null": null,
++  "number": 42,
++  "object": {
++    "hello": "world"
++  },
++  "open": "[unknown]",
++  "secret": "[secret]",
++  "string": "esc"
++}
+\ No newline at end of file
 
-  ```
-  > esc env diff default/test@2
-  # Value
-  ```diff
-  --- test-user/default/test@2
-  +++ test-user/default/test@latest
-  @@ -1,6 +1,19 @@
-   {
-  +  "array": [
-  +    "hello",
-  +    "world"
-  +  ],
-  +  "boolean": true,
-     "environmentVariables": {
-  -    "FOO": "bar"
-  +    "BAR": "qux",
-  +    "FOO": "baz"
-     },
-  -  "string": "hello, world!"
-  +  "null": null,
-  +  "number": 42,
-  +  "object": {
-  +    "hello": "world"
-  +  },
-  +  "open": "[unknown]",
-  +  "secret": "[secret]",
-  +  "string": "esc"
-   }
-  \ No newline at end of file
+```
+# Definition
+```diff
+--- test-user/default/test@1
++++ test-user/default/test@latest
+@@ -1 +1,19 @@
++imports:
++  - a
++  - b
++values:
++  # comment
++  "null": null
++  boolean: true
++  number: 42
++  string: esc
++  array: [hello, world]
++  object: {hello: world}
++  open:
++    fn::open::test: echo
++  secret:
++    fn::secret:
++      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
++  environmentVariables:
++    FOO: baz
++    BAR: qux
 
-  ```
-  # Definition
-  ```diff
-  --- test-user/default/test@2
-  +++ test-user/default/test@latest
-  @@ -1,4 +1,19 @@
-  +imports:
-  +  - a
-  +  - b
-   values:
-  -  string: hello, world!
-  +  # comment
-  +  "null": null
-  +  boolean: true
-  +  number: 42
-  +  string: esc
-  +  array: [hello, world]
-  +  object: {hello: world}
-  +  open:
-  +    fn::open::test: echo
-  +  secret:
-  +    fn::secret:
-  +      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
-     environmentVariables:
-  -    FOO: bar
-  +    FOO: baz
-  +    BAR: qux
+```
+> esc env diff default/test@2
+# Value
+```diff
+--- test-user/default/test@2
++++ test-user/default/test@latest
+@@ -1,6 +1,19 @@
+ {
++  "array": [
++    "hello",
++    "world"
++  ],
++  "boolean": true,
+   "environmentVariables": {
+-    "FOO": "bar"
++    "BAR": "qux",
++    "FOO": "baz"
+   },
+-  "string": "hello, world!"
++  "null": null,
++  "number": 42,
++  "object": {
++    "hello": "world"
++  },
++  "open": "[unknown]",
++  "secret": "[secret]",
++  "string": "esc"
+ }
+\ No newline at end of file
 
-  ```
-  > esc env diff default/test@3
-  > esc env diff default/test@1 @2
-  # Value
-  ```diff
-  --- test-user/default/test@1
-  +++ test-user/default/test@2
-  @@ -1 +1,6 @@
-  +{
-  +  "environmentVariables": {
-  +    "FOO": "bar"
-  +  },
-  +  "string": "hello, world!"
-  +}
-  \ No newline at end of file
+```
+# Definition
+```diff
+--- test-user/default/test@2
++++ test-user/default/test@latest
+@@ -1,4 +1,19 @@
++imports:
++  - a
++  - b
+ values:
+-  string: hello, world!
++  # comment
++  "null": null
++  boolean: true
++  number: 42
++  string: esc
++  array: [hello, world]
++  object: {hello: world}
++  open:
++    fn::open::test: echo
++  secret:
++    fn::secret:
++      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+   environmentVariables:
+-    FOO: bar
++    FOO: baz
++    BAR: qux
 
-  ```
-  # Definition
-  ```diff
-  --- test-user/default/test@1
-  +++ test-user/default/test@2
-  @@ -1 +1,4 @@
-  +values:
-  +  string: hello, world!
-  +  environmentVariables:
-  +    FOO: bar
+```
+> esc env diff default/test@3
+> esc env diff default/test@1 @2
+# Value
+```diff
+--- test-user/default/test@1
++++ test-user/default/test@2
+@@ -1 +1,6 @@
++{
++  "environmentVariables": {
++    "FOO": "bar"
++  },
++  "string": "hello, world!"
++}
+\ No newline at end of file
 
-  ```
-  > esc env diff default/test@1 @stable
-  # Value
-  ```diff
-  --- test-user/default/test@1
-  +++ test-user/default/test@stable
-  @@ -1 +1,6 @@
-  +{
-  +  "environmentVariables": {
-  +    "FOO": "bar"
-  +  },
-  +  "string": "hello, world!"
-  +}
-  \ No newline at end of file
+```
+# Definition
+```diff
+--- test-user/default/test@1
++++ test-user/default/test@2
+@@ -1 +1,4 @@
++values:
++  string: hello, world!
++  environmentVariables:
++    FOO: bar
 
-  ```
-  # Definition
-  ```diff
-  --- test-user/default/test@1
-  +++ test-user/default/test@stable
-  @@ -1 +1,4 @@
-  +values:
-  +  string: hello, world!
-  +  environmentVariables:
-  +    FOO: bar
+```
+> esc env diff default/test@1 @stable
+# Value
+```diff
+--- test-user/default/test@1
++++ test-user/default/test@stable
+@@ -1 +1,6 @@
++{
++  "environmentVariables": {
++    "FOO": "bar"
++  },
++  "string": "hello, world!"
++}
+\ No newline at end of file
 
-  ```
-  > esc env diff default/test@stable default/test-v2@stable
-  # Value
-  ```diff
-  --- test-user/default/test@stable
-  +++ test-user/default/test-v2@stable
-  @@ -2,5 +2,5 @@
-     "environmentVariables": {
-       "FOO": "bar"
-     },
-  -  "string": "hello, world!"
-  +  "string": "bonjour, monde!"
-   }
-  \ No newline at end of file
+```
+# Definition
+```diff
+--- test-user/default/test@1
++++ test-user/default/test@stable
+@@ -1 +1,4 @@
++values:
++  string: hello, world!
++  environmentVariables:
++    FOO: bar
 
-  ```
-  # Definition
-  ```diff
-  --- test-user/default/test@stable
-  +++ test-user/default/test-v2@stable
-  @@ -1,4 +1,4 @@
-   values:
-  -  string: hello, world!
-  +  string: bonjour, monde!
-     environmentVariables:
-       FOO: bar
+```
+> esc env diff default/test@stable default/test-v2@stable
+# Value
+```diff
+--- test-user/default/test@stable
++++ test-user/default/test-v2@stable
+@@ -2,5 +2,5 @@
+   "environmentVariables": {
+     "FOO": "bar"
+   },
+-  "string": "hello, world!"
++  "string": "bonjour, monde!"
+ }
+\ No newline at end of file
 
-  ```
-  > esc env diff default/test default/test-v2
-  # Value
-  ```diff
-  --- test-user/default/test@latest
-  +++ test-user/default/test-v2
-  @@ -1,19 +1,7 @@
-   {
-  -  "array": [
-  -    "hello",
-  -    "world"
-  -  ],
-  -  "boolean": true,
-     "environmentVariables": {
-       "BAR": "qux",
-  -    "FOO": "baz"
-  +    "FOO": "bar"
-     },
-  -  "null": null,
-  -  "number": 42,
-  -  "object": {
-  -    "hello": "world"
-  -  },
-  -  "open": "[unknown]",
-  -  "secret": "[secret]",
-  -  "string": "esc"
-  +  "string": "cse"
-   }
-  \ No newline at end of file
+```
+# Definition
+```diff
+--- test-user/default/test@stable
++++ test-user/default/test-v2@stable
+@@ -1,4 +1,4 @@
+ values:
+-  string: hello, world!
++  string: bonjour, monde!
+   environmentVariables:
+     FOO: bar
 
-  ```
-  # Definition
-  ```diff
-  --- test-user/default/test@latest
-  +++ test-user/default/test-v2
-  @@ -3,17 +3,7 @@
-     - b
-   values:
-     # comment
-  -  "null": null
-  -  boolean: true
-  -  number: 42
-  -  string: esc
-  -  array: [hello, world]
-  -  object: {hello: world}
-  -  open:
-  -    fn::open::test: echo
-  -  secret:
-  -    fn::secret:
-  -      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
-  +  string: cse
-     environmentVariables:
-  -    FOO: baz
-  +    FOO: bar
-       BAR: qux
+```
+> esc env diff default/test default/test-v2
+# Value
+```diff
+--- test-user/default/test@latest
++++ test-user/default/test-v2
+@@ -1,19 +1,7 @@
+ {
+-  "array": [
+-    "hello",
+-    "world"
+-  ],
+-  "boolean": true,
+   "environmentVariables": {
+     "BAR": "qux",
+-    "FOO": "baz"
++    "FOO": "bar"
+   },
+-  "null": null,
+-  "number": 42,
+-  "object": {
+-    "hello": "world"
+-  },
+-  "open": "[unknown]",
+-  "secret": "[secret]",
+-  "string": "esc"
++  "string": "cse"
+ }
+\ No newline at end of file
 
-  ```
-  > esc env diff default/test@stable --format json
-  --- test-user/default/test@stable
-  +++ test-user/default/test@latest
-  @@ -1,6 +1,19 @@
-   {
-  +  "array": [
-  +    "hello",
-  +    "world"
-  +  ],
-  +  "boolean": true,
-     "environmentVariables": {
-  -    "FOO": "bar"
-  +    "BAR": "qux",
-  +    "FOO": "baz"
-     },
-  -  "string": "hello, world!"
-  +  "null": null,
-  +  "number": 42,
-  +  "object": {
-  +    "hello": "world"
-  +  },
-  +  "open": "[unknown]",
-  +  "secret": "[secret]",
-  +  "string": "esc"
-   }
-  > esc env diff default/test@stable --format string
-  --- test-user/default/test@stable
-  +++ test-user/default/test@latest
-  @@ -1 +1 @@
-  -"environmentVariables"="\"FOO\"=\"bar\"","string"="hello, world!"
-  +"array"="\"hello\",\"world\"","boolean"="true","environmentVariables"="\"BAR\"=\"qux\",\"FOO\"=\"baz\"","null"="","number"="42","object"="\"hello\"=\"world\"","open"="[unknown]","secret"="[secret]","string"="esc"
-  > esc env diff default/test@stable --format dotenv
-  --- test-user/default/test@stable
-  +++ test-user/default/test@latest
-  @@ -1 +1,2 @@
-  -FOO="bar"
-  +BAR="qux"
-  +FOO="baz"
-  > esc env diff default/test@stable --format shell
-  --- test-user/default/test@stable
-  +++ test-user/default/test@latest
-  @@ -1 +1,2 @@
-  -export FOO="bar"
-  +export BAR="qux"
-  +export FOO="baz"
-stderr: |
-  > esc env diff default/test
-  > esc env diff default/test@latest
-  > esc env diff default/test@stable
-  > esc env diff default/test@1
-  > esc env diff default/test@2
-  > esc env diff default/test@3
-  > esc env diff default/test@1 @2
-  > esc env diff default/test@1 @stable
-  > esc env diff default/test@stable default/test-v2@stable
-  > esc env diff default/test default/test-v2
-  > esc env diff default/test@stable --format json
-  > esc env diff default/test@stable --format string
-  > esc env diff default/test@stable --format dotenv
-  > esc env diff default/test@stable --format shell
+```
+# Definition
+```diff
+--- test-user/default/test@latest
++++ test-user/default/test-v2
+@@ -3,17 +3,7 @@
+   - b
+ values:
+   # comment
+-  "null": null
+-  boolean: true
+-  number: 42
+-  string: esc
+-  array: [hello, world]
+-  object: {hello: world}
+-  open:
+-    fn::open::test: echo
+-  secret:
+-    fn::secret:
+-      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
++  string: cse
+   environmentVariables:
+-    FOO: baz
++    FOO: bar
+     BAR: qux
+
+```
+> esc env diff default/test@stable --format json
+--- test-user/default/test@stable
++++ test-user/default/test@latest
+@@ -1,6 +1,19 @@
+ {
++  "array": [
++    "hello",
++    "world"
++  ],
++  "boolean": true,
+   "environmentVariables": {
+-    "FOO": "bar"
++    "BAR": "qux",
++    "FOO": "baz"
+   },
+-  "string": "hello, world!"
++  "null": null,
++  "number": 42,
++  "object": {
++    "hello": "world"
++  },
++  "open": "[unknown]",
++  "secret": "[secret]",
++  "string": "esc"
+ }
+> esc env diff default/test@stable --format string
+--- test-user/default/test@stable
++++ test-user/default/test@latest
+@@ -1 +1 @@
+-"environmentVariables"="\"FOO\"=\"bar\"","string"="hello, world!"
++"array"="\"hello\",\"world\"","boolean"="true","environmentVariables"="\"BAR\"=\"qux\",\"FOO\"=\"baz\"","null"="","number"="42","object"="\"hello\"=\"world\"","open"="[unknown]","secret"="[secret]","string"="esc"
+> esc env diff default/test@stable --format dotenv
+--- test-user/default/test@stable
++++ test-user/default/test@latest
+@@ -1 +1,2 @@
+-FOO="bar"
++BAR="qux"
++FOO="baz"
+> esc env diff default/test@stable --format shell
+--- test-user/default/test@stable
++++ test-user/default/test@latest
+@@ -1 +1,2 @@
+-export FOO="bar"
++export BAR="qux"
++export FOO="baz"
+
+---
+> esc env diff default/test
+> esc env diff default/test@latest
+> esc env diff default/test@stable
+> esc env diff default/test@1
+> esc env diff default/test@2
+> esc env diff default/test@3
+> esc env diff default/test@1 @2
+> esc env diff default/test@1 @stable
+> esc env diff default/test@stable default/test-v2@stable
+> esc env diff default/test default/test-v2
+> esc env diff default/test@stable --format json
+> esc env diff default/test@stable --format string
+> esc env diff default/test@stable --format dotenv
+> esc env diff default/test@stable --format shell

--- a/cmd/esc/cli/testdata/env-edit-editor-abort.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-abort.yaml
@@ -9,8 +9,10 @@ environments:
   test-user/default/test:
     values:
       foo: bar
-stdout: |
-  > esc env edit default/test
-stderr: |
-  > esc env edit default/test
-  Aborting edit due to empty definition.
+
+---
+> esc env edit default/test
+
+---
+> esc env edit default/test
+Aborting edit due to empty definition.

--- a/cmd/esc/cli/testdata/env-edit-editor-diags.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-diags.yaml
@@ -13,23 +13,25 @@ environments:
       - a
     values:
       foo: bar
-stdout: |+
-  > esc env edit default/test
-  Environment updated.
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": "baz"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo: baz
 
-  ```
+---
+> esc env edit default/test
+Environment updated.
+> esc env get default/test
+# Value
+```json
+{
+  "foo": "baz"
+}
+```
+# Definition
+```yaml
+values:
+  foo: baz
 
-stderr: |
-  > esc env edit default/test
-  > esc env get default/test
+```
+
+
+---
+> esc env edit default/test
+> esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-editor-docs-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-docs-ok.yaml
@@ -11,23 +11,25 @@ environments:
   test-user/default/test:
     values:
       foo: bar
-stdout: |+
-  > esc env edit default/test
-  Environment updated.
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": "baz"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo: baz
 
-  ```
+---
+> esc env edit default/test
+Environment updated.
+> esc env get default/test
+# Value
+```json
+{
+  "foo": "baz"
+}
+```
+# Definition
+```yaml
+values:
+  foo: baz
 
-stderr: |
-  > esc env edit default/test
-  > esc env get default/test
+```
+
+
+---
+> esc env edit default/test
+> esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-editor-invalid.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-invalid.yaml
@@ -9,14 +9,16 @@ environments:
   test-user/default/test:
     values:
       foo: bar
-stdout: |
-  > esc env edit default/test
-stderr: |
-  > esc env edit default/test
-  Error: imports must be a list
 
-    on test line 1:
-     1: imports:
+---
+> esc env edit default/test
 
-  Press ENTER to continue editing or ^D to exit
-  Aborting edit.
+---
+> esc env edit default/test
+Error: imports must be a list
+
+  on test line 1:
+   1: imports:
+
+Press ENTER to continue editing or ^D to exit
+Aborting edit.

--- a/cmd/esc/cli/testdata/env-edit-editor-not-found.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-not-found.yaml
@@ -3,8 +3,10 @@ error: exit status 1
 process:
   environ:
     EDITOR: my-editor
-stdout: |
-  > esc env edit default/test
-stderr: |
-  > esc env edit default/test
-  Error: finding "my-editor" on path: command not found
+
+---
+> esc env edit default/test
+
+---
+> esc env edit default/test
+Error: finding "my-editor" on path: command not found

--- a/cmd/esc/cli/testdata/env-edit-editor-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-ok.yaml
@@ -11,23 +11,25 @@ environments:
   test-user/default/test:
     values:
       foo: bar
-stdout: |+
-  > esc env edit default/test
-  Environment updated.
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": "baz"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo: baz
 
-  ```
+---
+> esc env edit default/test
+Environment updated.
+> esc env get default/test
+# Value
+```json
+{
+  "foo": "baz"
+}
+```
+# Definition
+```yaml
+values:
+  foo: baz
 
-stderr: |
-  > esc env edit default/test
-  > esc env get default/test
+```
+
+
+---
+> esc env edit default/test
+> esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-env-not-found.yaml
+++ b/cmd/esc/cli/testdata/env-edit-env-not-found.yaml
@@ -5,8 +5,10 @@ process:
     EDITOR: my-editor
   commands:
     my-editor: exit 1
-stdout: |
-  > esc env edit default/test
-stderr: |
-  > esc env edit default/test
-  Error: getting environment definition: not found
+
+---
+> esc env edit default/test
+
+---
+> esc env edit default/test
+Error: getting environment definition: not found

--- a/cmd/esc/cli/testdata/env-edit-file.yaml
+++ b/cmd/esc/cli/testdata/env-edit-file.yaml
@@ -8,39 +8,41 @@ environments:
   test-user/default/test:
     values:
       foo: bar
-stdout: |+
-  > esc env edit default/test -f=-
-  Environment updated.
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": "baz"
-  }
-  ```
-  # Definition
-  ```yaml
-  {"values": {"foo": "baz"}}
 
-  ```
+---
+> esc env edit default/test -f=-
+Environment updated.
+> esc env get default/test
+# Value
+```json
+{
+  "foo": "baz"
+}
+```
+# Definition
+```yaml
+{"values": {"foo": "baz"}}
 
-  > esc env edit default/test -f=def.yaml
-  Environment updated.
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": "qux"
-  }
-  ```
-  # Definition
-  ```yaml
-  {"values": {"foo": "qux"}}
+```
 
-  ```
+> esc env edit default/test -f=def.yaml
+Environment updated.
+> esc env get default/test
+# Value
+```json
+{
+  "foo": "qux"
+}
+```
+# Definition
+```yaml
+{"values": {"foo": "qux"}}
 
-stderr: |
-  > esc env edit default/test -f=-
-  > esc env get default/test
-  > esc env edit default/test -f=def.yaml
-  > esc env get default/test
+```
+
+
+---
+> esc env edit default/test -f=-
+> esc env get default/test
+> esc env edit default/test -f=def.yaml
+> esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-flag-code-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-code-ok.yaml
@@ -10,23 +10,25 @@ environments:
   test-user/default/test:
     values:
       foo: bar
-stdout: |+
-  > esc env edit default/test --editor code
-  Environment updated.
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": "baz"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo: baz
 
-  ```
+---
+> esc env edit default/test --editor code
+Environment updated.
+> esc env get default/test
+# Value
+```json
+{
+  "foo": "baz"
+}
+```
+# Definition
+```yaml
+values:
+  foo: baz
 
-stderr: |
-  > esc env edit default/test --editor code
-  > esc env get default/test
+```
+
+
+---
+> esc env edit default/test --editor code
+> esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-flag-editor-args.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-editor-args.yaml
@@ -11,23 +11,25 @@ environments:
   test-user/default/test:
     values:
       foo: bar
-stdout: |+
-  > esc env edit default/test --editor editor --some-flag --other-flag="a\"b"
-  Environment updated.
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": "bar"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo: bar
 
-  ```
+---
+> esc env edit default/test --editor editor --some-flag --other-flag="a\"b"
+Environment updated.
+> esc env get default/test
+# Value
+```json
+{
+  "foo": "bar"
+}
+```
+# Definition
+```yaml
+values:
+  foo: bar
 
-stderr: |
-  > esc env edit default/test --editor editor --some-flag --other-flag="a\"b"
-  > esc env get default/test
+```
+
+
+---
+> esc env edit default/test --editor editor --some-flag --other-flag="a\"b"
+> esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-flag-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-ok.yaml
@@ -9,23 +9,25 @@ environments:
   test-user/default/test:
     values:
       foo: bar
-stdout: |+
-  > esc env edit default/test --editor my-editor
-  Environment updated.
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": "baz"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo: baz
 
-  ```
+---
+> esc env edit default/test --editor my-editor
+Environment updated.
+> esc env get default/test
+# Value
+```json
+{
+  "foo": "baz"
+}
+```
+# Definition
+```yaml
+values:
+  foo: baz
 
-stderr: |
-  > esc env edit default/test --editor my-editor
-  > esc env get default/test
+```
+
+
+---
+> esc env edit default/test --editor my-editor
+> esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-none-not-found.yaml
+++ b/cmd/esc/cli/testdata/env-edit-none-not-found.yaml
@@ -1,7 +1,9 @@
 run: esc env edit default/test
 error: exit status 1
-stdout: |
-  > esc env edit default/test
-stderr: |
-  > esc env edit default/test
-  Error: No available editor. Please use the --editor flag or set one of the VISUAL or EDITOR environment variables.
+
+---
+> esc env edit default/test
+
+---
+> esc env edit default/test
+Error: No available editor. Please use the --editor flag or set one of the VISUAL or EDITOR environment variables.

--- a/cmd/esc/cli/testdata/env-edit-none-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-none-ok.yaml
@@ -9,23 +9,25 @@ environments:
   test-user/default/test:
     values:
       foo: bar
-stdout: |+
-  > esc env edit default/test
-  Environment updated.
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": "baz"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo: baz
 
-  ```
+---
+> esc env edit default/test
+Environment updated.
+> esc env get default/test
+# Value
+```json
+{
+  "foo": "baz"
+}
+```
+# Definition
+```yaml
+values:
+  foo: baz
 
-stderr: |
-  > esc env edit default/test
-  > esc env get default/test
+```
+
+
+---
+> esc env edit default/test
+> esc env get default/test

--- a/cmd/esc/cli/testdata/env-edit-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-edit-revision-or-tag.yaml
@@ -10,11 +10,13 @@ environments:
   test-user/default/test:
     values:
       foo: bar
-stdout: |
-  > esc env edit default/test@1 --editor my-editor
-  > esc env edit default/test@foo --editor my-editor
-stderr: |
-  > esc env edit default/test@1 --editor my-editor
-  Error: the edit command does not accept versions
-  > esc env edit default/test@foo --editor my-editor
-  Error: the edit command does not accept versions
+
+---
+> esc env edit default/test@1 --editor my-editor
+> esc env edit default/test@foo --editor my-editor
+
+---
+> esc env edit default/test@1 --editor my-editor
+Error: the edit command does not accept versions
+> esc env edit default/test@foo --editor my-editor
+Error: the edit command does not accept versions

--- a/cmd/esc/cli/testdata/env-edit-visual-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-visual-ok.yaml
@@ -11,23 +11,25 @@ environments:
   test-user/default/test:
     values:
       foo: bar
-stdout: |+
-  > esc env edit default/test
-  Environment updated.
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": "baz"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo: baz
 
-  ```
+---
+> esc env edit default/test
+Environment updated.
+> esc env get default/test
+# Value
+```json
+{
+  "foo": "baz"
+}
+```
+# Definition
+```yaml
+values:
+  foo: baz
 
-stderr: |
-  > esc env edit default/test
-  > esc env get default/test
+```
+
+
+---
+> esc env edit default/test
+> esc env get default/test

--- a/cmd/esc/cli/testdata/env-get-all-value-dotenv.yaml
+++ b/cmd/esc/cli/testdata/env-get-all-value-dotenv.yaml
@@ -30,23 +30,25 @@ environments:
         SECRET: ${secret}
       files:
         FILE: ${string}
-stdout: |
-  > esc env get default/test --value=dotenv
-  BOOLEAN="true"
-  NULLV=""
-  NUMBER="3.14"
-  OBJECT="{\"hello\":\"world\"}"
-  SECRET="[secret]"
-  STRING="esc"
-  FILE="[unknown]"
-  > esc env get default/test --value=dotenv --show-secrets
-  BOOLEAN="true"
-  NULLV=""
-  NUMBER="3.14"
-  OBJECT="{\"hello\":\"world\"}"
-  SECRET="secretAccessKey"
-  STRING="esc"
-  FILE="[unknown]"
-stderr: |
-  > esc env get default/test --value=dotenv
-  > esc env get default/test --value=dotenv --show-secrets
+
+---
+> esc env get default/test --value=dotenv
+BOOLEAN="true"
+NULLV=""
+NUMBER="3.14"
+OBJECT="{\"hello\":\"world\"}"
+SECRET="[secret]"
+STRING="esc"
+FILE="[unknown]"
+> esc env get default/test --value=dotenv --show-secrets
+BOOLEAN="true"
+NULLV=""
+NUMBER="3.14"
+OBJECT="{\"hello\":\"world\"}"
+SECRET="secretAccessKey"
+STRING="esc"
+FILE="[unknown]"
+
+---
+> esc env get default/test --value=dotenv
+> esc env get default/test --value=dotenv --show-secrets

--- a/cmd/esc/cli/testdata/env-get-all-value-shell.yaml
+++ b/cmd/esc/cli/testdata/env-get-all-value-shell.yaml
@@ -30,23 +30,25 @@ environments:
         SECRET: ${secret}
       files:
         FILE: ${string}
-stdout: |
-  > esc env get default/test --value=shell
-  export BOOLEAN="true"
-  export NULLV=""
-  export NUMBER="3.14"
-  export OBJECT="{\"hello\":\"world\"}"
-  export SECRET="[secret]"
-  export STRING="esc"
-  export FILE="[unknown]"
-  > esc env get default/test --value=shell --show-secrets
-  export BOOLEAN="true"
-  export NULLV=""
-  export NUMBER="3.14"
-  export OBJECT="{\"hello\":\"world\"}"
-  export SECRET="secretAccessKey"
-  export STRING="esc"
-  export FILE="[unknown]"
-stderr: |
-  > esc env get default/test --value=shell
-  > esc env get default/test --value=shell --show-secrets
+
+---
+> esc env get default/test --value=shell
+export BOOLEAN="true"
+export NULLV=""
+export NUMBER="3.14"
+export OBJECT="{\"hello\":\"world\"}"
+export SECRET="[secret]"
+export STRING="esc"
+export FILE="[unknown]"
+> esc env get default/test --value=shell --show-secrets
+export BOOLEAN="true"
+export NULLV=""
+export NUMBER="3.14"
+export OBJECT="{\"hello\":\"world\"}"
+export SECRET="secretAccessKey"
+export STRING="esc"
+export FILE="[unknown]"
+
+---
+> esc env get default/test --value=shell
+> esc env get default/test --value=shell --show-secrets

--- a/cmd/esc/cli/testdata/env-get-all.yaml
+++ b/cmd/esc/cli/testdata/env-get-all.yaml
@@ -37,205 +37,207 @@ environments:
             secret:
               fn::secret:
                 ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
-stdout: |+
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "world"
-    ],
-    "baseSecret": "[secret]",
-    "boolean": true,
-    "null": null,
-    "number": 42,
-    "object": {
-      "hello": "world"
-    },
-    "open": "[unknown]",
-    "secret": "[secret]",
-    "string": "esc"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    # comment
-    "null": null
-    boolean: true
-    number: 42
-    string: esc
-    array: [hello, world]
-    object: {hello: world}
-    open:
-      fn::open::test: echo
-    secret:
-      fn::secret:
-        ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
 
-  ```
+---
+> esc env get default/test
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "world"
+  ],
+  "baseSecret": "[secret]",
+  "boolean": true,
+  "null": null,
+  "number": 42,
+  "object": {
+    "hello": "world"
+  },
+  "open": "[unknown]",
+  "secret": "[secret]",
+  "string": "esc"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  # comment
+  "null": null
+  boolean: true
+  number: 42
+  string: esc
+  array: [hello, world]
+  object: {hello: world}
+  open:
+    fn::open::test: echo
+  secret:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
 
-  > esc env get default/test@latest
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "world"
-    ],
-    "baseSecret": "[secret]",
-    "boolean": true,
-    "null": null,
-    "number": 42,
-    "object": {
-      "hello": "world"
-    },
-    "open": "[unknown]",
-    "secret": "[secret]",
-    "string": "esc"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    # comment
-    "null": null
-    boolean: true
-    number: 42
-    string: esc
-    array: [hello, world]
-    object: {hello: world}
-    open:
-      fn::open::test: echo
-    secret:
-      fn::secret:
-        ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+```
 
-  ```
+> esc env get default/test@latest
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "world"
+  ],
+  "baseSecret": "[secret]",
+  "boolean": true,
+  "null": null,
+  "number": 42,
+  "object": {
+    "hello": "world"
+  },
+  "open": "[unknown]",
+  "secret": "[secret]",
+  "string": "esc"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  # comment
+  "null": null
+  boolean: true
+  number: 42
+  string: esc
+  array: [hello, world]
+  object: {hello: world}
+  open:
+    fn::open::test: echo
+  secret:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
 
-  > esc env get default/test@stable
-  # Value
-  ```json
-  {
-    "string": "hello, world!"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    string: hello, world!
+```
 
-  ```
+> esc env get default/test@stable
+# Value
+```json
+{
+  "string": "hello, world!"
+}
+```
+# Definition
+```yaml
+values:
+  string: hello, world!
 
-  > esc env get default/test@1
+```
 
-  > esc env get default/test@2
-  # Value
-  ```json
-  {
-    "string": "hello, world!"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    string: hello, world!
+> esc env get default/test@1
 
-  ```
+> esc env get default/test@2
+# Value
+```json
+{
+  "string": "hello, world!"
+}
+```
+# Definition
+```yaml
+values:
+  string: hello, world!
 
-  > esc env get default/test@3
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "world"
-    ],
-    "baseSecret": "[secret]",
-    "boolean": true,
-    "null": null,
-    "number": 42,
-    "object": {
-      "hello": "world"
-    },
-    "open": "[unknown]",
-    "secret": "[secret]",
-    "string": "esc"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    # comment
-    "null": null
-    boolean: true
-    number: 42
-    string: esc
-    array: [hello, world]
-    object: {hello: world}
-    open:
-      fn::open::test: echo
-    secret:
-      fn::secret:
-        ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+```
 
-  ```
+> esc env get default/test@3
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "world"
+  ],
+  "baseSecret": "[secret]",
+  "boolean": true,
+  "null": null,
+  "number": 42,
+  "object": {
+    "hello": "world"
+  },
+  "open": "[unknown]",
+  "secret": "[secret]",
+  "string": "esc"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  # comment
+  "null": null
+  boolean: true
+  number: 42
+  string: esc
+  array: [hello, world]
+  object: {hello: world}
+  open:
+    fn::open::test: echo
+  secret:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
 
-  > esc env get default/test@latest --show-secrets
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "world"
-    ],
-    "baseSecret": "secretAccessKey",
-    "boolean": true,
-    "null": null,
-    "number": 42,
-    "object": {
-      "hello": "world"
-    },
-    "open": "[unknown]",
-    "secret": "secretAccessKey",
-    "string": "esc"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    # comment
-    "null": null
-    boolean: true
-    number: 42
-    string: esc
-    array: [hello, world]
-    object: {hello: world}
-    open:
-      fn::open::test: echo
-    secret:
-      fn::secret: secretAccessKey
+```
 
-  ```
+> esc env get default/test@latest --show-secrets
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "world"
+  ],
+  "baseSecret": "secretAccessKey",
+  "boolean": true,
+  "null": null,
+  "number": 42,
+  "object": {
+    "hello": "world"
+  },
+  "open": "[unknown]",
+  "secret": "secretAccessKey",
+  "string": "esc"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  # comment
+  "null": null
+  boolean: true
+  number: 42
+  string: esc
+  array: [hello, world]
+  object: {hello: world}
+  open:
+    fn::open::test: echo
+  secret:
+    fn::secret: secretAccessKey
 
-stderr: |
-  > esc env get default/test
-  > esc env get default/test@latest
-  > esc env get default/test@stable
-  > esc env get default/test@1
-  > esc env get default/test@2
-  > esc env get default/test@3
-  > esc env get default/test@latest --show-secrets
+```
+
+
+---
+> esc env get default/test
+> esc env get default/test@latest
+> esc env get default/test@stable
+> esc env get default/test@1
+> esc env get default/test@2
+> esc env get default/test@3
+> esc env get default/test@latest --show-secrets

--- a/cmd/esc/cli/testdata/env-get-definition-error.yaml
+++ b/cmd/esc/cli/testdata/env-get-definition-error.yaml
@@ -1,7 +1,9 @@
 run: esc env get default/test --definition --value=json
 error: exit status 1
-stdout: |
-  > esc env get default/test --definition --value=json
-stderr: |
-  > esc env get default/test --definition --value=json
-  Error: `--value` and `--definition` flags cannot be used together
+
+---
+> esc env get default/test --definition --value=json
+
+---
+> esc env get default/test --definition --value=json
+Error: `--value` and `--definition` flags cannot be used together

--- a/cmd/esc/cli/testdata/env-get-definition.yaml
+++ b/cmd/esc/cli/testdata/env-get-definition.yaml
@@ -9,14 +9,16 @@ environments:
       string: esc
       files:
         FILE: ${string}
-stdout: |
-  > esc env get default/test --definition
-  imports:
-    - a
-  values:
-    # comment
-    string: esc
-    files:
-      FILE: ${string}
-stderr: |
-  > esc env get default/test --definition
+
+---
+> esc env get default/test --definition
+imports:
+  - a
+values:
+  # comment
+  string: esc
+  files:
+    FILE: ${string}
+
+---
+> esc env get default/test --definition

--- a/cmd/esc/cli/testdata/env-get-each-import.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-import.yaml
@@ -25,30 +25,32 @@ environments:
       open:
         fn::open::test:
           foo: bar
-stdout: |+
-  > esc env get default/test imports
-  # Definition
-  ```yaml
-  - a
-  - b
 
-  ```
+---
+> esc env get default/test imports
+# Definition
+```yaml
+- a
+- b
 
-  > esc env get default/test imports[0]
-  # Definition
-  ```yaml
-  a
+```
 
-  ```
+> esc env get default/test imports[0]
+# Definition
+```yaml
+a
 
-  > esc env get default/test imports[1]
-  # Definition
-  ```yaml
-  b
+```
 
-  ```
+> esc env get default/test imports[1]
+# Definition
+```yaml
+b
 
-stderr: |
-  > esc env get default/test imports
-  > esc env get default/test imports[0]
-  > esc env get default/test imports[1]
+```
+
+
+---
+> esc env get default/test imports
+> esc env get default/test imports[0]
+> esc env get default/test imports[1]

--- a/cmd/esc/cli/testdata/env-get-each-value-detailed.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-value-detailed.yaml
@@ -32,407 +32,407 @@ environments:
       object: {hello: world}
       open:
         fn::open::test: echo
-stdout: |
-  > esc env get default/test --value detailed null
-  {
-    "trace": {
-      "def": {
-        "environment": "\u003cyaml\u003e",
-        "begin": {
-          "line": 6,
-          "column": 13,
-          "byte": 59
-        },
-        "end": {
-          "line": 6,
-          "column": 17,
-          "byte": 63
-        }
-      }
-    }
-  }
-  > esc env get default/test --value detailed boolean
-  {
-    "value": true,
-    "trace": {
-      "def": {
-        "environment": "\u003cyaml\u003e",
-        "begin": {
-          "line": 7,
-          "column": 14,
-          "byte": 77
-        },
-        "end": {
-          "line": 7,
-          "column": 18,
-          "byte": 81
-        }
-      }
-    }
-  }
-  > esc env get default/test --value detailed number
-  {
-    "value": 42,
-    "trace": {
-      "def": {
-        "environment": "\u003cyaml\u003e",
-        "begin": {
-          "line": 8,
-          "column": 13,
-          "byte": 94
-        },
-        "end": {
-          "line": 8,
-          "column": 15,
-          "byte": 96
-        }
-      }
-    }
-  }
-  > esc env get default/test --value detailed string
-  {
-    "value": "esc",
-    "trace": {
-      "def": {
-        "environment": "\u003cyaml\u003e",
-        "begin": {
-          "line": 9,
-          "column": 13,
-          "byte": 109
-        },
-        "end": {
-          "line": 9,
-          "column": 16,
-          "byte": 112
-        }
+
+---
+> esc env get default/test --value detailed null
+{
+  "trace": {
+    "def": {
+      "environment": "\u003cyaml\u003e",
+      "begin": {
+        "line": 6,
+        "column": 13,
+        "byte": 59
       },
-      "base": {
-        "value": "foo",
-        "trace": {
-          "def": {
-            "environment": "b",
-            "begin": {
-              "line": 2,
-              "column": 13,
-              "byte": 20
-            },
-            "end": {
-              "line": 2,
-              "column": 16,
-              "byte": 23
-            }
-          }
-        }
+      "end": {
+        "line": 6,
+        "column": 17,
+        "byte": 63
       }
     }
   }
-  > esc env get default/test --value detailed array
-  {
-    "value": [
-      {
-        "value": "hello",
-        "trace": {
-          "def": {
-            "environment": "\u003cyaml\u003e",
-            "begin": {
-              "line": 10,
-              "column": 13,
-              "byte": 125
-            },
-            "end": {
-              "line": 10,
-              "column": 18,
-              "byte": 130
-            }
-          }
-        }
+}
+> esc env get default/test --value detailed boolean
+{
+  "value": true,
+  "trace": {
+    "def": {
+      "environment": "\u003cyaml\u003e",
+      "begin": {
+        "line": 7,
+        "column": 14,
+        "byte": 77
       },
-      {
-        "value": "world",
-        "trace": {
-          "def": {
-            "environment": "\u003cyaml\u003e",
-            "begin": {
-              "line": 10,
-              "column": 20,
-              "byte": 132
-            },
-            "end": {
-              "line": 10,
-              "column": 25,
-              "byte": 137
-            }
-          }
-        }
-      }
-    ],
-    "trace": {
-      "def": {
-        "environment": "\u003cyaml\u003e",
-        "begin": {
-          "line": 10,
-          "column": 12,
-          "byte": 124
-        },
-        "end": {
-          "line": 10,
-          "column": 25,
-          "byte": 137
-        }
+      "end": {
+        "line": 7,
+        "column": 18,
+        "byte": 81
       }
     }
   }
-  > esc env get default/test --value detailed array[0]
-  {
-    "value": "hello",
-    "trace": {
-      "def": {
-        "environment": "\u003cyaml\u003e",
-        "begin": {
-          "line": 10,
-          "column": 13,
-          "byte": 125
-        },
-        "end": {
-          "line": 10,
-          "column": 18,
-          "byte": 130
-        }
+}
+> esc env get default/test --value detailed number
+{
+  "value": 42,
+  "trace": {
+    "def": {
+      "environment": "\u003cyaml\u003e",
+      "begin": {
+        "line": 8,
+        "column": 13,
+        "byte": 94
+      },
+      "end": {
+        "line": 8,
+        "column": 15,
+        "byte": 96
       }
     }
   }
-  > esc env get default/test --value detailed array[1]
-  {
-    "value": "world",
-    "trace": {
-      "def": {
-        "environment": "\u003cyaml\u003e",
-        "begin": {
-          "line": 10,
-          "column": 20,
-          "byte": 132
-        },
-        "end": {
-          "line": 10,
-          "column": 25,
-          "byte": 137
-        }
+}
+> esc env get default/test --value detailed string
+{
+  "value": "esc",
+  "trace": {
+    "def": {
+      "environment": "\u003cyaml\u003e",
+      "begin": {
+        "line": 9,
+        "column": 13,
+        "byte": 109
+      },
+      "end": {
+        "line": 9,
+        "column": 16,
+        "byte": 112
       }
-    }
-  }
-  > esc env get default/test --value detailed object
-  {
-    "value": {
-      "goodbye": {
-        "value": "all",
-        "trace": {
-          "def": {
-            "environment": "b",
-            "begin": {
-              "line": 3,
-              "column": 23,
-              "byte": 46
-            },
-            "end": {
-              "line": 3,
-              "column": 26,
-              "byte": 49
-            }
+    },
+    "base": {
+      "value": "foo",
+      "trace": {
+        "def": {
+          "environment": "b",
+          "begin": {
+            "line": 2,
+            "column": 13,
+            "byte": 20
           },
-          "base": {
-            "value": "world",
-            "trace": {
-              "def": {
-                "environment": "a",
-                "begin": {
-                  "line": 2,
-                  "column": 35,
-                  "byte": 42
-                },
-                "end": {
-                  "line": 2,
-                  "column": 40,
-                  "byte": 47
-                }
-              }
-            }
+          "end": {
+            "line": 2,
+            "column": 16,
+            "byte": 23
           }
         }
-      },
-      "hello": {
-        "value": "world",
-        "trace": {
-          "def": {
-            "environment": "\u003cyaml\u003e",
-            "begin": {
-              "line": 11,
-              "column": 21,
-              "byte": 159
-            },
-            "end": {
-              "line": 11,
-              "column": 26,
-              "byte": 164
-            }
+      }
+    }
+  }
+}
+> esc env get default/test --value detailed array
+{
+  "value": [
+    {
+      "value": "hello",
+      "trace": {
+        "def": {
+          "environment": "\u003cyaml\u003e",
+          "begin": {
+            "line": 10,
+            "column": 13,
+            "byte": 125
           },
-          "base": {
-            "value": "esc",
-            "trace": {
-              "def": {
-                "environment": "a",
-                "begin": {
-                  "line": 2,
-                  "column": 21,
-                  "byte": 28
-                },
-                "end": {
-                  "line": 2,
-                  "column": 24,
-                  "byte": 31
-                }
+          "end": {
+            "line": 10,
+            "column": 18,
+            "byte": 130
+          }
+        }
+      }
+    },
+    {
+      "value": "world",
+      "trace": {
+        "def": {
+          "environment": "\u003cyaml\u003e",
+          "begin": {
+            "line": 10,
+            "column": 20,
+            "byte": 132
+          },
+          "end": {
+            "line": 10,
+            "column": 25,
+            "byte": 137
+          }
+        }
+      }
+    }
+  ],
+  "trace": {
+    "def": {
+      "environment": "\u003cyaml\u003e",
+      "begin": {
+        "line": 10,
+        "column": 12,
+        "byte": 124
+      },
+      "end": {
+        "line": 10,
+        "column": 25,
+        "byte": 137
+      }
+    }
+  }
+}
+> esc env get default/test --value detailed array[0]
+{
+  "value": "hello",
+  "trace": {
+    "def": {
+      "environment": "\u003cyaml\u003e",
+      "begin": {
+        "line": 10,
+        "column": 13,
+        "byte": 125
+      },
+      "end": {
+        "line": 10,
+        "column": 18,
+        "byte": 130
+      }
+    }
+  }
+}
+> esc env get default/test --value detailed array[1]
+{
+  "value": "world",
+  "trace": {
+    "def": {
+      "environment": "\u003cyaml\u003e",
+      "begin": {
+        "line": 10,
+        "column": 20,
+        "byte": 132
+      },
+      "end": {
+        "line": 10,
+        "column": 25,
+        "byte": 137
+      }
+    }
+  }
+}
+> esc env get default/test --value detailed object
+{
+  "value": {
+    "goodbye": {
+      "value": "all",
+      "trace": {
+        "def": {
+          "environment": "b",
+          "begin": {
+            "line": 3,
+            "column": 23,
+            "byte": 46
+          },
+          "end": {
+            "line": 3,
+            "column": 26,
+            "byte": 49
+          }
+        },
+        "base": {
+          "value": "world",
+          "trace": {
+            "def": {
+              "environment": "a",
+              "begin": {
+                "line": 2,
+                "column": 35,
+                "byte": 42
+              },
+              "end": {
+                "line": 2,
+                "column": 40,
+                "byte": 47
               }
             }
           }
         }
       }
     },
-    "trace": {
-      "def": {
-        "environment": "\u003cyaml\u003e",
-        "begin": {
-          "line": 11,
-          "column": 13,
-          "byte": 151
+    "hello": {
+      "value": "world",
+      "trace": {
+        "def": {
+          "environment": "\u003cyaml\u003e",
+          "begin": {
+            "line": 11,
+            "column": 21,
+            "byte": 159
+          },
+          "end": {
+            "line": 11,
+            "column": 26,
+            "byte": 164
+          }
         },
-        "end": {
-          "line": 11,
-          "column": 26,
-          "byte": 164
+        "base": {
+          "value": "esc",
+          "trace": {
+            "def": {
+              "environment": "a",
+              "begin": {
+                "line": 2,
+                "column": 21,
+                "byte": 28
+              },
+              "end": {
+                "line": 2,
+                "column": 24,
+                "byte": 31
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "trace": {
+    "def": {
+      "environment": "\u003cyaml\u003e",
+      "begin": {
+        "line": 11,
+        "column": 13,
+        "byte": 151
+      },
+      "end": {
+        "line": 11,
+        "column": 26,
+        "byte": 164
+      }
+    },
+    "base": {
+      "value": {
+        "goodbye": {
+          "value": "all",
+          "trace": {
+            "def": {
+              "environment": "b",
+              "begin": {
+                "line": 3,
+                "column": 23,
+                "byte": 46
+              },
+              "end": {
+                "line": 3,
+                "column": 26,
+                "byte": 49
+              }
+            },
+            "base": {
+              "value": "world",
+              "trace": {
+                "def": {
+                  "environment": "a",
+                  "begin": {
+                    "line": 2,
+                    "column": 35,
+                    "byte": 42
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 40,
+                    "byte": 47
+                  }
+                }
+              }
+            }
+          }
+        },
+        "hello": {
+          "value": "esc",
+          "trace": {
+            "def": {
+              "environment": "a",
+              "begin": {
+                "line": 2,
+                "column": 21,
+                "byte": 28
+              },
+              "end": {
+                "line": 2,
+                "column": 24,
+                "byte": 31
+              }
+            }
+          }
         }
       },
-      "base": {
-        "value": {
-          "goodbye": {
-            "value": "all",
-            "trace": {
-              "def": {
-                "environment": "b",
-                "begin": {
-                  "line": 3,
-                  "column": 23,
-                  "byte": 46
-                },
-                "end": {
-                  "line": 3,
-                  "column": 26,
-                  "byte": 49
+      "trace": {
+        "def": {
+          "environment": "b",
+          "begin": {
+            "line": 3,
+            "column": 13,
+            "byte": 36
+          },
+          "end": {
+            "line": 3,
+            "column": 26,
+            "byte": 49
+          }
+        },
+        "base": {
+          "value": {
+            "goodbye": {
+              "value": "world",
+              "trace": {
+                "def": {
+                  "environment": "a",
+                  "begin": {
+                    "line": 2,
+                    "column": 35,
+                    "byte": 42
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 40,
+                    "byte": 47
+                  }
                 }
-              },
-              "base": {
-                "value": "world",
-                "trace": {
-                  "def": {
-                    "environment": "a",
-                    "begin": {
-                      "line": 2,
-                      "column": 35,
-                      "byte": 42
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 40,
-                      "byte": 47
-                    }
+              }
+            },
+            "hello": {
+              "value": "esc",
+              "trace": {
+                "def": {
+                  "environment": "a",
+                  "begin": {
+                    "line": 2,
+                    "column": 21,
+                    "byte": 28
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 24,
+                    "byte": 31
                   }
                 }
               }
             }
           },
-          "hello": {
-            "value": "esc",
-            "trace": {
-              "def": {
-                "environment": "a",
-                "begin": {
-                  "line": 2,
-                  "column": 21,
-                  "byte": 28
-                },
-                "end": {
-                  "line": 2,
-                  "column": 24,
-                  "byte": 31
-                }
-              }
-            }
-          }
-        },
-        "trace": {
-          "def": {
-            "environment": "b",
-            "begin": {
-              "line": 3,
-              "column": 13,
-              "byte": 36
-            },
-            "end": {
-              "line": 3,
-              "column": 26,
-              "byte": 49
-            }
-          },
-          "base": {
-            "value": {
-              "goodbye": {
-                "value": "world",
-                "trace": {
-                  "def": {
-                    "environment": "a",
-                    "begin": {
-                      "line": 2,
-                      "column": 35,
-                      "byte": 42
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 40,
-                      "byte": 47
-                    }
-                  }
-                }
+          "trace": {
+            "def": {
+              "environment": "a",
+              "begin": {
+                "line": 2,
+                "column": 13,
+                "byte": 20
               },
-              "hello": {
-                "value": "esc",
-                "trace": {
-                  "def": {
-                    "environment": "a",
-                    "begin": {
-                      "line": 2,
-                      "column": 21,
-                      "byte": 28
-                    },
-                    "end": {
-                      "line": 2,
-                      "column": 24,
-                      "byte": 31
-                    }
-                  }
-                }
-              }
-            },
-            "trace": {
-              "def": {
-                "environment": "a",
-                "begin": {
-                  "line": 2,
-                  "column": 13,
-                  "byte": 20
-                },
-                "end": {
-                  "line": 2,
-                  "column": 40,
-                  "byte": 47
-                }
+              "end": {
+                "line": 2,
+                "column": 40,
+                "byte": 47
               }
             }
           }
@@ -440,108 +440,110 @@ stdout: |
       }
     }
   }
-  > esc env get default/test --value detailed object.hello
-  {
-    "value": "world",
-    "trace": {
-      "def": {
-        "environment": "\u003cyaml\u003e",
-        "begin": {
-          "line": 11,
-          "column": 21,
-          "byte": 159
-        },
-        "end": {
-          "line": 11,
-          "column": 26,
-          "byte": 164
-        }
+}
+> esc env get default/test --value detailed object.hello
+{
+  "value": "world",
+  "trace": {
+    "def": {
+      "environment": "\u003cyaml\u003e",
+      "begin": {
+        "line": 11,
+        "column": 21,
+        "byte": 159
       },
-      "base": {
-        "value": "esc",
-        "trace": {
-          "def": {
-            "environment": "a",
-            "begin": {
-              "line": 2,
-              "column": 21,
-              "byte": 28
-            },
-            "end": {
-              "line": 2,
-              "column": 24,
-              "byte": 31
-            }
+      "end": {
+        "line": 11,
+        "column": 26,
+        "byte": 164
+      }
+    },
+    "base": {
+      "value": "esc",
+      "trace": {
+        "def": {
+          "environment": "a",
+          "begin": {
+            "line": 2,
+            "column": 21,
+            "byte": 28
+          },
+          "end": {
+            "line": 2,
+            "column": 24,
+            "byte": 31
           }
         }
       }
     }
   }
-  > esc env get default/test --value detailed object.goodbye
-  {
-    "value": "all",
-    "trace": {
-      "def": {
-        "environment": "b",
-        "begin": {
-          "line": 3,
-          "column": 23,
-          "byte": 46
-        },
-        "end": {
-          "line": 3,
-          "column": 26,
-          "byte": 49
-        }
+}
+> esc env get default/test --value detailed object.goodbye
+{
+  "value": "all",
+  "trace": {
+    "def": {
+      "environment": "b",
+      "begin": {
+        "line": 3,
+        "column": 23,
+        "byte": 46
       },
-      "base": {
-        "value": "world",
-        "trace": {
-          "def": {
-            "environment": "a",
-            "begin": {
-              "line": 2,
-              "column": 35,
-              "byte": 42
-            },
-            "end": {
-              "line": 2,
-              "column": 40,
-              "byte": 47
-            }
+      "end": {
+        "line": 3,
+        "column": 26,
+        "byte": 49
+      }
+    },
+    "base": {
+      "value": "world",
+      "trace": {
+        "def": {
+          "environment": "a",
+          "begin": {
+            "line": 2,
+            "column": 35,
+            "byte": 42
+          },
+          "end": {
+            "line": 2,
+            "column": 40,
+            "byte": 47
           }
         }
       }
     }
   }
-  > esc env get default/test --value detailed open
-  {
-    "unknown": true,
-    "trace": {
-      "def": {
-        "environment": "\u003cyaml\u003e",
-        "begin": {
-          "line": 13,
-          "column": 9,
-          "byte": 184
-        },
-        "end": {
-          "line": 13,
-          "column": 29,
-          "byte": 204
-        }
+}
+> esc env get default/test --value detailed open
+{
+  "unknown": true,
+  "trace": {
+    "def": {
+      "environment": "\u003cyaml\u003e",
+      "begin": {
+        "line": 13,
+        "column": 9,
+        "byte": 184
+      },
+      "end": {
+        "line": 13,
+        "column": 29,
+        "byte": 204
       }
     }
   }
-stderr: |
-  > esc env get default/test --value detailed null
-  > esc env get default/test --value detailed boolean
-  > esc env get default/test --value detailed number
-  > esc env get default/test --value detailed string
-  > esc env get default/test --value detailed array
-  > esc env get default/test --value detailed array[0]
-  > esc env get default/test --value detailed array[1]
-  > esc env get default/test --value detailed object
-  > esc env get default/test --value detailed object.hello
-  > esc env get default/test --value detailed object.goodbye
-  > esc env get default/test --value detailed open
+}
+
+---
+> esc env get default/test --value detailed null
+> esc env get default/test --value detailed boolean
+> esc env get default/test --value detailed number
+> esc env get default/test --value detailed string
+> esc env get default/test --value detailed array
+> esc env get default/test --value detailed array[0]
+> esc env get default/test --value detailed array[1]
+> esc env get default/test --value detailed object
+> esc env get default/test --value detailed object.hello
+> esc env get default/test --value detailed object.goodbye
+> esc env get default/test --value detailed open

--- a/cmd/esc/cli/testdata/env-get-each-value-json.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-value-json.yaml
@@ -32,44 +32,46 @@ environments:
       object: {hello: world}
       open:
         fn::open::test: echo
-stdout: |
-  > esc env get default/test --value json null
-  null
-  > esc env get default/test --value json boolean
-  true
-  > esc env get default/test --value json number
-  42
-  > esc env get default/test --value json string
-  "esc"
-  > esc env get default/test --value json array
-  [
-    "hello",
-    "world"
-  ]
-  > esc env get default/test --value json array[0]
-  "hello"
-  > esc env get default/test --value json array[1]
+
+---
+> esc env get default/test --value json null
+null
+> esc env get default/test --value json boolean
+true
+> esc env get default/test --value json number
+42
+> esc env get default/test --value json string
+"esc"
+> esc env get default/test --value json array
+[
+  "hello",
   "world"
-  > esc env get default/test --value json object
-  {
-    "goodbye": "all",
-    "hello": "world"
-  }
-  > esc env get default/test --value json object.hello
-  "world"
-  > esc env get default/test --value json object.goodbye
-  "all"
-  > esc env get default/test --value json open
-  "[unknown]"
-stderr: |
-  > esc env get default/test --value json null
-  > esc env get default/test --value json boolean
-  > esc env get default/test --value json number
-  > esc env get default/test --value json string
-  > esc env get default/test --value json array
-  > esc env get default/test --value json array[0]
-  > esc env get default/test --value json array[1]
-  > esc env get default/test --value json object
-  > esc env get default/test --value json object.hello
-  > esc env get default/test --value json object.goodbye
-  > esc env get default/test --value json open
+]
+> esc env get default/test --value json array[0]
+"hello"
+> esc env get default/test --value json array[1]
+"world"
+> esc env get default/test --value json object
+{
+  "goodbye": "all",
+  "hello": "world"
+}
+> esc env get default/test --value json object.hello
+"world"
+> esc env get default/test --value json object.goodbye
+"all"
+> esc env get default/test --value json open
+"[unknown]"
+
+---
+> esc env get default/test --value json null
+> esc env get default/test --value json boolean
+> esc env get default/test --value json number
+> esc env get default/test --value json string
+> esc env get default/test --value json array
+> esc env get default/test --value json array[0]
+> esc env get default/test --value json array[1]
+> esc env get default/test --value json object
+> esc env get default/test --value json object.hello
+> esc env get default/test --value json object.goodbye
+> esc env get default/test --value json open

--- a/cmd/esc/cli/testdata/env-get-each-value-string.yaml
+++ b/cmd/esc/cli/testdata/env-get-each-value-string.yaml
@@ -32,37 +32,39 @@ environments:
       object: {hello: world}
       open:
         fn::open::test: echo
-stdout: |
-  "> esc env get default/test --value string null"
-  > esc env get default/test --value string boolean
-  true
-  > esc env get default/test --value string number
-  42
-  > esc env get default/test --value string string
-  esc
-  > esc env get default/test --value string array
-  "hello","world"
-  > esc env get default/test --value string array[0]
-  hello
-  > esc env get default/test --value string array[1]
-  world
-  > esc env get default/test --value string object
-  "goodbye"="all","hello"="world"
-  > esc env get default/test --value string object.hello
-  world
-  > esc env get default/test --value string object.goodbye
-  all
-  > esc env get default/test --value string open
-  [unknown]
-stderr: |
-  > esc env get default/test --value string null
-  > esc env get default/test --value string boolean
-  > esc env get default/test --value string number
-  > esc env get default/test --value string string
-  > esc env get default/test --value string array
-  > esc env get default/test --value string array[0]
-  > esc env get default/test --value string array[1]
-  > esc env get default/test --value string object
-  > esc env get default/test --value string object.hello
-  > esc env get default/test --value string object.goodbye
-  > esc env get default/test --value string open
+
+---
+"> esc env get default/test --value string null"
+> esc env get default/test --value string boolean
+true
+> esc env get default/test --value string number
+42
+> esc env get default/test --value string string
+esc
+> esc env get default/test --value string array
+"hello","world"
+> esc env get default/test --value string array[0]
+hello
+> esc env get default/test --value string array[1]
+world
+> esc env get default/test --value string object
+"goodbye"="all","hello"="world"
+> esc env get default/test --value string object.hello
+world
+> esc env get default/test --value string object.goodbye
+all
+> esc env get default/test --value string open
+[unknown]
+
+---
+> esc env get default/test --value string null
+> esc env get default/test --value string boolean
+> esc env get default/test --value string number
+> esc env get default/test --value string string
+> esc env get default/test --value string array
+> esc env get default/test --value string array[0]
+> esc env get default/test --value string array[1]
+> esc env get default/test --value string object
+> esc env get default/test --value string object.hello
+> esc env get default/test --value string object.goodbye
+> esc env get default/test --value string open

--- a/cmd/esc/cli/testdata/env-get-each.yaml
+++ b/cmd/esc/cli/testdata/env-get-each.yaml
@@ -35,198 +35,200 @@ environments:
       open:
         fn::open::test:
           foo: bar
-stdout: |+
-  > esc env get default/test null
-  # Value
-  ```json
-  null
-  ```
-  # Definition
-  ```yaml
-  null
 
-  ```
+---
+> esc env get default/test null
+# Value
+```json
+null
+```
+# Definition
+```yaml
+null
 
-  # Defined at
-  - test:6:13
+```
 
-  > esc env get default/test boolean
-  # Value
-  ```json
-  true
-  ```
-  # Definition
-  ```yaml
-  true
+# Defined at
+- test:6:13
 
-  ```
+> esc env get default/test boolean
+# Value
+```json
+true
+```
+# Definition
+```yaml
+true
 
-  # Defined at
-  - test:7:14
+```
 
-  > esc env get default/test number
-  # Value
-  ```json
-  42
-  ```
-  # Definition
-  ```yaml
-  42
+# Defined at
+- test:7:14
 
-  ```
+> esc env get default/test number
+# Value
+```json
+42
+```
+# Definition
+```yaml
+42
 
-  # Defined at
-  - test:8:13
+```
 
-  > esc env get default/test string
-  # Value
-  ```json
-  "esc"
-  ```
-  # Definition
-  ```yaml
-  esc
+# Defined at
+- test:8:13
 
-  ```
+> esc env get default/test string
+# Value
+```json
+"esc"
+```
+# Definition
+```yaml
+esc
 
-  # Defined at
-  - test:9:13
-  - b:2:13
+```
 
-  > esc env get default/test array
-  # Value
-  ```json
-  [
-    "hello",
-    "world"
-  ]
-  ```
-  # Definition
-  ```yaml
-  [hello, world]
+# Defined at
+- test:9:13
+- b:2:13
 
-  ```
-
-  # Defined at
-  - test:10:12
-
-  > esc env get default/test array[0]
-  # Value
-  ```json
-  "hello"
-  ```
-  # Definition
-  ```yaml
-  hello
-
-  ```
-
-  # Defined at
-  - test:10:13
-
-  > esc env get default/test array[1]
-  # Value
-  ```json
+> esc env get default/test array
+# Value
+```json
+[
+  "hello",
   "world"
-  ```
-  # Definition
-  ```yaml
-  world
+]
+```
+# Definition
+```yaml
+[hello, world]
 
-  ```
+```
 
-  # Defined at
-  - test:10:20
+# Defined at
+- test:10:12
 
-  > esc env get default/test object
-  # Value
-  ```json
-  {
-    "goodbye": "all",
-    "hello": "world"
-  }
-  ```
-  # Definition
-  ```yaml
-  {hello: world}
+> esc env get default/test array[0]
+# Value
+```json
+"hello"
+```
+# Definition
+```yaml
+hello
 
-  ```
+```
 
-  # Defined at
-  - test:11:13
-  - b:3:13
+# Defined at
+- test:10:13
 
-  > esc env get default/test object.hello
-  # Value
-  ```json
-  "world"
-  ```
-  # Definition
-  ```yaml
-  world
+> esc env get default/test array[1]
+# Value
+```json
+"world"
+```
+# Definition
+```yaml
+world
 
-  ```
+```
 
-  # Defined at
-  - test:11:21
-  - a:2:21
+# Defined at
+- test:10:20
 
-  > esc env get default/test object.goodbye
-  # Value
-  ```json
-  "all"
-  ```
+> esc env get default/test object
+# Value
+```json
+{
+  "goodbye": "all",
+  "hello": "world"
+}
+```
+# Definition
+```yaml
+{hello: world}
 
-  # Defined at
-  - b:3:23
-  - a:2:35
+```
 
-  > esc env get default/test open
-  # Value
-  ```json
-  "[unknown]"
-  ```
-  # Definition
-  ```yaml
-  fn::open::test:
-    foo: bar
+# Defined at
+- test:11:13
+- b:3:13
 
-  ```
+> esc env get default/test object.hello
+# Value
+```json
+"world"
+```
+# Definition
+```yaml
+world
 
-  # Defined at
-  - test:13:9
+```
 
-  > esc env get default/test open["fn::open::test"]
-  # Definition
-  ```yaml
+# Defined at
+- test:11:21
+- a:2:21
+
+> esc env get default/test object.goodbye
+# Value
+```json
+"all"
+```
+
+# Defined at
+- b:3:23
+- a:2:35
+
+> esc env get default/test open
+# Value
+```json
+"[unknown]"
+```
+# Definition
+```yaml
+fn::open::test:
   foo: bar
 
-  ```
+```
 
-  # Defined at
-  - test:14:13
+# Defined at
+- test:13:9
 
-  > esc env get default/test open["fn::open::test"].foo
-  # Definition
-  ```yaml
-  bar
+> esc env get default/test open["fn::open::test"]
+# Definition
+```yaml
+foo: bar
 
-  ```
+```
 
-  # Defined at
-  - test:14:18
+# Defined at
+- test:14:13
 
-stderr: |
-  > esc env get default/test null
-  > esc env get default/test boolean
-  > esc env get default/test number
-  > esc env get default/test string
-  > esc env get default/test array
-  > esc env get default/test array[0]
-  > esc env get default/test array[1]
-  > esc env get default/test object
-  > esc env get default/test object.hello
-  > esc env get default/test object.goodbye
-  > esc env get default/test open
-  > esc env get default/test open["fn::open::test"]
-  > esc env get default/test open["fn::open::test"].foo
+> esc env get default/test open["fn::open::test"].foo
+# Definition
+```yaml
+bar
+
+```
+
+# Defined at
+- test:14:18
+
+
+---
+> esc env get default/test null
+> esc env get default/test boolean
+> esc env get default/test number
+> esc env get default/test string
+> esc env get default/test array
+> esc env get default/test array[0]
+> esc env get default/test array[1]
+> esc env get default/test object
+> esc env get default/test object.hello
+> esc env get default/test object.goodbye
+> esc env get default/test open
+> esc env get default/test open["fn::open::test"]
+> esc env get default/test open["fn::open::test"].foo

--- a/cmd/esc/cli/testdata/env-init-conflict.yaml
+++ b/cmd/esc/cli/testdata/env-init-conflict.yaml
@@ -2,8 +2,10 @@ run: esc env init default/dup
 error: exit status 1
 environments:
   test-user/default/dup: arbitrary
-stdout: |
-  > esc env init default/dup
-stderr: |
-  > esc env init default/dup
-  Error: creating environment: already exists
+
+---
+> esc env init default/dup
+
+---
+> esc env init default/dup
+Error: creating environment: already exists

--- a/cmd/esc/cli/testdata/env-init-diags.yaml
+++ b/cmd/esc/cli/testdata/env-init-diags.yaml
@@ -2,14 +2,16 @@ run: |
   echo '{"values":{"foo":"${bar}"}}' | esc env init default/test-stdin -f=-
   esc env get default/test-stdin
 error: exit status 1
-stdout: |
-  > esc env init default/test-stdin -f=-
-  Environment created: test-user/default/test-stdin
-stderr: |
-  > esc env init default/test-stdin -f=-
-  Error: unknown property "bar"
 
-    on test-stdin line 1:
-     1: {"values":{"foo":"${bar}"}}
+---
+> esc env init default/test-stdin -f=-
+Environment created: test-user/default/test-stdin
 
-  Error: updating environment definition: too many errors
+---
+> esc env init default/test-stdin -f=-
+Error: unknown property "bar"
+
+  on test-stdin line 1:
+   1: {"values":{"foo":"${bar}"}}
+
+Error: updating environment definition: too many errors

--- a/cmd/esc/cli/testdata/env-init-ok.yaml
+++ b/cmd/esc/cli/testdata/env-init-ok.yaml
@@ -6,45 +6,47 @@ run: |
   echo '{"values":{"foo":"bar"}}' >def.yaml
   esc env init default/test-file -f def.yaml
   esc env get default/test-file
-stdout: |+
-  > esc env init default/test-env
-  Environment created: test-user/default/test-env
-  > esc env get default/test-env
 
-  > esc env init default/test-stdin -f=-
-  Environment created: test-user/default/test-stdin
-  > esc env get default/test-stdin
-  # Value
-  ```json
-  {
-    "foo": "bar"
-  }
-  ```
-  # Definition
-  ```yaml
-  {"values": {"foo": "bar"}}
+---
+> esc env init default/test-env
+Environment created: test-user/default/test-env
+> esc env get default/test-env
 
-  ```
+> esc env init default/test-stdin -f=-
+Environment created: test-user/default/test-stdin
+> esc env get default/test-stdin
+# Value
+```json
+{
+  "foo": "bar"
+}
+```
+# Definition
+```yaml
+{"values": {"foo": "bar"}}
 
-  > esc env init default/test-file -f def.yaml
-  Environment created: test-user/default/test-file
-  > esc env get default/test-file
-  # Value
-  ```json
-  {
-    "foo": "bar"
-  }
-  ```
-  # Definition
-  ```yaml
-  {"values": {"foo": "bar"}}
+```
 
-  ```
+> esc env init default/test-file -f def.yaml
+Environment created: test-user/default/test-file
+> esc env get default/test-file
+# Value
+```json
+{
+  "foo": "bar"
+}
+```
+# Definition
+```yaml
+{"values": {"foo": "bar"}}
 
-stderr: |
-  > esc env init default/test-env
-  > esc env get default/test-env
-  > esc env init default/test-stdin -f=-
-  > esc env get default/test-stdin
-  > esc env init default/test-file -f def.yaml
-  > esc env get default/test-file
+```
+
+
+---
+> esc env init default/test-env
+> esc env get default/test-env
+> esc env init default/test-stdin -f=-
+> esc env get default/test-stdin
+> esc env init default/test-file -f def.yaml
+> esc env get default/test-file

--- a/cmd/esc/cli/testdata/env-init-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-init-revision-or-tag.yaml
@@ -2,11 +2,13 @@ run: |
   (esc env init default/test-env@1 || exit 0)
   esc env init default/test-env@foo
 error: exit status 1
-stdout: |
-  > esc env init default/test-env@1
-  > esc env init default/test-env@foo
-stderr: |
-  > esc env init default/test-env@1
-  Error: the init command does not accept versions
-  > esc env init default/test-env@foo
-  Error: the init command does not accept versions
+
+---
+> esc env init default/test-env@1
+> esc env init default/test-env@foo
+
+---
+> esc env init default/test-env@1
+Error: the init command does not accept versions
+> esc env init default/test-env@foo
+Error: the init command does not accept versions

--- a/cmd/esc/cli/testdata/env-init-warning.yaml
+++ b/cmd/esc/cli/testdata/env-init-warning.yaml
@@ -1,9 +1,11 @@
 run: |
   esc env init test-env
-stdout: |+
-  > esc env init test-env
-  Environment created: test-user/default/test-env
-stderr: |
-  > esc env init test-env
-  Warning: Referring to an environment name ('test-env') without a project is deprecated.
-  Please use 'test-user/default/test-env' or 'default/test-env' instead.
+
+---
+> esc env init test-env
+Environment created: test-user/default/test-env
+
+---
+> esc env init test-env
+Warning: Referring to an environment name ('test-env') without a project is deprecated.
+Please use 'test-user/default/test-env' or 'default/test-env' instead.

--- a/cmd/esc/cli/testdata/env-login-gh100.yaml
+++ b/cmd/esc/cli/testdata/env-login-gh100.yaml
@@ -1,24 +1,24 @@
-# This is a regression default/test for #100 that aims to capture issues logging in when no existing Pulumi
-# credentials exist.
 run: |
   esc logout --all
   esc login
   esc env ls
   esc logout
   esc logout
-stdout: |
-  > esc logout --all
-  Logged out of all clouds
-  > esc login
-  Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
-  > esc env ls
-  > esc logout
-  Logged out of https://api.pulumi.com
-  > esc logout
-  Already logged out.
-stderr: |
-  > esc logout --all
-  > esc login
-  > esc env ls
-  > esc logout
-  > esc logout
+
+---
+> esc logout --all
+Logged out of all clouds
+> esc login
+Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
+> esc env ls
+> esc logout
+Logged out of https://api.pulumi.com
+> esc logout
+Already logged out.
+
+---
+> esc logout --all
+> esc login
+> esc env ls
+> esc logout
+> esc logout

--- a/cmd/esc/cli/testdata/env-ls.yaml
+++ b/cmd/esc/cli/testdata/env-ls.yaml
@@ -5,12 +5,14 @@ environments:
   test-org/default/env-2: true
   test-user/default/env: true
   test-user/default/env-2: true
-stdout: |
-  > esc env ls
-  default/env
-  default/env-2
-  test-org/default/env
-  test-org/default/env-2
-  test-org-2/default/env
-stderr: |
-  > esc env ls
+
+---
+> esc env ls
+default/env
+default/env-2
+test-org/default/env
+test-org/default/env-2
+test-org-2/default/env
+
+---
+> esc env ls

--- a/cmd/esc/cli/testdata/env-rm-each.yaml
+++ b/cmd/esc/cli/testdata/env-rm-each.yaml
@@ -34,350 +34,352 @@ environments:
         fn::open::test:
           foo: bar
           baz: qux
-stdout: |+
-  > esc env rm default/test null
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "world"
-    ],
-    "boolean": true,
-    "number": 42,
-    "object": {
-      "goodbye": "all",
-      "hello": "world"
-    },
-    "open": "[unknown]",
-    "string": "esc"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    boolean: true
-    number: 42
-    string: esc
-    array: [hello, world]
-    object: {hello: world}
-    open:
-      fn::open::test:
-        foo: bar
-        baz: qux
 
-  ```
+---
+> esc env rm default/test null
+> esc env get default/test
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "world"
+  ],
+  "boolean": true,
+  "number": 42,
+  "object": {
+    "goodbye": "all",
+    "hello": "world"
+  },
+  "open": "[unknown]",
+  "string": "esc"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  boolean: true
+  number: 42
+  string: esc
+  array: [hello, world]
+  object: {hello: world}
+  open:
+    fn::open::test:
+      foo: bar
+      baz: qux
 
-  > esc env rm default/test boolean
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "world"
-    ],
-    "number": 42,
-    "object": {
-      "goodbye": "all",
-      "hello": "world"
-    },
-    "open": "[unknown]",
-    "string": "esc"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    number: 42
-    string: esc
-    array: [hello, world]
-    object: {hello: world}
-    open:
-      fn::open::test:
-        foo: bar
-        baz: qux
+```
 
-  ```
+> esc env rm default/test boolean
+> esc env get default/test
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "world"
+  ],
+  "number": 42,
+  "object": {
+    "goodbye": "all",
+    "hello": "world"
+  },
+  "open": "[unknown]",
+  "string": "esc"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  number: 42
+  string: esc
+  array: [hello, world]
+  object: {hello: world}
+  open:
+    fn::open::test:
+      foo: bar
+      baz: qux
 
-  > esc env rm default/test number
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "world"
-    ],
-    "object": {
-      "goodbye": "all",
-      "hello": "world"
-    },
-    "open": "[unknown]",
-    "string": "esc"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    string: esc
-    array: [hello, world]
-    object: {hello: world}
-    open:
-      fn::open::test:
-        foo: bar
-        baz: qux
+```
 
-  ```
+> esc env rm default/test number
+> esc env get default/test
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "world"
+  ],
+  "object": {
+    "goodbye": "all",
+    "hello": "world"
+  },
+  "open": "[unknown]",
+  "string": "esc"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  string: esc
+  array: [hello, world]
+  object: {hello: world}
+  open:
+    fn::open::test:
+      foo: bar
+      baz: qux
 
-  > esc env rm default/test string
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "world"
-    ],
-    "object": {
-      "goodbye": "all",
-      "hello": "world"
-    },
-    "open": "[unknown]",
-    "string": "foo"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    array: [hello, world]
-    object: {hello: world}
-    open:
-      fn::open::test:
-        foo: bar
-        baz: qux
+```
 
-  ```
+> esc env rm default/test string
+> esc env get default/test
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "world"
+  ],
+  "object": {
+    "goodbye": "all",
+    "hello": "world"
+  },
+  "open": "[unknown]",
+  "string": "foo"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  array: [hello, world]
+  object: {hello: world}
+  open:
+    fn::open::test:
+      foo: bar
+      baz: qux
 
-  > esc env rm default/test array[1]
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "array": [
-      "hello"
-    ],
-    "object": {
-      "goodbye": "all",
-      "hello": "world"
-    },
-    "open": "[unknown]",
-    "string": "foo"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    array: [hello]
-    object: {hello: world}
-    open:
-      fn::open::test:
-        foo: bar
-        baz: qux
+```
 
-  ```
+> esc env rm default/test array[1]
+> esc env get default/test
+# Value
+```json
+{
+  "array": [
+    "hello"
+  ],
+  "object": {
+    "goodbye": "all",
+    "hello": "world"
+  },
+  "open": "[unknown]",
+  "string": "foo"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  array: [hello]
+  object: {hello: world}
+  open:
+    fn::open::test:
+      foo: bar
+      baz: qux
 
-  > esc env rm default/test array[0]
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "array": [],
-    "object": {
-      "goodbye": "all",
-      "hello": "world"
-    },
-    "open": "[unknown]",
-    "string": "foo"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    array: []
-    object: {hello: world}
-    open:
-      fn::open::test:
-        foo: bar
-        baz: qux
+```
 
-  ```
+> esc env rm default/test array[0]
+> esc env get default/test
+# Value
+```json
+{
+  "array": [],
+  "object": {
+    "goodbye": "all",
+    "hello": "world"
+  },
+  "open": "[unknown]",
+  "string": "foo"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  array: []
+  object: {hello: world}
+  open:
+    fn::open::test:
+      foo: bar
+      baz: qux
 
-  > esc env rm default/test array
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "object": {
-      "goodbye": "all",
-      "hello": "world"
-    },
-    "open": "[unknown]",
-    "string": "foo"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    object: {hello: world}
-    open:
-      fn::open::test:
-        foo: bar
-        baz: qux
+```
 
-  ```
+> esc env rm default/test array
+> esc env get default/test
+# Value
+```json
+{
+  "object": {
+    "goodbye": "all",
+    "hello": "world"
+  },
+  "open": "[unknown]",
+  "string": "foo"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  object: {hello: world}
+  open:
+    fn::open::test:
+      foo: bar
+      baz: qux
 
-  > esc env rm default/test object.hello
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "object": {
-      "goodbye": "all",
-      "hello": "esc"
-    },
-    "open": "[unknown]",
-    "string": "foo"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    object: {}
-    open:
-      fn::open::test:
-        foo: bar
-        baz: qux
+```
 
-  ```
+> esc env rm default/test object.hello
+> esc env get default/test
+# Value
+```json
+{
+  "object": {
+    "goodbye": "all",
+    "hello": "esc"
+  },
+  "open": "[unknown]",
+  "string": "foo"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  object: {}
+  open:
+    fn::open::test:
+      foo: bar
+      baz: qux
 
-  > esc env rm default/test object
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "object": {
-      "goodbye": "all",
-      "hello": "esc"
-    },
-    "open": "[unknown]",
-    "string": "foo"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    open:
-      fn::open::test:
-        foo: bar
-        baz: qux
+```
 
-  ```
+> esc env rm default/test object
+> esc env get default/test
+# Value
+```json
+{
+  "object": {
+    "goodbye": "all",
+    "hello": "esc"
+  },
+  "open": "[unknown]",
+  "string": "foo"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  open:
+    fn::open::test:
+      foo: bar
+      baz: qux
 
-  > esc env rm default/test open["fn::open::test"].foo
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "object": {
-      "goodbye": "all",
-      "hello": "esc"
-    },
-    "open": "[unknown]",
-    "string": "foo"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values:
-    open:
-      fn::open::test:
-        baz: qux
+```
 
-  ```
+> esc env rm default/test open["fn::open::test"].foo
+> esc env get default/test
+# Value
+```json
+{
+  "object": {
+    "goodbye": "all",
+    "hello": "esc"
+  },
+  "open": "[unknown]",
+  "string": "foo"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values:
+  open:
+    fn::open::test:
+      baz: qux
 
-  > esc env rm default/test open
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "object": {
-      "goodbye": "all",
-      "hello": "esc"
-    },
-    "string": "foo"
-  }
-  ```
-  # Definition
-  ```yaml
-  imports:
-    - a
-    - b
-  values: {}
+```
 
-  ```
+> esc env rm default/test open
+> esc env get default/test
+# Value
+```json
+{
+  "object": {
+    "goodbye": "all",
+    "hello": "esc"
+  },
+  "string": "foo"
+}
+```
+# Definition
+```yaml
+imports:
+  - a
+  - b
+values: {}
 
-stderr: |
-  > esc env rm default/test null
-  > esc env get default/test
-  > esc env rm default/test boolean
-  > esc env get default/test
-  > esc env rm default/test number
-  > esc env get default/test
-  > esc env rm default/test string
-  > esc env get default/test
-  > esc env rm default/test array[1]
-  > esc env get default/test
-  > esc env rm default/test array[0]
-  > esc env get default/test
-  > esc env rm default/test array
-  > esc env get default/test
-  > esc env rm default/test object.hello
-  > esc env get default/test
-  > esc env rm default/test object
-  > esc env get default/test
-  > esc env rm default/test open["fn::open::test"].foo
-  > esc env get default/test
-  > esc env rm default/test open
-  > esc env get default/test
+```
+
+
+---
+> esc env rm default/test null
+> esc env get default/test
+> esc env rm default/test boolean
+> esc env get default/test
+> esc env rm default/test number
+> esc env get default/test
+> esc env rm default/test string
+> esc env get default/test
+> esc env rm default/test array[1]
+> esc env get default/test
+> esc env rm default/test array[0]
+> esc env get default/test
+> esc env rm default/test array
+> esc env get default/test
+> esc env rm default/test object.hello
+> esc env get default/test
+> esc env rm default/test object
+> esc env get default/test
+> esc env rm default/test open["fn::open::test"].foo
+> esc env get default/test
+> esc env rm default/test open
+> esc env get default/test

--- a/cmd/esc/cli/testdata/env-rm-not-found.yaml
+++ b/cmd/esc/cli/testdata/env-rm-not-found.yaml
@@ -1,7 +1,9 @@
 run: esc env rm default/dup -y
 error: exit status 1
-stdout: |
-  > esc env rm default/dup -y
-stderr: |
-  > esc env rm default/dup -y
-  Error: not found
+
+---
+> esc env rm default/dup -y
+
+---
+> esc env rm default/dup -y
+Error: not found

--- a/cmd/esc/cli/testdata/env-rm-ok.yaml
+++ b/cmd/esc/cli/testdata/env-rm-ok.yaml
@@ -1,8 +1,10 @@
 run: esc env rm default/dup -y
 environments:
   test-user/default/dup: arbitrary
-stdout: |
-  > esc env rm default/dup -y
-  Environment "test-user/default/dup" has been removed!
-stderr: |
-  > esc env rm default/dup -y
+
+---
+> esc env rm default/dup -y
+Environment "test-user/default/dup" has been removed!
+
+---
+> esc env rm default/dup -y

--- a/cmd/esc/cli/testdata/env-rm-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-rm-revision-or-tag.yaml
@@ -2,11 +2,13 @@ run: |
   (esc env rm default/dup@1 -y || exit 0)
   esc env rm default/dup@foo -y
 error: exit status 1
-stdout: |
-  > esc env rm default/dup@1 -y
-  > esc env rm default/dup@foo -y
-stderr: |
-  > esc env rm default/dup@1 -y
-  Error: the rm command does not accept versions
-  > esc env rm default/dup@foo -y
-  Error: the rm command does not accept versions
+
+---
+> esc env rm default/dup@1 -y
+> esc env rm default/dup@foo -y
+
+---
+> esc env rm default/dup@1 -y
+Error: the rm command does not accept versions
+> esc env rm default/dup@foo -y
+Error: the rm command does not accept versions

--- a/cmd/esc/cli/testdata/env-set-invalid.yaml
+++ b/cmd/esc/cli/testdata/env-set-invalid.yaml
@@ -6,23 +6,25 @@ run: |
   esc env set default/test string.bar baz || echo -n ""
   esc env set default/test 'object[0]' foo || echo -n ""
   esc env set default/test array.foo bar || echo -n ""
-stdout: |
-  > esc env init default/test
-  Environment created: test-user/default/test
-  > esc env set default/test string foo
-  > esc env set default/test object {}
-  > esc env set default/test array []
-  > esc env set default/test string.bar baz
-  > esc env set default/test object[0] foo
-  > esc env set default/test array.foo bar
-stderr: |
-  > esc env init default/test
-  > esc env set default/test string foo
-  > esc env set default/test object {}
-  > esc env set default/test array []
-  > esc env set default/test string.bar baz
-  Error: string.bar: expected an array or an object
-  > esc env set default/test object[0] foo
-  Error: object[0]: key for a map must be a string
-  > esc env set default/test array.foo bar
-  Error: array.foo: key for an array must be an int
+
+---
+> esc env init default/test
+Environment created: test-user/default/test
+> esc env set default/test string foo
+> esc env set default/test object {}
+> esc env set default/test array []
+> esc env set default/test string.bar baz
+> esc env set default/test object[0] foo
+> esc env set default/test array.foo bar
+
+---
+> esc env init default/test
+> esc env set default/test string foo
+> esc env set default/test object {}
+> esc env set default/test array []
+> esc env set default/test string.bar baz
+Error: string.bar: expected an array or an object
+> esc env set default/test object[0] foo
+Error: object[0]: key for a map must be a string
+> esc env set default/test array.foo bar
+Error: array.foo: key for an array must be an int

--- a/cmd/esc/cli/testdata/env-set-revision-or-tag.yaml
+++ b/cmd/esc/cli/testdata/env-set-revision-or-tag.yaml
@@ -2,11 +2,13 @@ run: |
   (esc env set default/test@1 string foo || exit 0)
   esc env set default/test@foo string foo
 error: exit status 1
-stdout: |
-  > esc env set default/test@1 string foo
-  > esc env set default/test@foo string foo
-stderr: |
-  > esc env set default/test@1 string foo
-  Error: the set command does not accept versions
-  > esc env set default/test@foo string foo
-  Error: the set command does not accept versions
+
+---
+> esc env set default/test@1 string foo
+> esc env set default/test@foo string foo
+
+---
+> esc env set default/test@1 string foo
+Error: the set command does not accept versions
+> esc env set default/test@foo string foo
+Error: the set command does not accept versions

--- a/cmd/esc/cli/testdata/env-set-secret-error.yaml
+++ b/cmd/esc/cli/testdata/env-set-secret-error.yaml
@@ -2,11 +2,13 @@ run: |
   esc env init default/test
   esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
 error: exit status 1
-stdout: |
-  > esc env init default/test
-  Environment created: test-user/default/test
-  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
-stderr: |
-  > esc env init default/test
-  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
-  Error: value looks like a secret; rerun with --secret to mark it as such, or --plaintext if you meant to leave it as plaintext
+
+---
+> esc env init default/test
+Environment created: test-user/default/test
+> esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+
+---
+> esc env init default/test
+> esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+Error: value looks like a secret; rerun with --secret to mark it as such, or --plaintext if you meant to leave it as plaintext

--- a/cmd/esc/cli/testdata/env-set-secret.yaml
+++ b/cmd/esc/cli/testdata/env-set-secret.yaml
@@ -17,174 +17,176 @@ run: |
   esc env set default/test password true --secret
   esc env get default/test
   esc env set default/test password '[]' --secret || echo OK
-stdout: |
-  > esc env init default/test
-  Environment created: test-user/default/test
-  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
-  OK
-  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "password": "[secret]"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    password:
-      fn::secret:
-        ciphertext: ZXNjeAAAAAHZzcjk7+e21uvV8eLW07XkwcXy+Nflzfm4s/K0yOXC5c7S5MX11cb3y7PNve6n0kM=
 
-  ```
+---
+> esc env init default/test
+Environment created: test-user/default/test
+> esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+OK
+> esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret
+> esc env get default/test
+# Value
+```json
+{
+  "password": "[secret]"
+}
+```
+# Definition
+```yaml
+values:
+  password:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAHZzcjk7+e21uvV8eLW07XkwcXy+Nflzfm4s/K0yOXC5c7S5MX11cb3y7PNve6n0kM=
 
-  > esc env get default/test password
-  # Value
-  ```json
-  "[secret]"
-  ```
-  # Definition
-  ```yaml
-  fn::secret:
-    ciphertext: ZXNjeAAAAAHZzcjk7+e21uvV8eLW07XkwcXy+Nflzfm4s/K0yOXC5c7S5MX11cb3y7PNve6n0kM=
+```
 
-  ```
+> esc env get default/test password
+# Value
+```json
+"[secret]"
+```
+# Definition
+```yaml
+fn::secret:
+  ciphertext: ZXNjeAAAAAHZzcjk7+e21uvV8eLW07XkwcXy+Nflzfm4s/K0yOXC5c7S5MX11cb3y7PNve6n0kM=
 
-  # Defined at
-  - test:3:5
+```
 
-  > esc env get default/test --show-secrets
-  # Value
-  ```json
-  {
-    "password": "YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M="
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    password:
-      fn::secret: YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+# Defined at
+- test:3:5
 
-  ```
+> esc env get default/test --show-secrets
+# Value
+```json
+{
+  "password": "YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M="
+}
+```
+# Definition
+```yaml
+values:
+  password:
+    fn::secret: YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
 
-  > esc env get default/test password --show-secrets
-  # Value
-  ```json
-  "YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M="
-  ```
-  # Definition
-  ```yaml
-  fn::secret: YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+```
 
-  ```
+> esc env get default/test password --show-secrets
+# Value
+```json
+"YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M="
+```
+# Definition
+```yaml
+fn::secret: YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
 
-  # Defined at
-  - test:3:5
+```
 
-  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "password": "YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M="
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    password: YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+# Defined at
+- test:3:5
 
-  ```
+> esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
+> esc env get default/test
+# Value
+```json
+{
+  "password": "YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M="
+}
+```
+# Definition
+```yaml
+values:
+  password: YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
 
-  > esc env set default/test password 1234 --secret
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "password": "[secret]"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    password:
-      fn::secret:
-        ciphertext: ZXNjeAAAAAGxsrO0gN+X5A==
+```
 
-  ```
+> esc env set default/test password 1234 --secret
+> esc env get default/test
+# Value
+```json
+{
+  "password": "[secret]"
+}
+```
+# Definition
+```yaml
+values:
+  password:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAGxsrO0gN+X5A==
 
-  > esc env set default/test password 123.4 --secret
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "password": "[secret]"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    password:
-      fn::secret:
-        ciphertext: ZXNjeAAAAAGxsrOutAnEmzU=
+```
 
-  ```
+> esc env set default/test password 123.4 --secret
+> esc env get default/test
+# Value
+```json
+{
+  "password": "[secret]"
+}
+```
+# Definition
+```yaml
+values:
+  password:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAGxsrOutAnEmzU=
 
-  > esc env set default/test password false --secret
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "password": "[secret]"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    password:
-      fn::secret:
-        ciphertext: ZXNjeAAAAAHm4ezz5S7WA1Q=
+```
 
-  ```
+> esc env set default/test password false --secret
+> esc env get default/test
+# Value
+```json
+{
+  "password": "[secret]"
+}
+```
+# Definition
+```yaml
+values:
+  password:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAHm4ezz5S7WA1Q=
 
-  > esc env set default/test password true --secret
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "password": "[secret]"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    password:
-      fn::secret:
-        ciphertext: ZXNjeAAAAAH08vXl5sA7yg==
+```
 
-  ```
+> esc env set default/test password true --secret
+> esc env get default/test
+# Value
+```json
+{
+  "password": "[secret]"
+}
+```
+# Definition
+```yaml
+values:
+  password:
+    fn::secret:
+      ciphertext: ZXNjeAAAAAH08vXl5sA7yg==
 
-  > esc env set default/test password [] --secret
-stderr: |
-  > esc env init default/test
-  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
-  Error: value looks like a secret; rerun with --secret to mark it as such, or --plaintext if you meant to leave it as plaintext
-  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret
-  > esc env get default/test
-  > esc env get default/test password
-  > esc env get default/test --show-secrets
-  > esc env get default/test password --show-secrets
-  > esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
-  > esc env get default/test
-  > esc env set default/test password 1234 --secret
-  > esc env get default/test
-  > esc env set default/test password 123.4 --secret
-  > esc env get default/test
-  > esc env set default/test password false --secret
-  > esc env get default/test
-  > esc env set default/test password true --secret
-  > esc env get default/test
-  > esc env set default/test password [] --secret
-  test:3:21: secret values must be string literals
+```
+
+> esc env set default/test password [] --secret
+
+---
+> esc env init default/test
+> esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M=
+Error: value looks like a secret; rerun with --secret to mark it as such, or --plaintext if you meant to leave it as plaintext
+> esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --secret
+> esc env get default/test
+> esc env get default/test password
+> esc env get default/test --show-secrets
+> esc env get default/test password --show-secrets
+> esc env set default/test password YMHdog6VkUqbVS5dAErxWeMy83r4HeBeNRdEuUFwK3M= --plaintext
+> esc env get default/test
+> esc env set default/test password 1234 --secret
+> esc env get default/test
+> esc env set default/test password 123.4 --secret
+> esc env get default/test
+> esc env set default/test password false --secret
+> esc env get default/test
+> esc env set default/test password true --secret
+> esc env get default/test
+> esc env set default/test password [] --secret
+test:3:21: secret values must be string literals

--- a/cmd/esc/cli/testdata/env-set.yaml
+++ b/cmd/esc/cli/testdata/env-set.yaml
@@ -15,511 +15,513 @@ run: |
   esc env set default/test 'imports[0]' default/test2 && esc env get default/test
   esc env init default/test3
   esc env set default/test 'imports[1]' default/test3 && esc env get default/test
-stdout: |+
-  > esc env init default/test
-  Environment created: test-user/default/test
-  > esc env set default/test foo.bar.baz qux
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": {
-      "bar": {
-        "baz": "qux"
-      }
+
+---
+> esc env init default/test
+Environment created: test-user/default/test
+> esc env set default/test foo.bar.baz qux
+> esc env get default/test
+# Value
+```json
+{
+  "foo": {
+    "bar": {
+      "baz": "qux"
     }
   }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo:
-      bar:
-        baz: qux
+}
+```
+# Definition
+```yaml
+values:
+  foo:
+    bar:
+      baz: qux
 
-  ```
+```
 
-  > esc env set default/test foo.bar.alpha zed
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": {
-      "bar": {
-        "alpha": "zed",
-        "baz": "qux"
-      }
+> esc env set default/test foo.bar.alpha zed
+> esc env get default/test
+# Value
+```json
+{
+  "foo": {
+    "bar": {
+      "alpha": "zed",
+      "baz": "qux"
     }
   }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo:
-      bar:
-        baz: qux
-        alpha: zed
+}
+```
+# Definition
+```yaml
+values:
+  foo:
+    bar:
+      baz: qux
+      alpha: zed
 
-  ```
+```
 
-  > esc env set default/test foo.beta[0] gamma
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": {
-      "bar": {
-        "alpha": "zed",
-        "baz": "qux"
-      },
-      "beta": [
-        "gamma"
-      ]
+> esc env set default/test foo.beta[0] gamma
+> esc env get default/test
+# Value
+```json
+{
+  "foo": {
+    "bar": {
+      "alpha": "zed",
+      "baz": "qux"
+    },
+    "beta": [
+      "gamma"
+    ]
+  }
+}
+```
+# Definition
+```yaml
+values:
+  foo:
+    bar:
+      baz: qux
+      alpha: zed
+    beta:
+      - gamma
+
+```
+
+> esc env set default/test foo.beta[1] 42
+> esc env get default/test
+# Value
+```json
+{
+  "foo": {
+    "bar": {
+      "alpha": "zed",
+      "baz": "qux"
+    },
+    "beta": [
+      "gamma",
+      42
+    ]
+  }
+}
+```
+# Definition
+```yaml
+values:
+  foo:
+    bar:
+      baz: qux
+      alpha: zed
+    beta:
+      - gamma
+      - 42
+
+```
+
+> esc env set default/test open {"fn::open::test": "esc"}
+> esc env get default/test
+# Value
+```json
+{
+  "foo": {
+    "bar": {
+      "alpha": "zed",
+      "baz": "qux"
+    },
+    "beta": [
+      "gamma",
+      42
+    ]
+  },
+  "open": "[unknown]"
+}
+```
+# Definition
+```yaml
+values:
+  foo:
+    bar:
+      baz: qux
+      alpha: zed
+    beta:
+      - gamma
+      - 42
+  open:
+    "fn::open::test": "esc"
+
+```
+
+> esc env set default/test open["fn::open::test"] cse
+> esc env get default/test
+# Value
+```json
+{
+  "foo": {
+    "bar": {
+      "alpha": "zed",
+      "baz": "qux"
+    },
+    "beta": [
+      "gamma",
+      42
+    ]
+  },
+  "open": "[unknown]"
+}
+```
+# Definition
+```yaml
+values:
+  foo:
+    bar:
+      baz: qux
+      alpha: zed
+    beta:
+      - gamma
+      - 42
+  open:
+    "fn::open::test": "cse"
+
+```
+
+> esc env set default/test array [hello, world]
+> esc env get default/test
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "world"
+  ],
+  "foo": {
+    "bar": {
+      "alpha": "zed",
+      "baz": "qux"
+    },
+    "beta": [
+      "gamma",
+      42
+    ]
+  },
+  "open": "[unknown]"
+}
+```
+# Definition
+```yaml
+values:
+  foo:
+    bar:
+      baz: qux
+      alpha: zed
+    beta:
+      - gamma
+      - 42
+  open:
+    "fn::open::test": "cse"
+  array:
+    - hello
+    - world
+
+```
+
+> esc env set default/test array[1] esc
+> esc env get default/test
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "esc"
+  ],
+  "foo": {
+    "bar": {
+      "alpha": "zed",
+      "baz": "qux"
+    },
+    "beta": [
+      "gamma",
+      42
+    ]
+  },
+  "open": "[unknown]"
+}
+```
+# Definition
+```yaml
+values:
+  foo:
+    bar:
+      baz: qux
+      alpha: zed
+    beta:
+      - gamma
+      - 42
+  open:
+    "fn::open::test": "cse"
+  array:
+    - hello
+    - esc
+
+```
+
+> esc env set default/test array[2] {}
+> esc env get default/test
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "esc",
+    {}
+  ],
+  "foo": {
+    "bar": {
+      "alpha": "zed",
+      "baz": "qux"
+    },
+    "beta": [
+      "gamma",
+      42
+    ]
+  },
+  "open": "[unknown]"
+}
+```
+# Definition
+```yaml
+values:
+  foo:
+    bar:
+      baz: qux
+      alpha: zed
+    beta:
+      - gamma
+      - 42
+  open:
+    "fn::open::test": "cse"
+  array:
+    - hello
+    - esc
+    - {}
+
+```
+
+> esc env set default/test array[2].foo bar
+> esc env get default/test
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "esc",
+    {
+      "foo": "bar"
     }
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo:
-      bar:
-        baz: qux
-        alpha: zed
-      beta:
-        - gamma
+  ],
+  "foo": {
+    "bar": {
+      "alpha": "zed",
+      "baz": "qux"
+    },
+    "beta": [
+      "gamma",
+      42
+    ]
+  },
+  "open": "[unknown]"
+}
+```
+# Definition
+```yaml
+values:
+  foo:
+    bar:
+      baz: qux
+      alpha: zed
+    beta:
+      - gamma
+      - 42
+  open:
+    "fn::open::test": "cse"
+  array:
+    - hello
+    - esc
+    - {foo: bar}
 
-  ```
+```
 
-  > esc env set default/test foo.beta[1] 42
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": {
-      "bar": {
-        "alpha": "zed",
-        "baz": "qux"
-      },
-      "beta": [
-        "gamma",
-        42
-      ]
+> esc env set default/test array[2].foo 
+> esc env get default/test
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "esc",
+    {
+      "foo": ""
     }
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo:
-      bar:
-        baz: qux
-        alpha: zed
-      beta:
-        - gamma
-        - 42
-
-  ```
-
-  > esc env set default/test open {"fn::open::test": "esc"}
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": {
-      "bar": {
-        "alpha": "zed",
-        "baz": "qux"
-      },
-      "beta": [
-        "gamma",
-        42
-      ]
+  ],
+  "foo": {
+    "bar": {
+      "alpha": "zed",
+      "baz": "qux"
     },
-    "open": "[unknown]"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo:
-      bar:
-        baz: qux
-        alpha: zed
-      beta:
-        - gamma
-        - 42
-    open:
-      "fn::open::test": "esc"
+    "beta": [
+      "gamma",
+      42
+    ]
+  },
+  "open": "[unknown]"
+}
+```
+# Definition
+```yaml
+values:
+  foo:
+    bar:
+      baz: qux
+      alpha: zed
+    beta:
+      - gamma
+      - 42
+  open:
+    "fn::open::test": "cse"
+  array:
+    - hello
+    - esc
+    - {foo: ""}
 
-  ```
+```
 
-  > esc env set default/test open["fn::open::test"] cse
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "foo": {
-      "bar": {
-        "alpha": "zed",
-        "baz": "qux"
-      },
-      "beta": [
-        "gamma",
-        42
-      ]
+> esc env init default/test2
+Environment created: test-user/default/test2
+> esc env set default/test imports[0] default/test2
+> esc env get default/test
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "esc",
+    {
+      "foo": ""
+    }
+  ],
+  "foo": {
+    "bar": {
+      "alpha": "zed",
+      "baz": "qux"
     },
-    "open": "[unknown]"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo:
-      bar:
-        baz: qux
-        alpha: zed
-      beta:
-        - gamma
-        - 42
-    open:
-      "fn::open::test": "cse"
+    "beta": [
+      "gamma",
+      42
+    ]
+  },
+  "open": "[unknown]"
+}
+```
+# Definition
+```yaml
+values:
+  foo:
+    bar:
+      baz: qux
+      alpha: zed
+    beta:
+      - gamma
+      - 42
+  open:
+    "fn::open::test": "cse"
+  array:
+    - hello
+    - esc
+    - {foo: ""}
+imports:
+  - default/test2
 
-  ```
+```
 
-  > esc env set default/test array [hello, world]
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "world"
-    ],
-    "foo": {
-      "bar": {
-        "alpha": "zed",
-        "baz": "qux"
-      },
-      "beta": [
-        "gamma",
-        42
-      ]
+> esc env init default/test3
+Environment created: test-user/default/test3
+> esc env set default/test imports[1] default/test3
+> esc env get default/test
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "esc",
+    {
+      "foo": ""
+    }
+  ],
+  "foo": {
+    "bar": {
+      "alpha": "zed",
+      "baz": "qux"
     },
-    "open": "[unknown]"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo:
-      bar:
-        baz: qux
-        alpha: zed
-      beta:
-        - gamma
-        - 42
-    open:
-      "fn::open::test": "cse"
-    array:
-      - hello
-      - world
+    "beta": [
+      "gamma",
+      42
+    ]
+  },
+  "open": "[unknown]"
+}
+```
+# Definition
+```yaml
+values:
+  foo:
+    bar:
+      baz: qux
+      alpha: zed
+    beta:
+      - gamma
+      - 42
+  open:
+    "fn::open::test": "cse"
+  array:
+    - hello
+    - esc
+    - {foo: ""}
+imports:
+  - default/test2
+  - default/test3
 
-  ```
+```
 
-  > esc env set default/test array[1] esc
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "esc"
-    ],
-    "foo": {
-      "bar": {
-        "alpha": "zed",
-        "baz": "qux"
-      },
-      "beta": [
-        "gamma",
-        42
-      ]
-    },
-    "open": "[unknown]"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo:
-      bar:
-        baz: qux
-        alpha: zed
-      beta:
-        - gamma
-        - 42
-    open:
-      "fn::open::test": "cse"
-    array:
-      - hello
-      - esc
 
-  ```
-
-  > esc env set default/test array[2] {}
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "esc",
-      {}
-    ],
-    "foo": {
-      "bar": {
-        "alpha": "zed",
-        "baz": "qux"
-      },
-      "beta": [
-        "gamma",
-        42
-      ]
-    },
-    "open": "[unknown]"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo:
-      bar:
-        baz: qux
-        alpha: zed
-      beta:
-        - gamma
-        - 42
-    open:
-      "fn::open::test": "cse"
-    array:
-      - hello
-      - esc
-      - {}
-
-  ```
-
-  > esc env set default/test array[2].foo bar
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "esc",
-      {
-        "foo": "bar"
-      }
-    ],
-    "foo": {
-      "bar": {
-        "alpha": "zed",
-        "baz": "qux"
-      },
-      "beta": [
-        "gamma",
-        42
-      ]
-    },
-    "open": "[unknown]"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo:
-      bar:
-        baz: qux
-        alpha: zed
-      beta:
-        - gamma
-        - 42
-    open:
-      "fn::open::test": "cse"
-    array:
-      - hello
-      - esc
-      - {foo: bar}
-
-  ```
-
-  > esc env set default/test array[2].foo 
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "esc",
-      {
-        "foo": ""
-      }
-    ],
-    "foo": {
-      "bar": {
-        "alpha": "zed",
-        "baz": "qux"
-      },
-      "beta": [
-        "gamma",
-        42
-      ]
-    },
-    "open": "[unknown]"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo:
-      bar:
-        baz: qux
-        alpha: zed
-      beta:
-        - gamma
-        - 42
-    open:
-      "fn::open::test": "cse"
-    array:
-      - hello
-      - esc
-      - {foo: ""}
-
-  ```
-
-  > esc env init default/test2
-  Environment created: test-user/default/test2
-  > esc env set default/test imports[0] default/test2
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "esc",
-      {
-        "foo": ""
-      }
-    ],
-    "foo": {
-      "bar": {
-        "alpha": "zed",
-        "baz": "qux"
-      },
-      "beta": [
-        "gamma",
-        42
-      ]
-    },
-    "open": "[unknown]"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo:
-      bar:
-        baz: qux
-        alpha: zed
-      beta:
-        - gamma
-        - 42
-    open:
-      "fn::open::test": "cse"
-    array:
-      - hello
-      - esc
-      - {foo: ""}
-  imports:
-    - default/test2
-
-  ```
-
-  > esc env init default/test3
-  Environment created: test-user/default/test3
-  > esc env set default/test imports[1] default/test3
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "array": [
-      "hello",
-      "esc",
-      {
-        "foo": ""
-      }
-    ],
-    "foo": {
-      "bar": {
-        "alpha": "zed",
-        "baz": "qux"
-      },
-      "beta": [
-        "gamma",
-        42
-      ]
-    },
-    "open": "[unknown]"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    foo:
-      bar:
-        baz: qux
-        alpha: zed
-      beta:
-        - gamma
-        - 42
-    open:
-      "fn::open::test": "cse"
-    array:
-      - hello
-      - esc
-      - {foo: ""}
-  imports:
-    - default/test2
-    - default/test3
-
-  ```
-
-stderr: |
-  > esc env init default/test
-  > esc env set default/test foo.bar.baz qux
-  > esc env get default/test
-  > esc env set default/test foo.bar.alpha zed
-  > esc env get default/test
-  > esc env set default/test foo.beta[0] gamma
-  > esc env get default/test
-  > esc env set default/test foo.beta[1] 42
-  > esc env get default/test
-  > esc env set default/test open {"fn::open::test": "esc"}
-  > esc env get default/test
-  > esc env set default/test open["fn::open::test"] cse
-  > esc env get default/test
-  > esc env set default/test array [hello, world]
-  > esc env get default/test
-  > esc env set default/test array[1] esc
-  > esc env get default/test
-  > esc env set default/test array[2] {}
-  > esc env get default/test
-  > esc env set default/test array[2].foo bar
-  > esc env get default/test
-  > esc env set default/test array[2].foo 
-  > esc env get default/test
-  > esc env init default/test2
-  > esc env set default/test imports[0] default/test2
-  > esc env get default/test
-  > esc env init default/test3
-  > esc env set default/test imports[1] default/test3
-  > esc env get default/test
+---
+> esc env init default/test
+> esc env set default/test foo.bar.baz qux
+> esc env get default/test
+> esc env set default/test foo.bar.alpha zed
+> esc env get default/test
+> esc env set default/test foo.beta[0] gamma
+> esc env get default/test
+> esc env set default/test foo.beta[1] 42
+> esc env get default/test
+> esc env set default/test open {"fn::open::test": "esc"}
+> esc env get default/test
+> esc env set default/test open["fn::open::test"] cse
+> esc env get default/test
+> esc env set default/test array [hello, world]
+> esc env get default/test
+> esc env set default/test array[1] esc
+> esc env get default/test
+> esc env set default/test array[2] {}
+> esc env get default/test
+> esc env set default/test array[2].foo bar
+> esc env get default/test
+> esc env set default/test array[2].foo 
+> esc env get default/test
+> esc env init default/test2
+> esc env set default/test imports[0] default/test2
+> esc env get default/test
+> esc env init default/test3
+> esc env set default/test imports[1] default/test3
+> esc env get default/test

--- a/cmd/esc/cli/testdata/env-tag-arg-err.yaml
+++ b/cmd/esc/cli/testdata/env-tag-arg-err.yaml
@@ -4,10 +4,12 @@ run: |
 error: exit status 1
 environments:
   test-org/default/env: {}
-stdout: |
-  > esc env tag ls test-org/default/env
-  > esc env tag test-org/default/env owner
-stderr: |
-  > esc env tag ls test-org/default/env
-  > esc env tag test-org/default/env owner
-  Error: accepts 3 arg(s), received 2
+
+---
+> esc env tag ls test-org/default/env
+> esc env tag test-org/default/env owner
+
+---
+> esc env tag ls test-org/default/env
+> esc env tag test-org/default/env owner
+Error: accepts 3 arg(s), received 2

--- a/cmd/esc/cli/testdata/env-tag-empty-err.yaml
+++ b/cmd/esc/cli/testdata/env-tag-empty-err.yaml
@@ -2,5 +2,10 @@ run: esc env tag test-org/default/env "" ""
 error: exit status 1
 environments:
   test-org/default/env: {}
-stdout: "> esc env tag test-org/default/env  \n"
-stderr: "> esc env tag test-org/default/env  \nError: environment tag name cannot be empty\n"
+
+---
+> esc env tag test-org/default/env  
+
+---
+> esc env tag test-org/default/env  
+Error: environment tag name cannot be empty

--- a/cmd/esc/cli/testdata/env-tag-ls.yaml
+++ b/cmd/esc/cli/testdata/env-tag-ls.yaml
@@ -14,20 +14,22 @@ environments:
   test-user/default/unused:
     tags:
       owner: pulumipus
-stdout: |
-  > esc env tag ls test-org/default/one-tag --utc
-  Name: owner
-  Value: pulumi
-  Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag ls test-org/default/no-tags --utc
-  > esc env tag ls test-user/default/multi-tags --utc
-  Name: owner
-  Value: pulumipus
-  Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  Name: team
-  Value: esc
-  Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-stderr: |
-  > esc env tag ls test-org/default/one-tag --utc
-  > esc env tag ls test-org/default/no-tags --utc
-  > esc env tag ls test-user/default/multi-tags --utc
+
+---
+> esc env tag ls test-org/default/one-tag --utc
+Name: owner
+Value: pulumi
+Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
+> esc env tag ls test-org/default/no-tags --utc
+> esc env tag ls test-user/default/multi-tags --utc
+Name: owner
+Value: pulumipus
+Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
+Name: team
+Value: esc
+Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
+
+---
+> esc env tag ls test-org/default/one-tag --utc
+> esc env tag ls test-org/default/no-tags --utc
+> esc env tag ls test-user/default/multi-tags --utc

--- a/cmd/esc/cli/testdata/env-tag-mv.yaml
+++ b/cmd/esc/cli/testdata/env-tag-mv.yaml
@@ -8,23 +8,25 @@ environments:
   test-org/default/env:
     tags:
       team: pulumi
-stdout: |
-  > esc env tag ls test-org/default/env --utc
-  Name: team
-  Value: pulumi
-  Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag mv test-org/default/env team owner --utc
-  Name: owner
-  Value: pulumi
-  Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag get test-org/default/env owner --utc
-  Name: owner
-  Value: pulumi
-  Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag mv test-org/default/env team --utc
-stderr: |
-  > esc env tag ls test-org/default/env --utc
-  > esc env tag mv test-org/default/env team owner --utc
-  > esc env tag get test-org/default/env owner --utc
-  > esc env tag mv test-org/default/env team --utc
-  Error: accepts 3 arg(s), received 2
+
+---
+> esc env tag ls test-org/default/env --utc
+Name: team
+Value: pulumi
+Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
+> esc env tag mv test-org/default/env team owner --utc
+Name: owner
+Value: pulumi
+Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
+> esc env tag get test-org/default/env owner --utc
+Name: owner
+Value: pulumi
+Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
+> esc env tag mv test-org/default/env team --utc
+
+---
+> esc env tag ls test-org/default/env --utc
+> esc env tag mv test-org/default/env team owner --utc
+> esc env tag get test-org/default/env owner --utc
+> esc env tag mv test-org/default/env team --utc
+Error: accepts 3 arg(s), received 2

--- a/cmd/esc/cli/testdata/env-tag-rm.yaml
+++ b/cmd/esc/cli/testdata/env-tag-rm.yaml
@@ -8,18 +8,20 @@ environments:
   test-org/default/env:
     tags:
       owner: pulumi
-stdout: |
-  > esc env tag ls test-org/default/env --utc
-  Name: owner
-  Value: pulumi
-  Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag rm test-org/default/env owner
-  Successfully deleted environment tag: owner
-  > esc env tag ls test-org/default/env --utc
-  > esc env tag rm test-org/default/env owner
-stderr: |
-  > esc env tag ls test-org/default/env --utc
-  > esc env tag rm test-org/default/env owner
-  > esc env tag ls test-org/default/env --utc
-  > esc env tag rm test-org/default/env owner
-  Error: tag not found
+
+---
+> esc env tag ls test-org/default/env --utc
+Name: owner
+Value: pulumi
+Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
+> esc env tag rm test-org/default/env owner
+Successfully deleted environment tag: owner
+> esc env tag ls test-org/default/env --utc
+> esc env tag rm test-org/default/env owner
+
+---
+> esc env tag ls test-org/default/env --utc
+> esc env tag rm test-org/default/env owner
+> esc env tag ls test-org/default/env --utc
+> esc env tag rm test-org/default/env owner
+Error: tag not found

--- a/cmd/esc/cli/testdata/env-tag.yaml
+++ b/cmd/esc/cli/testdata/env-tag.yaml
@@ -8,33 +8,35 @@ environments:
   test-org/default/env:
     tags:
       team: esc
-stdout: |
-  > esc env tag ls test-org/default/env --utc
-  Name: team
-  Value: esc
-  Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag test-org/default/env owner pulumi --utc
-  Name: owner
-  Value: pulumi
-  Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag get test-org/default/env owner --utc
-  Name: owner
-  Value: pulumi
-  Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag test-org/default/env team esc-team --utc
-  Name: team
-  Value: esc-team
-  Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  > esc env tag ls test-org/default/env --utc
-  Name: owner
-  Value: pulumi
-  Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-  Name: team
-  Value: esc-team
-  Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
-stderr: |
-  > esc env tag ls test-org/default/env --utc
-  > esc env tag test-org/default/env owner pulumi --utc
-  > esc env tag get test-org/default/env owner --utc
-  > esc env tag test-org/default/env team esc-team --utc
-  > esc env tag ls test-org/default/env --utc
+
+---
+> esc env tag ls test-org/default/env --utc
+Name: team
+Value: esc
+Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
+> esc env tag test-org/default/env owner pulumi --utc
+Name: owner
+Value: pulumi
+Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
+> esc env tag get test-org/default/env owner --utc
+Name: owner
+Value: pulumi
+Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
+> esc env tag test-org/default/env team esc-team --utc
+Name: team
+Value: esc-team
+Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
+> esc env tag ls test-org/default/env --utc
+Name: owner
+Value: pulumi
+Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
+Name: team
+Value: esc-team
+Last updated at 2024-07-29 12:30:00 +0000 UTC by pulumipus <pulumipus>
+
+---
+> esc env tag ls test-org/default/env --utc
+> esc env tag test-org/default/env owner pulumi --utc
+> esc env tag get test-org/default/env owner --utc
+> esc env tag test-org/default/env team esc-team --utc
+> esc env tag ls test-org/default/env --utc

--- a/cmd/esc/cli/testdata/env-version-history.yaml
+++ b/cmd/esc/cli/testdata/env-version-history.yaml
@@ -41,135 +41,137 @@ environments:
             secret:
               fn::secret:
                 ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
-stdout: |+
-  > esc env version history default/test --utc
-  revision 5
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 05:00:00 +0000 UTC
 
-  revision 4 (tag: stable)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 04:00:00 +0000 UTC
+---
+> esc env version history default/test --utc
+revision 5
+Author: Test Tester <test-tester>
+Date:   1970-01-01 05:00:00 +0000 UTC
 
-  revision 3 (retracted)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 03:00:00 +0000 UTC
+revision 4 (tag: stable)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 04:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 3.
+revision 3 (retracted)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 03:00:00 +0000 UTC
 
-      leaked secret
+    Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 3.
 
-  revision 2
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 02:00:00 +0000 UTC
+    leaked secret
 
-  revision 1
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 01:00:00 +0000 UTC
+revision 2
+Author: Test Tester <test-tester>
+Date:   1970-01-01 02:00:00 +0000 UTC
 
-  > esc env version history default/test@latest --utc
-  revision 5
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 05:00:00 +0000 UTC
+revision 1
+Author: Test Tester <test-tester>
+Date:   1970-01-01 01:00:00 +0000 UTC
 
-  revision 4 (tag: stable)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 04:00:00 +0000 UTC
+> esc env version history default/test@latest --utc
+revision 5
+Author: Test Tester <test-tester>
+Date:   1970-01-01 05:00:00 +0000 UTC
 
-  revision 3 (retracted)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 03:00:00 +0000 UTC
+revision 4 (tag: stable)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 04:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 3.
+revision 3 (retracted)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 03:00:00 +0000 UTC
 
-      leaked secret
+    Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 3.
 
-  revision 2
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 02:00:00 +0000 UTC
+    leaked secret
 
-  revision 1
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 01:00:00 +0000 UTC
+revision 2
+Author: Test Tester <test-tester>
+Date:   1970-01-01 02:00:00 +0000 UTC
 
-  > esc env version history default/test@stable --utc
-  revision 4 (tag: stable)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 04:00:00 +0000 UTC
+revision 1
+Author: Test Tester <test-tester>
+Date:   1970-01-01 01:00:00 +0000 UTC
 
-  revision 3 (retracted)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 03:00:00 +0000 UTC
+> esc env version history default/test@stable --utc
+revision 4 (tag: stable)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 04:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 3.
+revision 3 (retracted)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 03:00:00 +0000 UTC
 
-      leaked secret
+    Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 3.
 
-  revision 2
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 02:00:00 +0000 UTC
+    leaked secret
 
-  revision 1
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 01:00:00 +0000 UTC
+revision 2
+Author: Test Tester <test-tester>
+Date:   1970-01-01 02:00:00 +0000 UTC
 
-  > esc env version history default/test@1 --utc
-  revision 1
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 01:00:00 +0000 UTC
+revision 1
+Author: Test Tester <test-tester>
+Date:   1970-01-01 01:00:00 +0000 UTC
 
-  > esc env version history default/test@2 --utc
-  revision 2
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 02:00:00 +0000 UTC
+> esc env version history default/test@1 --utc
+revision 1
+Author: Test Tester <test-tester>
+Date:   1970-01-01 01:00:00 +0000 UTC
 
-  revision 1
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 01:00:00 +0000 UTC
+> esc env version history default/test@2 --utc
+revision 2
+Author: Test Tester <test-tester>
+Date:   1970-01-01 02:00:00 +0000 UTC
 
-  > esc env version history default/test@3 --utc
-  revision 3 (retracted)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 03:00:00 +0000 UTC
+revision 1
+Author: Test Tester <test-tester>
+Date:   1970-01-01 01:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 3.
+> esc env version history default/test@3 --utc
+revision 3 (retracted)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 03:00:00 +0000 UTC
 
-      leaked secret
+    Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 3.
 
-  revision 2
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 02:00:00 +0000 UTC
+    leaked secret
 
-  revision 1
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 01:00:00 +0000 UTC
+revision 2
+Author: Test Tester <test-tester>
+Date:   1970-01-01 02:00:00 +0000 UTC
 
-  > esc env version history default/test@4 --utc
-  revision 4 (tag: stable)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 04:00:00 +0000 UTC
+revision 1
+Author: Test Tester <test-tester>
+Date:   1970-01-01 01:00:00 +0000 UTC
 
-  revision 3 (retracted)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 03:00:00 +0000 UTC
+> esc env version history default/test@4 --utc
+revision 4 (tag: stable)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 04:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 3.
+revision 3 (retracted)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 03:00:00 +0000 UTC
 
-      leaked secret
+    Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 3.
 
-  revision 2
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 02:00:00 +0000 UTC
+    leaked secret
 
-  revision 1
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 01:00:00 +0000 UTC
+revision 2
+Author: Test Tester <test-tester>
+Date:   1970-01-01 02:00:00 +0000 UTC
 
-stderr: |
-  > esc env version history default/test --utc
-  > esc env version history default/test@latest --utc
-  > esc env version history default/test@stable --utc
-  > esc env version history default/test@1 --utc
-  > esc env version history default/test@2 --utc
-  > esc env version history default/test@3 --utc
-  > esc env version history default/test@4 --utc
+revision 1
+Author: Test Tester <test-tester>
+Date:   1970-01-01 01:00:00 +0000 UTC
+
+
+---
+> esc env version history default/test --utc
+> esc env version history default/test@latest --utc
+> esc env version history default/test@stable --utc
+> esc env version history default/test@1 --utc
+> esc env version history default/test@2 --utc
+> esc env version history default/test@3 --utc
+> esc env version history default/test@4 --utc

--- a/cmd/esc/cli/testdata/env-version-retract.yaml
+++ b/cmd/esc/cli/testdata/env-version-retract.yaml
@@ -21,121 +21,123 @@ environments:
       - yaml:
           vaues:
             goodbye: cruel world
-stdout: |+
-  > esc env version history default/test --utc
-  revision 5
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 05:00:00 +0000 UTC
 
-  revision 4
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 04:00:00 +0000 UTC
+---
+> esc env version history default/test --utc
+revision 5
+Author: Test Tester <test-tester>
+Date:   1970-01-01 05:00:00 +0000 UTC
 
-  revision 3
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 03:00:00 +0000 UTC
+revision 4
+Author: Test Tester <test-tester>
+Date:   1970-01-01 04:00:00 +0000 UTC
 
-  revision 2
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 02:00:00 +0000 UTC
+revision 3
+Author: Test Tester <test-tester>
+Date:   1970-01-01 03:00:00 +0000 UTC
 
-  revision 1
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 01:00:00 +0000 UTC
+revision 2
+Author: Test Tester <test-tester>
+Date:   1970-01-01 02:00:00 +0000 UTC
 
-  > esc env version retract default/test@2 --reason plaintext secret --replace-with @3
-  > esc env version history default/test --utc
-  revision 5
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 05:00:00 +0000 UTC
+revision 1
+Author: Test Tester <test-tester>
+Date:   1970-01-01 01:00:00 +0000 UTC
 
-  revision 4
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 04:00:00 +0000 UTC
+> esc env version retract default/test@2 --reason plaintext secret --replace-with @3
+> esc env version history default/test --utc
+revision 5
+Author: Test Tester <test-tester>
+Date:   1970-01-01 05:00:00 +0000 UTC
 
-  revision 3
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 03:00:00 +0000 UTC
+revision 4
+Author: Test Tester <test-tester>
+Date:   1970-01-01 04:00:00 +0000 UTC
 
-  revision 2 (retracted)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 02:00:00 +0000 UTC
+revision 3
+Author: Test Tester <test-tester>
+Date:   1970-01-01 03:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1970-01-01 02:00:00 +0000 UTC and replaced with revision 3.
+revision 2 (retracted)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 02:00:00 +0000 UTC
 
-      plaintext secret
+    Retracted by Test Tester <test-tester> at 1970-01-01 02:00:00 +0000 UTC and replaced with revision 3.
 
-  revision 1
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 01:00:00 +0000 UTC
+    plaintext secret
 
-  > esc env version retract default/test@3 --reason test retraction --replace-with @latest
-  > esc env version history default/test --utc
-  revision 5
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 05:00:00 +0000 UTC
+revision 1
+Author: Test Tester <test-tester>
+Date:   1970-01-01 01:00:00 +0000 UTC
 
-  revision 4
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 04:00:00 +0000 UTC
+> esc env version retract default/test@3 --reason test retraction --replace-with @latest
+> esc env version history default/test --utc
+revision 5
+Author: Test Tester <test-tester>
+Date:   1970-01-01 05:00:00 +0000 UTC
 
-  revision 3 (retracted)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 03:00:00 +0000 UTC
+revision 4
+Author: Test Tester <test-tester>
+Date:   1970-01-01 04:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 5.
+revision 3 (retracted)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 03:00:00 +0000 UTC
 
-      test retraction
+    Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 5.
 
-  revision 2 (retracted)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 02:00:00 +0000 UTC
+    test retraction
 
-      Retracted by Test Tester <test-tester> at 1970-01-01 02:00:00 +0000 UTC and replaced with revision 3.
+revision 2 (retracted)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 02:00:00 +0000 UTC
 
-      plaintext secret
+    Retracted by Test Tester <test-tester> at 1970-01-01 02:00:00 +0000 UTC and replaced with revision 3.
 
-  revision 1
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 01:00:00 +0000 UTC
+    plaintext secret
 
-  > esc env version retract default/test@4
-  > esc env version history default/test --utc
-  revision 5
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 05:00:00 +0000 UTC
+revision 1
+Author: Test Tester <test-tester>
+Date:   1970-01-01 01:00:00 +0000 UTC
 
-  revision 4 (retracted)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 04:00:00 +0000 UTC
+> esc env version retract default/test@4
+> esc env version history default/test --utc
+revision 5
+Author: Test Tester <test-tester>
+Date:   1970-01-01 05:00:00 +0000 UTC
 
-      Retracted by Test Tester <test-tester> at 1970-01-01 04:00:00 +0000 UTC and replaced with revision 42.
+revision 4 (retracted)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 04:00:00 +0000 UTC
 
-  revision 3 (retracted)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 03:00:00 +0000 UTC
+    Retracted by Test Tester <test-tester> at 1970-01-01 04:00:00 +0000 UTC and replaced with revision 42.
 
-      Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 5.
+revision 3 (retracted)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 03:00:00 +0000 UTC
 
-      test retraction
+    Retracted by Test Tester <test-tester> at 1970-01-01 03:00:00 +0000 UTC and replaced with revision 5.
 
-  revision 2 (retracted)
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 02:00:00 +0000 UTC
+    test retraction
 
-      Retracted by Test Tester <test-tester> at 1970-01-01 02:00:00 +0000 UTC and replaced with revision 3.
+revision 2 (retracted)
+Author: Test Tester <test-tester>
+Date:   1970-01-01 02:00:00 +0000 UTC
 
-      plaintext secret
+    Retracted by Test Tester <test-tester> at 1970-01-01 02:00:00 +0000 UTC and replaced with revision 3.
 
-  revision 1
-  Author: Test Tester <test-tester>
-  Date:   1970-01-01 01:00:00 +0000 UTC
+    plaintext secret
 
-stderr: |
-  > esc env version history default/test --utc
-  > esc env version retract default/test@2 --reason plaintext secret --replace-with @3
-  > esc env version history default/test --utc
-  > esc env version retract default/test@3 --reason test retraction --replace-with @latest
-  > esc env version history default/test --utc
-  > esc env version retract default/test@4
-  > esc env version history default/test --utc
+revision 1
+Author: Test Tester <test-tester>
+Date:   1970-01-01 01:00:00 +0000 UTC
+
+
+---
+> esc env version history default/test --utc
+> esc env version retract default/test@2 --reason plaintext secret --replace-with @3
+> esc env version history default/test --utc
+> esc env version retract default/test@3 --reason test retraction --replace-with @latest
+> esc env version history default/test --utc
+> esc env version retract default/test@4
+> esc env version history default/test --utc

--- a/cmd/esc/cli/testdata/env-version-rollback.yaml
+++ b/cmd/esc/cli/testdata/env-version-rollback.yaml
@@ -34,31 +34,33 @@ environments:
             secret:
               fn::secret:
                 ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
-stdout: |
-  > esc env version rollback default/test@stable
-  Environment updated.
-  > esc env get default/test
-  # Value
-  ```json
-  {
-    "string": "hello, world!"
-  }
-  ```
-  # Definition
-  ```yaml
-  values:
-    string: hello, world!
 
-  ```
+---
+> esc env version rollback default/test@stable
+Environment updated.
+> esc env get default/test
+# Value
+```json
+{
+  "string": "hello, world!"
+}
+```
+# Definition
+```yaml
+values:
+  string: hello, world!
 
-  > esc env version rollback default/test@2
-stderr: |
-  > esc env version rollback default/test@stable
-  > esc env get default/test
-  > esc env version rollback default/test@2
-  Error: not found
+```
 
-    on test line 2:
-     2:     - c
+> esc env version rollback default/test@2
 
-  Error: could not roll back: too many errors
+---
+> esc env version rollback default/test@stable
+> esc env get default/test
+> esc env version rollback default/test@2
+Error: not found
+
+  on test line 2:
+   2:     - c
+
+Error: could not roll back: too many errors

--- a/cmd/esc/cli/testdata/env-version-tag.yaml
+++ b/cmd/esc/cli/testdata/env-version-tag.yaml
@@ -38,69 +38,71 @@ environments:
             secret:
               fn::secret:
                 ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
-stdout: |+
-  > esc env version tag default/test@stable 2
-  > esc env version default/test@stable --utc
-  stable
-  Revision 2
-  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
-  > esc env version tag default/test@stable 3
-  > esc env version default/test@stable --utc
-  stable
-  Revision 3
-  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
-  > esc env version tag default/test@stable
-  > esc env version default/test@stable --utc
-  stable
-  Revision 4
-  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
-  > esc env version default/test@latest --utc
-  latest
-  Revision 4
-  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
-  > esc env version tag ls default/test --utc
-  latest
-  Revision 4
-  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
-  stable
-  Revision 4
-  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+---
+> esc env version tag default/test@stable 2
+> esc env version default/test@stable --utc
+stable
+Revision 2
+Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+> esc env version tag default/test@stable 3
+> esc env version default/test@stable --utc
+stable
+Revision 3
+Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+> esc env version tag default/test@stable
+> esc env version default/test@stable --utc
+stable
+Revision 4
+Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+> esc env version default/test@latest --utc
+latest
+Revision 4
+Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+> esc env version tag ls default/test --utc
+latest
+Revision 4
+Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
-  > esc env version tag default/test@initial 1
-  > esc env version tag ls default/test --utc
-  initial
-  Revision 1
-  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+stable
+Revision 4
+Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
-  latest
-  Revision 4
-  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+> esc env version tag default/test@initial 1
+> esc env version tag ls default/test --utc
+initial
+Revision 1
+Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
-  stable
-  Revision 4
-  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+latest
+Revision 4
+Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
-  > esc env version tag rm default/test@initial
-  > esc env version tag ls default/test --utc
-  latest
-  Revision 4
-  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+stable
+Revision 4
+Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
-  stable
-  Revision 4
-  Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+> esc env version tag rm default/test@initial
+> esc env version tag ls default/test --utc
+latest
+Revision 4
+Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
 
-stderr: |
-  > esc env version tag default/test@stable 2
-  > esc env version default/test@stable --utc
-  > esc env version tag default/test@stable 3
-  > esc env version default/test@stable --utc
-  > esc env version tag default/test@stable
-  > esc env version default/test@stable --utc
-  > esc env version default/test@latest --utc
-  > esc env version tag ls default/test --utc
-  > esc env version tag default/test@initial 1
-  > esc env version tag ls default/test --utc
-  > esc env version tag rm default/test@initial
-  > esc env version tag ls default/test --utc
+stable
+Revision 4
+Last updated at 0001-01-01 00:00:00 +0000 UTC by <unknown>
+
+
+---
+> esc env version tag default/test@stable 2
+> esc env version default/test@stable --utc
+> esc env version tag default/test@stable 3
+> esc env version default/test@stable --utc
+> esc env version tag default/test@stable
+> esc env version default/test@stable --utc
+> esc env version default/test@latest --utc
+> esc env version tag ls default/test --utc
+> esc env version tag default/test@initial 1
+> esc env version tag ls default/test --utc
+> esc env version tag rm default/test@initial
+> esc env version tag ls default/test --utc

--- a/cmd/esc/cli/testdata/login-logout.yaml
+++ b/cmd/esc/cli/testdata/login-logout.yaml
@@ -7,29 +7,31 @@ run: |
   esc login https://api.pulumi.com
   esc logout --all
   esc login || echo ok
-stdout: |
-  > esc login
-  Logged in to http://fake.pulumi.api as test-user ()
-  > esc login https://api.pulumi.com
-  Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
-  > esc login http://fake.pulumi.api
-  Logged in to http://fake.pulumi.api as test-user ()
-  > esc logout
-  Logged out of http://fake.pulumi.api
-  > esc login
-  Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
-  > esc login https://api.pulumi.com
-  Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
-  > esc logout --all
-  Logged out of all clouds
-  > esc login
-  Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
-stderr: |
-  > esc login
-  > esc login https://api.pulumi.com
-  > esc login http://fake.pulumi.api
-  > esc logout
-  > esc login
-  > esc login https://api.pulumi.com
-  > esc logout --all
-  > esc login
+
+---
+> esc login
+Logged in to http://fake.pulumi.api as test-user ()
+> esc login https://api.pulumi.com
+Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
+> esc login http://fake.pulumi.api
+Logged in to http://fake.pulumi.api as test-user ()
+> esc logout
+Logged out of http://fake.pulumi.api
+> esc login
+Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
+> esc login https://api.pulumi.com
+Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
+> esc logout --all
+Logged out of all clouds
+> esc login
+Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
+
+---
+> esc login
+> esc login https://api.pulumi.com
+> esc login http://fake.pulumi.api
+> esc logout
+> esc login
+> esc login https://api.pulumi.com
+> esc logout --all
+> esc login

--- a/cmd/esc/cli/testdata/open-detailed.yaml
+++ b/cmd/esc/cli/testdata/open-detailed.yaml
@@ -9,79 +9,81 @@ environments:
     values:
       foo: baz
       hello: world
-stdout: |
-  > esc open default/test --format detailed
-  {
-    "value": {
-      "foo": {
-        "value": "bar",
-        "trace": {
-          "def": {
-            "environment": "test",
-            "begin": {
-              "line": 4,
-              "column": 10,
-              "byte": 39
-            },
-            "end": {
-              "line": 4,
-              "column": 13,
-              "byte": 42
-            }
+
+---
+> esc open default/test --format detailed
+{
+  "value": {
+    "foo": {
+      "value": "bar",
+      "trace": {
+        "def": {
+          "environment": "test",
+          "begin": {
+            "line": 4,
+            "column": 10,
+            "byte": 39
           },
-          "base": {
-            "value": "baz",
-            "trace": {
-              "def": {
-                "environment": "test-2",
-                "begin": {
-                  "line": 2,
-                  "column": 10,
-                  "byte": 17
-                },
-                "end": {
-                  "line": 2,
-                  "column": 13,
-                  "byte": 20
-                }
-              }
-            }
+          "end": {
+            "line": 4,
+            "column": 13,
+            "byte": 42
           }
-        }
-      },
-      "hello": {
-        "value": "world",
-        "trace": {
-          "def": {
-            "environment": "test-2",
-            "begin": {
-              "line": 3,
-              "column": 12,
-              "byte": 32
-            },
-            "end": {
-              "line": 3,
-              "column": 17,
-              "byte": 37
+        },
+        "base": {
+          "value": "baz",
+          "trace": {
+            "def": {
+              "environment": "test-2",
+              "begin": {
+                "line": 2,
+                "column": 10,
+                "byte": 17
+              },
+              "end": {
+                "line": 2,
+                "column": 13,
+                "byte": 20
+              }
             }
           }
         }
       }
     },
-    "trace": {
-      "def": {
-        "begin": {
-          "line": 0,
-          "column": 0,
-          "byte": 0
-        },
-        "end": {
-          "line": 0,
-          "column": 0,
-          "byte": 0
+    "hello": {
+      "value": "world",
+      "trace": {
+        "def": {
+          "environment": "test-2",
+          "begin": {
+            "line": 3,
+            "column": 12,
+            "byte": 32
+          },
+          "end": {
+            "line": 3,
+            "column": 17,
+            "byte": 37
+          }
         }
       }
     }
+  },
+  "trace": {
+    "def": {
+      "begin": {
+        "line": 0,
+        "column": 0,
+        "byte": 0
+      },
+      "end": {
+        "line": 0,
+        "column": 0,
+        "byte": 0
+      }
+    }
   }
-stderr: |
-  > esc open default/test --format detailed
+}
+
+---
+> esc open default/test --format detailed

--- a/cmd/esc/cli/testdata/open-dotenv.yaml
+++ b/cmd/esc/cli/testdata/open-dotenv.yaml
@@ -22,14 +22,16 @@ environments:
         HELLO: ${hello}
       files:
         FILE: bar
-stdout: |
-  > esc open default/test --format dotenv
-  BOOL="true"
-  FOO="bar"
-  HELLO="world"
-  NUM="3.14"
-  BOOL_FILE="temp/esc-temp-0"
-  FILE="temp/esc-temp-1"
-  NUM_FILE="temp/esc-temp-2"
-stderr: |
-  > esc open default/test --format dotenv
+
+---
+> esc open default/test --format dotenv
+BOOL="true"
+FOO="bar"
+HELLO="world"
+NUM="3.14"
+BOOL_FILE="temp/esc-temp-0"
+FILE="temp/esc-temp-1"
+NUM_FILE="temp/esc-temp-2"
+
+---
+> esc open default/test --format dotenv

--- a/cmd/esc/cli/testdata/open-invalid.yaml
+++ b/cmd/esc/cli/testdata/open-invalid.yaml
@@ -1,7 +1,9 @@
 run: esc open default/test --format=flat
 error: exit status 1
-stdout: |
-  > esc open default/test --format=flat
-stderr: |
-  > esc open default/test --format=flat
-  Error: unknown output format "flat"
+
+---
+> esc open default/test --format=flat
+
+---
+> esc open default/test --format=flat
+Error: unknown output format "flat"

--- a/cmd/esc/cli/testdata/open-json-error.yaml
+++ b/cmd/esc/cli/testdata/open-json-error.yaml
@@ -5,9 +5,11 @@ environments:
       object: {}
       missing: ${foo}
       invalid: {'fn::toBase64': "${object}"}
-stdout: |
-  > esc open default/test --format json
-stderr: |
-  > esc open default/test --format json
-  test:3:16: unknown property "foo"
-  test:4:31: expected string, got object
+
+---
+> esc open default/test --format json
+
+---
+> esc open default/test --format json
+test:3:16: unknown property "foo"
+test:4:31: expected string, got object

--- a/cmd/esc/cli/testdata/open-json.yaml
+++ b/cmd/esc/cli/testdata/open-json.yaml
@@ -22,35 +22,37 @@ environments:
     values:
       foo: baz
       hello: world
-stdout: |
-  > esc open default/test --format json
-  {
-    "foo": "bar",
-    "hello": "world"
-  }
-  > esc open default/test@stable
-  {
-    "foo": "bar"
-  }
-  > esc open default/test@latest
-  {
-    "foo": "bar",
-    "hello": "world"
-  }
-  > esc open default/test@1
-  > esc open default/test@2
-  {
-    "foo": "bar"
-  }
-  > esc open default/test@3
-  {
-    "foo": "bar",
-    "hello": "world"
-  }
-stderr: |
-  > esc open default/test --format json
-  > esc open default/test@stable
-  > esc open default/test@latest
-  > esc open default/test@1
-  > esc open default/test@2
-  > esc open default/test@3
+
+---
+> esc open default/test --format json
+{
+  "foo": "bar",
+  "hello": "world"
+}
+> esc open default/test@stable
+{
+  "foo": "bar"
+}
+> esc open default/test@latest
+{
+  "foo": "bar",
+  "hello": "world"
+}
+> esc open default/test@1
+> esc open default/test@2
+{
+  "foo": "bar"
+}
+> esc open default/test@3
+{
+  "foo": "bar",
+  "hello": "world"
+}
+
+---
+> esc open default/test --format json
+> esc open default/test@stable
+> esc open default/test@latest
+> esc open default/test@1
+> esc open default/test@2
+> esc open default/test@3

--- a/cmd/esc/cli/testdata/open-shell.yaml
+++ b/cmd/esc/cli/testdata/open-shell.yaml
@@ -22,14 +22,16 @@ environments:
         HELLO: ${hello}
       files:
         FILE: bar
-stdout: |
-  > esc open default/test --format shell
-  export BOOL="true"
-  export FOO="bar"
-  export HELLO="world"
-  export NUM="3.14"
-  export BOOL_FILE="temp/esc-temp-0"
-  export FILE="temp/esc-temp-1"
-  export NUM_FILE="temp/esc-temp-2"
-stderr: |
-  > esc open default/test --format shell
+
+---
+> esc open default/test --format shell
+export BOOL="true"
+export FOO="bar"
+export HELLO="world"
+export NUM="3.14"
+export BOOL_FILE="temp/esc-temp-0"
+export FILE="temp/esc-temp-1"
+export NUM_FILE="temp/esc-temp-2"
+
+---
+> esc open default/test --format shell

--- a/cmd/esc/cli/testdata/open-string.yaml
+++ b/cmd/esc/cli/testdata/open-string.yaml
@@ -9,8 +9,10 @@ environments:
     values:
       foo: baz
       hello: world
-stdout: |
-  > esc open default/test --format string
-  "foo"="bar","hello"="world"
-stderr: |
-  > esc open default/test --format string
+
+---
+> esc open default/test --format string
+"foo"="bar","hello"="world"
+
+---
+> esc open default/test --format string

--- a/cmd/esc/cli/testdata/open-yaml.yaml
+++ b/cmd/esc/cli/testdata/open-yaml.yaml
@@ -9,9 +9,11 @@ environments:
     values:
       foo: baz
       hello: world
-stdout: |
-  > esc open default/test --format yaml
-  foo: bar
-  hello: world
-stderr: |
-  > esc open default/test --format yaml
+
+---
+> esc open default/test --format yaml
+foo: bar
+hello: world
+
+---
+> esc open default/test --format yaml

--- a/cmd/esc/cli/testdata/run.yaml
+++ b/cmd/esc/cli/testdata/run.yaml
@@ -34,28 +34,29 @@ environments:
           export F_PLAIN=${plain}
         BOOL_FILE: ${yup}
         NUM_FILE: ${pi}
-stdout: |-
-  > esc env run default/test dump-env
-  secret: [secret], plain: plaintext, bool: true, num: 3.14, file: temp/esc-temp-1, boolFile: temp/esc-temp-0, numFile: temp/esc-temp-2
-  > esc env run -i default/test dump-env
-  secret: hunter2, plain: plaintext, bool: true, num: 3.14, file: temp/esc-temp-1, boolFile: temp/esc-temp-0, numFile: temp/esc-temp-2
-  > esc env run default/test echo secret: ${secret}, plain: ${plain}
-  secret: [secret], plain: plaintext
-  > esc env run -i default/test echo secret: ${secret}, plain: ${plain}
-  secret: hunter2, plain: plaintext
-  > esc env run default/test source-file
-  secret: [secret], plain: plaintext
-  > esc env run -i default/test source-file
-  secret: hunter2, plain: plaintext
-  > esc env run default/test -- echo -n hunter2
-  [secret]> esc env run default/test -i -- echo -n hunter2
-  hunter2
-stderr: |
-  > esc env run default/test dump-env
-  > esc env run -i default/test dump-env
-  > esc env run default/test echo secret: ${secret}, plain: ${plain}
-  > esc env run -i default/test echo secret: ${secret}, plain: ${plain}
-  > esc env run default/test source-file
-  > esc env run -i default/test source-file
-  > esc env run default/test -- echo -n hunter2
-  > esc env run default/test -i -- echo -n hunter2
+
+---
+> esc env run default/test dump-env
+secret: [secret], plain: plaintext, bool: true, num: 3.14, file: temp/esc-temp-1, boolFile: temp/esc-temp-0, numFile: temp/esc-temp-2
+> esc env run -i default/test dump-env
+secret: hunter2, plain: plaintext, bool: true, num: 3.14, file: temp/esc-temp-1, boolFile: temp/esc-temp-0, numFile: temp/esc-temp-2
+> esc env run default/test echo secret: ${secret}, plain: ${plain}
+secret: [secret], plain: plaintext
+> esc env run -i default/test echo secret: ${secret}, plain: ${plain}
+secret: hunter2, plain: plaintext
+> esc env run default/test source-file
+secret: [secret], plain: plaintext
+> esc env run -i default/test source-file
+secret: hunter2, plain: plaintext
+> esc env run default/test -- echo -n hunter2
+[secret]> esc env run default/test -i -- echo -n hunter2
+hunter2
+---
+> esc env run default/test dump-env
+> esc env run -i default/test dump-env
+> esc env run default/test echo secret: ${secret}, plain: ${plain}
+> esc env run -i default/test echo secret: ${secret}, plain: ${plain}
+> esc env run default/test source-file
+> esc env run -i default/test source-file
+> esc env run default/test -- echo -n hunter2
+> esc env run default/test -i -- echo -n hunter2

--- a/cmd/esc/cli/testdata/usage-esc.yaml
+++ b/cmd/esc/cli/testdata/usage-esc.yaml
@@ -1,41 +1,43 @@
 run: esc
-stdout: |
-  > esc
-  Pulumi ESC - Manage environments, secrets, and configuration
 
-  To begin working with Pulumi ESC, run the `esc env init` command:
+---
+> esc
+Pulumi ESC - Manage environments, secrets, and configuration
 
-      $ esc env init
+To begin working with Pulumi ESC, run the `esc env init` command:
 
-  This will prompt you to create a new environment to hold secrets and configuration.
+    $ esc env init
 
-  The most common commands from there are:
+This will prompt you to create a new environment to hold secrets and configuration.
 
-      - esc env get  : Get a property in an environment definition
-      - esc env set  : Set a property in an environment definition
-      - esc env edit : Edit an environment definition
-      - esc env ls   : List available environments
-      - esc run      : Run a command within the context of an environment
-      - esc open     : Open an environment and access its contents
+The most common commands from there are:
 
-  For more information, please visit the project page: https://www.pulumi.com/docs/esc
+    - esc env get  : Get a property in an environment definition
+    - esc env set  : Set a property in an environment definition
+    - esc env edit : Edit an environment definition
+    - esc env ls   : List available environments
+    - esc run      : Run a command within the context of an environment
+    - esc open     : Open an environment and access its contents
 
-  Usage:
-    esc [command]
+For more information, please visit the project page: https://www.pulumi.com/docs/esc
 
-  Available Commands:
-    completion  Generate the autocompletion script for the specified shell
-    env         Manage environments
-    help        Help about any command
-    login       Log in to the Pulumi Cloud
-    logout      Log out of the Pulumi Cloud
-    open        Open the environment with the given name.
-    run         Open the environment with the given name and run a command.
-    version     Print esc's version number
+Usage:
+  esc [command]
 
-  Flags:
-    -h, --help   help for esc
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  env         Manage environments
+  help        Help about any command
+  login       Log in to the Pulumi Cloud
+  logout      Log out of the Pulumi Cloud
+  open        Open the environment with the given name.
+  run         Open the environment with the given name and run a command.
+  version     Print esc's version number
 
-  Use "esc [command] --help" for more information about a command.
-stderr: |
-  > esc
+Flags:
+  -h, --help   help for esc
+
+Use "esc [command] --help" for more information about a command.
+
+---
+> esc

--- a/cmd/esc/cli/testdata/usage-parent.yaml
+++ b/cmd/esc/cli/testdata/usage-parent.yaml
@@ -1,40 +1,42 @@
 parent: parent
 run: parent esc
-stdout: |
-  > parent esc
-  Pulumi ESC - Manage environments, secrets, and configuration
 
-  To begin working with Pulumi ESC, run the `parent esc env init` command:
+---
+> parent esc
+Pulumi ESC - Manage environments, secrets, and configuration
 
-      $ parent esc env init
+To begin working with Pulumi ESC, run the `parent esc env init` command:
 
-  This will prompt you to create a new environment to hold secrets and configuration.
+    $ parent esc env init
 
-  The most common commands from there are:
+This will prompt you to create a new environment to hold secrets and configuration.
 
-      - parent esc env get  : Get a property in an environment definition
-      - parent esc env set  : Set a property in an environment definition
-      - parent esc env edit : Edit an environment definition
-      - parent esc env ls   : List available environments
-      - parent esc run      : Run a command within the context of an environment
-      - parent esc open     : Open an environment and access its contents
+The most common commands from there are:
 
-  For more information, please visit the project page: https://www.pulumi.com/docs/esc
+    - parent esc env get  : Get a property in an environment definition
+    - parent esc env set  : Set a property in an environment definition
+    - parent esc env edit : Edit an environment definition
+    - parent esc env ls   : List available environments
+    - parent esc run      : Run a command within the context of an environment
+    - parent esc open     : Open an environment and access its contents
 
-  Usage:
-    parent esc [command]
+For more information, please visit the project page: https://www.pulumi.com/docs/esc
 
-  Available Commands:
-    env         Manage environments
-    login       Log in to the Pulumi Cloud
-    logout      Log out of the Pulumi Cloud
-    open        Open the environment with the given name.
-    run         Open the environment with the given name and run a command.
-    version     Print esc's version number
+Usage:
+  parent esc [command]
 
-  Flags:
-    -h, --help   help for esc
+Available Commands:
+  env         Manage environments
+  login       Log in to the Pulumi Cloud
+  logout      Log out of the Pulumi Cloud
+  open        Open the environment with the given name.
+  run         Open the environment with the given name and run a command.
+  version     Print esc's version number
 
-  Use "parent esc [command] --help" for more information about a command.
-stderr: |
-  > parent esc
+Flags:
+  -h, --help   help for esc
+
+Use "parent esc [command] --help" for more information about a command.
+
+---
+> parent esc


### PR DESCRIPTION
Change the test YAML from a single YAML document to three separate documents. The latter two documents represent the test's expected stdout and stderr, repsectively, and are treated as raw bytes rather than YAML. This should make test output more predictable, round-trippable, and diffable.