### PR TITLE
Don't decrypt secrets from invalid top-level keys

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,16 +1,11 @@
 ### Improvements
 
-- Add `--string` flag to `env set` to treat the given value as a string.
-  [#467](https://github.com/pulumi/esc/pull/467)
-- Add proper return code to list environments when organization doesn't exist
-  [#484](https://github.com/pulumi/esc/pull/484)
-
 ### Bug Fixes
 
+- No longer error when decrypting invalid secrets outside of values top-level key
+  [#491](https://github.com/pulumi/esc/pull/491)
 - Make CLI prefer environment variable `PULUMI_BACKEND_URL` over account backend URL
   [#477](https://github.com/pulumi/esc/pull/477)
 
 ### Breaking changes
 
-- It is now a syntax error to call a builtin function incorrectly.
-  [449](https://github.com/pulumi/esc/pull/449)

--- a/eval/crypt.go
+++ b/eval/crypt.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"strings"
 
 	"github.com/pulumi/esc/syntax"
 	"github.com/pulumi/esc/syntax/encoding"
@@ -147,6 +148,12 @@ func DecryptSecrets(ctx context.Context, filename string, source []byte, decrypt
 	return rewriteYAML(ctx, filename, source, func(n syntax.Node) (syntax.Node, syntax.Diagnostics, error) {
 		obj, _, ciphertextNode, ok := parseSecret(n)
 		if !ok || ciphertextNode == nil {
+			return n, nil, nil
+		}
+
+		// Don't attempt to decrypt secrets outside of "values"
+		path := n.Syntax().Path()
+		if !strings.HasPrefix(path, "values.") {
 			return n, nil, nil
 		}
 

--- a/eval/crypt_test.go
+++ b/eval/crypt_test.go
@@ -159,6 +159,17 @@ func TestDecryptMalformedSecret(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestDecryptInvalidTopLevelKey(t *testing.T) {
+	const doc = `invalid-top-level-key:
+  password:
+    fn::secret:
+      ciphertext: "invalid-ciphertext"
+`
+
+	_, err := DecryptSecrets(context.Background(), "doc", []byte(doc), broken{})
+	require.NoError(t, err)
+}
+
 func TestInvalidEnvelope(t *testing.T) {
 	encodeBin := func(magic string, version uint32, ciphertext []byte) []byte {
 		var b bytes.Buffer


### PR DESCRIPTION
We should only decrypt secrets under `values`. This fixes decryption errors when we have invalid ciphertexts under invalid top-level keys (which we don't validate for)