### PR TITLE
Ensuring env var is always taken over account backend url

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,9 @@
 
 ### Bug Fixes
 
+- Make CLI prefer environment variable `PULUMI_BACKEND_URL` over account backend URL
+  [#477](https://github.com/pulumi/esc/pull/477)
+
 ### Breaking changes
 
 - It is now a syntax error to call a builtin function incorrectly.

--- a/cmd/esc/cli/login.go
+++ b/cmd/esc/cli/login.go
@@ -156,15 +156,7 @@ func (esc *escCommand) getCachedClient(ctx context.Context) error {
 
 	backendURL := esc.workspace.GetCurrentCloudURL(account)
 
-	// If backendURL is overridden via env var, try to get a matching existing account
-	if backendURL != account.BackendURL {
-		account, err = esc.workspace.GetAccount(backendURL)
-		if err != nil {
-			return fmt.Errorf("could not determine current cloud: %w", err)
-		}
-	}
-
-	if account == nil {
+	if account == nil || account.BackendURL != backendURL {
 		nAccount, err := esc.login.Login(
 			ctx,
 			backendURL,

--- a/cmd/esc/cli/workspace/credentials.go
+++ b/cmd/esc/cli/workspace/credentials.go
@@ -68,12 +68,13 @@ func (w *Workspace) GetAccount(backendURL string) (*Account, error) {
 }
 
 func (w *Workspace) GetCurrentCloudURL(account *Account) string {
-	if account != nil {
-		return account.BackendURL
-	}
-
+	// Always prefer environment variable over account backend URL
 	if backend := os.Getenv(PulumiBackendURLEnvVar); backend != "" {
 		return backend
+	}
+
+	if account != nil {
+		return account.BackendURL
 	}
 
 	return "https://api.pulumi.com"


### PR DESCRIPTION
### Summary
- Fixes https://github.com/pulumi/esc/issues/473
- Makes ESC CLI always prefer env var `PULUMI_BACKEND_URL` over backend url saved into the account
- If backendURL is overridden, then login will run and look for `PULUMI_ACCESS_TOKEN` env var, falling back to accounts if it's not specified

### Testing
- Manually tested, the scenario in ticket now works
- Manually tested case when invalid backend URL is set via env var (or if user never logged in with that backend), user will see `Error: no credentials. Please run `esc login` to log in.`