### PR TITLE
fix rotate paths roundtripping

### DIFF
--- a/cmd/esc/cli/env_rotate.go
+++ b/cmd/esc/cli/env_rotate.go
@@ -44,6 +44,7 @@ func newEnvRotateCmd(envcmd *envCommand) *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("'%s' is an invalid property path: %w", arg, err)
 				}
+				// implicitly prefix the given path with the values top level key
 				path = slices.Insert(path, 0, "values")
 				rotationPaths = append(rotationPaths, path.String())
 			}

--- a/cmd/esc/cli/env_rotate.go
+++ b/cmd/esc/cli/env_rotate.go
@@ -5,6 +5,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/pulumi/esc/cmd/esc/cli/client"
@@ -39,11 +40,12 @@ func newEnvRotateCmd(envcmd *envCommand) *cobra.Command {
 
 			rotationPaths := []string{}
 			for _, arg := range args[1:] {
-				_, err := resource.ParsePropertyPath(arg)
+				path, err := resource.ParsePropertyPath(arg)
 				if err != nil {
 					return fmt.Errorf("'%s' is an invalid property path: %w", arg, err)
 				}
-				rotationPaths = append(rotationPaths, arg)
+				path = slices.Insert(path, 0, "values")
+				rotationPaths = append(rotationPaths, path.String())
 			}
 
 			resp, diags, err := envcmd.esc.client.RotateEnvironment(ctx, ref.orgName, ref.projectName, ref.envName, rotationPaths)

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -120,7 +120,7 @@ func RotateEnvironment(
 ) (*esc.Environment, *RotationResult, syntax.Diagnostics) {
 	rotateDocPaths := make(map[string]bool, len(paths))
 	for _, path := range paths {
-		rotateDocPaths["values."+path.String()] = true
+		rotateDocPaths[path.String()] = true
 	}
 	return evalEnvironment(ctx, false, true, name, env, decrypter, providers, environments, execContext, true, rotateDocPaths)
 }

--- a/eval/testdata/eval/rotate-paths/overrides.json
+++ b/eval/testdata/eval/rotate-paths/overrides.json
@@ -1,8 +1,8 @@
 {
   "rotate": true,
   "rotatePaths": [
-    "examples[\"subscript-path\"][0]",
-    "examples.deeply.nested[0][\"quoted \\\"property\\\"\"].path",
-    "examples.embedded-in-another-fn[\"fn::open::test\"].some-input"
+    "values.examples[\"subscript-path\"][0]",
+    "values.examples.deeply.nested[0][\"quoted \\\"property\\\"\"].path",
+    "values.examples.embedded-in-another-fn[\"fn::open::test\"].some-input"
   ]
 }


### PR DESCRIPTION
As part of adding the [retry-rotation button](https://github.com/pulumi/pulumi-service/pull/27132) to the console, I realized that the rotation paths that we output as part of rotation results cannot be directly used as rotation path inputs.  This is because rotation path inputs get implicitly prefixed by `values.`, while the result paths are physical docpaths that already have the `values` prefix.

Right now the frontend works around this by strip the `values.?` prefix from the result paths, but this just exposes the fact that the prefixing doesn't actually work correctly for quoted keys like `["rotated-creds"] -> values.["rotated-creds"] -> invalid path`

I think that doing this prefixing in eval.RotateEnvironment is probably a mistake. It was done to try to match the behavior of the paths used by the CLI. So, while this is technically a breaking change, I propose moving the prefixing behavior to the CLI instead, and have the eval apis just use physical docpaths consistently.
