### PR TITLE
chore(github-workflows): Adding permissions to github workflows

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -6,6 +6,8 @@ on:
       - 'CHANGELOG.md'
       - 'CHANGELOG_PENDING.md'
 
+permissions: read-all
+
 jobs:
   lint:
     uses: ./.github/workflows/stage-lint.yml

--- a/.github/workflows/publish-prerelease.yaml
+++ b/.github/workflows/publish-prerelease.yaml
@@ -8,6 +8,10 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 
+permissions:
+  contents: write  # Needed to publish releases
+  packages: write  # If publishing packages
+
 jobs:
   lint:
     uses: ./.github/workflows/stage-lint.yml

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -9,6 +9,11 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 
+permissions:
+  contents: write  # Needed to publish releases
+  packages: write  # Needed for publishing packages
+  id-token: write  # Needed for AWS credential provider
+
 jobs:
   lint:
     uses: ./.github/workflows/stage-lint.yml

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -11,6 +11,11 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 
+permissions:
+  contents: write  # Needed to publish releases
+  packages: write  # If publishing packages
+  # Add other specific permissions as needed
+
 jobs:
   lint:
     uses: ./.github/workflows/stage-lint.yml

--- a/.github/workflows/stage-publish.yml
+++ b/.github/workflows/stage-publish.yml
@@ -7,6 +7,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write  # Needed for publishing releases
+  packages: write  # Needed for publishing packages
+
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
 

--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -15,6 +15,8 @@ on:
         required: false
         type: boolean
 
+permissions: read-all
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
This pull request includes updates to several GitHub Actions workflow files to specify permissions for various jobs. These changes ensure that the workflows have the necessary permissions to perform their tasks, such as publishing releases and packages.

Permissions updates:

* [`.github/workflows/pr-tests.yaml`](diffhunk://#diff-3916175353da81b6cca987b01c9e9615428e7601e00c805533c7844c1528658fR9-R10): Added `read-all` permissions to the workflow.
* [`.github/workflows/publish-prerelease.yaml`](diffhunk://#diff-0f355e6081d174f772bc6161eace6e05b7af4da4dfad5a3b4510e6bb41b4c693R11-R14): Added `contents: write` and `packages: write` permissions needed for publishing releases and packages.
* [`.github/workflows/publish-release.yaml`](diffhunk://#diff-a6abdc5a2c99b75dc521141aa12b5dc8381ff914e4a7e4383062c94e6f8a4fc7R12-R16): Added `contents: write`, `packages: write`, and `id-token: write` permissions needed for publishing releases, packages, and AWS credential provider.
* [`.github/workflows/publish-snapshot.yaml`](diffhunk://#diff-78dcdf1f45e7a5c04e69779f2ea2ef93ec4e953b7cba3644075f40928613af6fR14-R18): Added `contents: write` and `packages: write` permissions needed for publishing releases and packages.
* [`.github/workflows/stage-publish.yml`](diffhunk://#diff-b19404a388f01ead0ab93fa29bc7436daa4a754b7bb58d34b99517bdb6bc5fa7R10-R13): Added `contents: write` and `packages: write` permissions needed for publishing releases and packages.
* [`.github/workflows/stage-test.yml`](diffhunk://#diff-fb4b31f7de709796ec40ffd63eb75d49266e7ec2bbc8445c230de3cb2c1b3155R18-R19): Added `read-all` permissions to the workflow.