### PR TITLE
chore(gosec): Fixes gosec G115

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 
+- cmd/esc/cli/env.go: Modified the writeYAMLEnvironmentDiagnostics function to instantiate hcl.NewDiagnosticTextWriter with a width of 0 initially, and then conditionally reinstantiate it with the specified width if it is greater than 0, addressing gosec G115. [#494](https://github.com/pulumi/esc/pull/494)
 - No longer error when decrypting invalid secrets outside of values top-level key
   [#491](https://github.com/pulumi/esc/pull/491)
 - Make CLI prefer environment variable `PULUMI_BACKEND_URL` over account backend URL

--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -340,7 +340,11 @@ func (cmd *envCommand) writeYAMLEnvironmentDiagnostics(
 	}
 
 	files := map[string]*hcl.File{envName: {Bytes: yaml}}
-	writer := hcl.NewDiagnosticTextWriter(out, files, uint(width), color)
+
+	writer := hcl.NewDiagnosticTextWriter(out, files, 0, color)
+	if width > 0 { // Fixes gosec G115
+		writer = hcl.NewDiagnosticTextWriter(out, files, uint(width), color)
+	}
 
 	sortEnvironmentDiagnostics(diags)
 


### PR DESCRIPTION
This pull request includes a change to the `writeYAMLEnvironmentDiagnostics` function in the `cmd/esc/cli/env.go` file. The change addresses a security issue identified by gosec G115 by modifying how the `hcl.NewDiagnosticTextWriter` is instantiated.

* [`cmd/esc/cli/env.go`](diffhunk://#diff-35037241ba6b265db4f58db9fa451f9e62c2b545e7236e1ee1ae0a5bdf7fdaeaL343-R347): Modified the `writeYAMLEnvironmentDiagnostics` function to instantiate `hcl.NewDiagnosticTextWriter` with a width of 0 initially, and then conditionally reinstantiate it with the specified width if it is greater than 0, addressing gosec G115.