### PR TITLE
Adding proper errors to list environments

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,6 +2,8 @@
 
 - Add `--string` flag to `env set` to treat the given value as a string.
   [#467](https://github.com/pulumi/esc/pull/467)
+- Add proper return code to list environments when organization doesn't exist
+  [#484](https://github.com/pulumi/esc/pull/484)
 
 ### Bug Fixes
 

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -474,6 +474,13 @@ func (c *testPulumiClient) GetRevisionNumber(ctx context.Context, orgName, proje
 
 func (c *testPulumiClient) ListEnvironments(
 	ctx context.Context,
+	continuationToken string,
+) ([]client.OrgEnvironment, string, error) {
+	return c.ListOrganizationEnvironments(ctx, "", continuationToken)
+}
+
+func (c *testPulumiClient) ListOrganizationEnvironments(
+	ctx context.Context,
 	orgName string,
 	continuationToken string,
 ) ([]client.OrgEnvironment, string, error) {

--- a/cmd/esc/cli/client/client_test.go
+++ b/cmd/esc/cli/client/client_test.go
@@ -114,7 +114,7 @@ func TestListEnvironments(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		actual, token, err := client.ListEnvironments(context.Background(), "", "")
+		actual, token, err := client.ListEnvironments(context.Background(), "")
 		require.NoError(t, err)
 		assert.Equal(t, expected, actual)
 		assert.Equal(t, expectedToken, token)
@@ -129,9 +129,8 @@ func TestListEnvironments(t *testing.T) {
 
 		expectedToken := "next-token"
 
-		client := newTestClient(t, http.MethodGet, "/api/esc/environments", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments/org-1", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "", r.URL.Query().Get("continuationToken"))
-			assert.Equal(t, org, r.URL.Query().Get("organization"))
 
 			err := json.NewEncoder(w).Encode(ListEnvironmentsResponse{
 				Environments: expected,
@@ -140,7 +139,7 @@ func TestListEnvironments(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		actual, token, err := client.ListEnvironments(context.Background(), org, "")
+		actual, token, err := client.ListOrganizationEnvironments(context.Background(), org, "")
 		require.NoError(t, err)
 		assert.Equal(t, expected, actual)
 		assert.Equal(t, expectedToken, token)
@@ -157,7 +156,7 @@ func TestListEnvironments(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		actual, token, err := client.ListEnvironments(context.Background(), "", token)
+		actual, token, err := client.ListEnvironments(context.Background(), token)
 		require.NoError(t, err)
 		assert.Nil(t, actual)
 		assert.Equal(t, "", token)

--- a/cmd/esc/cli/env_ls.go
+++ b/cmd/esc/cli/env_ls.go
@@ -69,7 +69,18 @@ func (env *envCommand) listEnvironments(ctx context.Context, orgFilter, projectF
 	user := env.esc.account.Username
 	continuationToken, allEnvs := "", []client.OrgEnvironment(nil)
 	for {
-		envs, nextToken, err := env.esc.client.ListEnvironments(ctx, orgFilter, continuationToken)
+		var envs []client.OrgEnvironment
+		var nextToken string
+		var err error
+
+		// If orgFilter is specified, use ListOrganizationEnvironments endpoint, so that we receive proper errors
+		// like 404 when environment doesn't exist, instead of an empty array
+		if orgFilter != "" {
+			envs, nextToken, err = env.esc.client.ListOrganizationEnvironments(ctx, orgFilter, continuationToken)
+		} else {
+			envs, nextToken, err = env.esc.client.ListEnvironments(ctx, continuationToken)
+		}
+
 		if err != nil {
 			return []client.OrgEnvironment(nil), fmt.Errorf("listing environments: %w", err)
 		}


### PR DESCRIPTION
### Summary
- Fixes https://github.com/pulumi/esc/issues/472
- Introduces ListOrganizationEnvironments API into the client
- Currently used API ListEnvironments only takes in orgName as a filter, so if no such org exists, it returns an empty array and a 2XX
- Therefore make the list command select between ListOrganizationEnvironments and ListEnvironments  based on whether org name is provided
- ListOrganizationEnvironments returns proper 404 when org is not found, which results in CLI command returning error code 1 properly

### Testing
- Adjusted client tests
- Manually tested using `esc env ls; echo $?`
  - `esc env real-org; echo $?` returns 0, whether or not it has environments
  - `esc env non-existing-org; echo $?` returns 1, and prints an error message `Error: listing environments: [404] Not Found: Organization 'non-existing-org' not found`