### PR TITLE
chore(deps): Setting up dependabot to run daily, and label p1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "go"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "p1"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
This pull request includes a configuration update to the `.github/dependabot.yml` file to enable automated dependency updates for Go packages.

Configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R11): Added configuration to enable daily dependency updates for Go packages, including setting the update interval to daily, applying the "p1" label, and specifying a commit message prefix of "chore" with the inclusion of the scope.