### PR TITLE
eval, cli: better support for binary data

### DIFF
--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -444,7 +445,17 @@ func (c *testPulumiClient) openEnvironment(ctx context.Context, orgName, name st
 		return "", mapDiags(diags), nil
 	}
 
-	c.openEnvs[id.String()] = openEnv
+	// round-trip through JSON for better fidelity with service-backed scenarios
+	encoded, err := json.Marshal(openEnv)
+	if err != nil {
+		return "", nil, nil
+	}
+	var decoded esc.Environment
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return "", nil, nil
+	}
+
+	c.openEnvs[id.String()] = &decoded
 	return id.String(), mapDiags(diags), nil
 }
 

--- a/cmd/esc/cli/prepare.go
+++ b/cmd/esc/cli/prepare.go
@@ -77,15 +77,22 @@ func createTemporaryFiles(e *esc.Environment, opts PrepareOptions) (paths, envir
 
 	for _, k := range keys {
 		v := files[k]
-		s := v.Value.(string)
+
+		var contents []byte
+		switch v := v.Value.(type) {
+		case string:
+			contents = []byte(v)
+		case []byte:
+			contents = v
+		}
 
 		if v.Secret {
-			secrets = append(secrets, s)
+			secrets = append(secrets, string(contents))
 		}
 
 		path := "[unknown]"
 		if !opts.Pretend {
-			path, err = createTemporaryFile(opts.fs, []byte(s))
+			path, err = createTemporaryFile(opts.fs, contents)
 			if err != nil {
 				removeTemporaryFiles(opts.fs, paths)
 				return nil, nil, nil, err

--- a/cmd/esc/cli/testdata/env-set.yaml
+++ b/cmd/esc/cli/testdata/env-set.yaml
@@ -15,6 +15,7 @@ run: |
   esc env set default/test 'imports[0]' default/test2 && esc env get default/test
   esc env init default/test3
   esc env set default/test 'imports[1]' default/test3 && esc env get default/test
+  esc env set default/test binary '{"fn::fromBase64": "SJ5zicDxjGWXv1Y53mDw/A=="}' && esc env get default/test && esc env get --value=detailed default/test binary
 
 ---
 > esc env init default/test
@@ -494,6 +495,76 @@ imports:
 
 ```
 
+> esc env set default/test binary {"fn::fromBase64": "SJ5zicDxjGWXv1Y53mDw/A=="}
+> esc env get default/test
+# Value
+```json
+{
+  "array": [
+    "hello",
+    "esc",
+    {
+      "foo": ""
+    }
+  ],
+  "binary": "SJ5zicDxjGWXv1Y53mDw/A==",
+  "foo": {
+    "bar": {
+      "alpha": "zed",
+      "baz": "qux"
+    },
+    "beta": [
+      "gamma",
+      42
+    ]
+  },
+  "open": "[unknown]"
+}
+```
+# Definition
+```yaml
+values:
+  foo:
+    bar:
+      baz: qux
+      alpha: zed
+    beta:
+      - gamma
+      - 42
+  open:
+    "fn::open::test": "cse"
+  array:
+    - hello
+    - esc
+    - {foo: ""}
+  binary:
+    "fn::fromBase64": "SJ5zicDxjGWXv1Y53mDw/A=="
+imports:
+  - default/test2
+  - default/test3
+
+```
+
+> esc env get --value=detailed default/test binary
+{
+  "value": "SJ5zicDxjGWXv1Y53mDw/A==",
+  "binary": true,
+  "trace": {
+    "def": {
+      "environment": "\u003cyaml\u003e",
+      "begin": {
+        "line": 16,
+        "column": 5,
+        "byte": 188
+      },
+      "end": {
+        "line": 16,
+        "column": 47,
+        "byte": 230
+      }
+    }
+  }
+}
 
 ---
 > esc env init default/test
@@ -525,3 +596,6 @@ imports:
 > esc env init default/test3
 > esc env set default/test imports[1] default/test3
 > esc env get default/test
+> esc env set default/test binary {"fn::fromBase64": "SJ5zicDxjGWXv1Y53mDw/A=="}
+> esc env get default/test
+> esc env get --value=detailed default/test binary

--- a/cmd/esc/cli/testdata/open-json.yaml
+++ b/cmd/esc/cli/testdata/open-json.yaml
@@ -39,6 +39,7 @@ environments:
   "hello": "world"
 }
 > esc open default/test@1
+{}
 > esc open default/test@2
 {
   "foo": "bar"

--- a/cmd/esc/cli/testdata/open-shell.yaml
+++ b/cmd/esc/cli/testdata/open-shell.yaml
@@ -1,4 +1,5 @@
-run: esc open default/test --format shell
+run: |
+  esc open default/test --format shell
 environments:
   test-user/default/test:
     imports:
@@ -14,6 +15,8 @@ environments:
       files:
         BOOL_FILE: ${yup}
         NUM_FILE: ${pi}
+        BINARY_FILE:
+          fn::fromBase64: 811TE9wfc1Wri9GglAeKdRUkglxk2GmjSo5MJWzTI4k=
   test-user/default/test-2:
     values:
       foo: baz
@@ -29,9 +32,10 @@ export BOOL="true"
 export FOO="bar"
 export HELLO="world"
 export NUM="3.14"
-export BOOL_FILE="temp/esc-temp-0"
-export FILE="temp/esc-temp-1"
-export NUM_FILE="temp/esc-temp-2"
+export BINARY_FILE="temp/esc-temp-0"
+export BOOL_FILE="temp/esc-temp-1"
+export FILE="temp/esc-temp-2"
+export NUM_FILE="temp/esc-temp-3"
 
 ---
 > esc open default/test --format shell

--- a/environment.go
+++ b/environment.go
@@ -229,6 +229,11 @@ func (e *Environment) GetTemporaryFiles() map[string]Value {
 			} else {
 				files[k] = NewValue(str)
 			}
+		case []byte:
+			if files == nil {
+				files = make(map[string]Value)
+			}
+			files[k] = v
 		}
 	}
 	return files

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -1231,7 +1231,7 @@ func (e *evalContext) evaluateBuiltinFromBase64(x *expr, repr *fromBase64Expr) *
 			v.unknown = true
 			return v
 		}
-		v.repr = string(b)
+		v.repr = b
 	}
 	return v
 }

--- a/eval/rotation.go
+++ b/eval/rotation.go
@@ -36,6 +36,10 @@ type Rotation struct {
 }
 
 func (r *RotationResult) Patches() []*Patch {
+	if r == nil {
+		return nil
+	}
+
 	var patches []*Patch
 	for _, rotation := range *r {
 		if rotation.Patch != nil {

--- a/eval/testdata/eval/omnibus/expected.json
+++ b/eval/testdata/eval/omnibus/expected.json
@@ -1195,7 +1195,8 @@
                 }
             },
             "fromBase64": {
-                "value": "hello,world",
+                "value": "aGVsbG8sd29ybGQ=",
+                "binary": true,
                 "trace": {
                     "def": {
                         "environment": "omnibus",
@@ -1719,7 +1720,7 @@
     },
     "checkJson": {
         "access": "[unknown]",
-        "fromBase64": "hello,world",
+        "fromBase64": "aGVsbG8sd29ybGQ=",
         "fromJSON": "[unknown]",
         "interp": "[unknown]",
         "join": "hello,world",
@@ -3179,7 +3180,8 @@
                 }
             },
             "fromBase64": {
-                "value": "hello,world",
+                "value": "aGVsbG8sd29ybGQ=",
+                "binary": true,
                 "trace": {
                     "def": {
                         "environment": "omnibus",
@@ -4209,7 +4211,7 @@
     },
     "evalJsonRedacted": {
         "access": "qux",
-        "fromBase64": "hello,world",
+        "fromBase64": "aGVsbG8sd29ybGQ=",
         "fromJSON": {
             "a": null,
             "b": true,
@@ -4253,7 +4255,7 @@
     },
     "evalJSONRevealed": {
         "access": "qux",
-        "fromBase64": "hello,world",
+        "fromBase64": "aGVsbG8sd29ybGQ=",
         "fromJSON": {
             "a": null,
             "b": true,

--- a/eval/value.go
+++ b/eval/value.go
@@ -15,6 +15,7 @@
 package eval
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -48,7 +49,7 @@ type value struct {
 	rotateOnly bool
 	secret     bool // true if the value is secret
 
-	repr any // nil | bool | json.Number | string | []*value | map[string]*value
+	repr any // nil | bool | json.Number | string | []byte | []*value | map[string]*value
 }
 
 func (v *value) GoString() string {
@@ -295,6 +296,8 @@ func (v *value) toString() (str string, unknown bool, secret bool) {
 		s = repr.String()
 	case string:
 		s = repr
+	case []byte:
+		s = base64.StdEncoding.EncodeToString(repr)
 	case []*value:
 		vals := make([]string, len(repr))
 		for i, v := range repr {
@@ -373,6 +376,8 @@ func unexport(v esc.Value, x *expr) *value {
 		vv.repr, vv.schema = pv, schema.Number().Const(pv).Schema()
 	case string:
 		vv.repr, vv.schema = pv, schema.String().Const(pv).Schema()
+	case []byte:
+		vv.repr, vv.schema = pv, schema.String().Const(base64.StdEncoding.EncodeToString(pv)).Schema()
 	case []esc.Value:
 		a, items := make([]*value, len(pv)), make([]schema.Builder, len(pv))
 		for i, v := range pv {

--- a/value.go
+++ b/value.go
@@ -146,7 +146,7 @@ func (v *Value) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// FromJSON converts a plain-old-JSON value (i.e. a value of type nil, bool, json.Number, string, []byte, []any, or
+// FromJSON converts a plain-old-JSON value (i.e. a value of type nil, bool, json.Number, string, []any, or
 // map[string]any) into a Value.
 func FromJSON(v any, secret bool) (Value, error) {
 	return fromJSON("", v, secret)
@@ -167,11 +167,6 @@ func fromJSON(path string, v any, secret bool) (Value, error) {
 		}
 		return NewValue(v), nil
 	case string:
-		if secret {
-			return NewSecret(v), nil
-		}
-		return NewValue(v), nil
-	case []byte:
 		if secret {
 			return NewSecret(v), nil
 		}
@@ -209,7 +204,7 @@ func fromJSON(path string, v any, secret bool) (Value, error) {
 	}
 }
 
-// ToJSON converts a Value into a plain-old-JSON value (i.e. a value of type nil, bool, json.Number, string, []byte, []any, or
+// ToJSON converts a Value into a plain-old-JSON value (i.e. a value of type nil, bool, json.Number, string, []any, or
 // map[string]any). If redact is true, secrets are replaced with [secret].
 func (v Value) ToJSON(redact bool) any {
 	if v.Secret && redact {
@@ -232,6 +227,8 @@ func (v Value) ToJSON(redact bool) any {
 			m[k] = v.ToJSON(redact)
 		}
 		return m
+	case []byte:
+		return base64.StdEncoding.EncodeToString(pv)
 	default:
 		return pv
 	}


### PR DESCRIPTION
ESC currently handles binary data by coercing binary values to a (potentially-invalid) strings. This works okay internally, since Go does not validate the wellformedness of strings when coercing from binary data. However, the standard Go JSON encoder ensures that all strings are [coerced to valid UTF-8 during marshaling](https://pkg.go.dev/encoding/json#Marshal), which replaces any invalid bytes with the replacement character. This corrupts the data.

For example, the following environment should write the bytes `dcc5 43bc 1b4f f4fb 8263 d630 a199 2688 166b c084 5b71 1240 24c3 a944 d937 e2fc` to a temporary file:

```yaml
values:
  files:
    MY_FILE:
      fn::fromBase64: 3MVDvBtP9PuCY9YwoZkmiBZrwIRbcRJAJMOpRNk34vw=
```

Instead, it writes the bytes `efbf bdef bfbd 43ef bfbd 1b4f efbf bdef bfbd efbf bd63 efbf bd30 efbf bdef bfbd 26ef bfbd 166b efbf bdef bfbd 5b71 1240 24c3 a944 efbf bd37 efbf bdef bfbd`, because the decoded value of `MY_FILE` is marshaled as `"��C�\u001bO���c�0��\u0026�\u0016k��[q\u0012@$éD�7��"` due to the presence of invalid UTF-8 bytes in the decoded value.

This commit addresses these challenges through three related changes:

1. `[]byte` values are now allowed inside of `eval.value`. This allows binary data to be faithfully represented within the evaluator.
2. `[]byte` values are now allowed inside of `esc.Value`. If an `esc.Value` contains a `[]byte`, its contents are marshaled as a base64-encoded string and a new `binary` property is set to `true`. This allows binary data to be safely roundtripped without complicated encoding schemes.
3. The `files` stanza now supports binary data. If the value of an entry in `files` is binary data, it is written to the filesystem as-is.

Strictly speaking this is a breaking change: prior to these changes, binary data--which can only be manufactured by a provider, rotator, or `fn::fromBase64`--would be marshaled as a plain old JSON string. With these changes, binary data is still marshaled as a JSON string, but its contents are now base64-encoded bytes. If users had binary data that happened to be valid UTF-8, that data will now be encoded using base64 during marshaling instead of being represented verbatim. If this is a major concern, we could change our marshaling behavior to only base64-encode if the binary data is not valid UTF-8.

Fixes #480.