### PR TITLE
chore(actions): fixing permissions for github actions

### DIFF
--- a/.github/workflows/publish-prerelease.yaml
+++ b/.github/workflows/publish-prerelease.yaml
@@ -11,6 +11,18 @@ env:
 permissions:
   contents: write  # Needed to publish releases
   packages: write  # If publishing packages
+  id-token: write
+  actions: read
+  attestations: read
+  checks: read
+  deployments: read
+  discussions: read
+  issues: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  statuses: read
+  security-events: read
 
 jobs:
   lint:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -12,7 +12,18 @@ env:
 permissions:
   contents: write  # Needed to publish releases
   packages: write  # Needed for publishing packages
-  id-token: write  # Needed for AWS credential provider
+  id-token: write
+  actions: read
+  attestations: read
+  checks: read
+  deployments: read
+  discussions: read
+  issues: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  statuses: read
+  security-events: read
 
 jobs:
   lint:

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -14,7 +14,18 @@ env:
 permissions:
   contents: write  # Needed to publish releases
   packages: write  # If publishing packages
-  # Add other specific permissions as needed
+  id-token: write
+  actions: read
+  attestations: read
+  checks: read
+  deployments: read
+  discussions: read
+  issues: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  statuses: read
+  security-events: read
 
 jobs:
   lint:


### PR DESCRIPTION
This pull request includes updates to the permissions in several GitHub workflow files to ensure they have the necessary read and write access for various actions. The most important changes include adding specific read permissions for different GitHub features.

Permissions updates in workflow files:

* [`.github/workflows/publish-prerelease.yaml`](diffhunk://#diff-0f355e6081d174f772bc6161eace6e05b7af4da4dfad5a3b4510e6bb41b4c693R14-R25): Added read permissions for actions, attestations, checks, deployments, discussions, issues, pages, pull-requests, repository-projects, statuses, and security-events.
* [`.github/workflows/publish-release.yaml`](diffhunk://#diff-a6abdc5a2c99b75dc521141aa12b5dc8381ff914e4a7e4383062c94e6f8a4fc7L15-R26): Added read permissions for actions, attestations, checks, deployments, discussions, issues, pages, pull-requests, repository-projects, statuses, and security-events.
* [`.github/workflows/publish-snapshot.yaml`](diffhunk://#diff-78dcdf1f45e7a5c04e69779f2ea2ef93ec4e953b7cba3644075f40928613af6fL17-R28): Added read permissions for actions, attestations, checks, deployments, discussions, issues, pages, pull-requests, repository-projects, statuses, and security-events.