### PR TITLE
Enable client lookup of default orgs if not locally set

### DIFF
--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -151,6 +151,7 @@ func (env testEnviron) Vars() []string {
 
 type testPulumiWorkspace struct {
 	credentials workspace.Credentials
+	config      workspace.PulumiConfig
 }
 
 func (w *testPulumiWorkspace) DeleteAccount(backendURL string) error {
@@ -167,12 +168,12 @@ func (w *testPulumiWorkspace) DeleteAllAccounts() error {
 	return nil
 }
 
-func (*testPulumiWorkspace) SetBackendConfigDefaultOrg(backendURL, defaultOrg string) error {
+func (w *testPulumiWorkspace) SetBackendConfigDefaultOrg(backendURL, defaultOrg string) error {
 	return nil
 }
 
-func (*testPulumiWorkspace) GetPulumiConfig() (workspace.PulumiConfig, error) {
-	return workspace.PulumiConfig{}, nil
+func (w *testPulumiWorkspace) GetPulumiConfig() (workspace.PulumiConfig, error) {
+	return w.config, nil
 }
 
 func (*testPulumiWorkspace) GetPulumiPath(elem ...string) (string, error) {
@@ -281,6 +282,7 @@ func (env *testEnvironment) latest() *testEnvironmentRevision {
 
 type testPulumiClient struct {
 	user         string
+	defaultOrg   string
 	environments map[string]*testEnvironment
 	openEnvs     map[string]*esc.Environment
 }
@@ -469,6 +471,11 @@ func (c *testPulumiClient) GetRevisionNumber(ctx context.Context, orgName, proje
 		return 0, err
 	}
 	return rev.number, nil
+
+}
+
+func (c *testPulumiClient) GetDefaultOrg(ctx context.Context) (string, error) {
+	return c.defaultOrg, nil
 
 }
 

--- a/cmd/esc/cli/client/apitype.go
+++ b/cmd/esc/cli/client/apitype.go
@@ -207,3 +207,11 @@ type RetractEnvironmentRevisionRequest struct {
 	Replacement *int   `json:"replacement,omitempty"`
 	Reason      string `json:"reason,omitempty"`
 }
+
+// GetDefaultOrganizationResponse returns the backend's opinion of which organization
+// to default to for a given user, if a default organization has not been configured.
+type GetDefaultOrganizationResponse struct {
+	// Returns the organization name.
+	// Can be an empty string, if the user is a member of no organizations
+	GitHubLogin string
+}

--- a/cmd/esc/cli/client/apitype.go
+++ b/cmd/esc/cli/client/apitype.go
@@ -213,5 +213,5 @@ type RetractEnvironmentRevisionRequest struct {
 type GetDefaultOrganizationResponse struct {
 	// Returns the organization name.
 	// Can be an empty string, if the user is a member of no organizations
-	GitHubLogin string
+	Organization string `json:"gitHubLogin"`
 }

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -467,7 +467,7 @@ func (pc *client) GetDefaultOrg(ctx context.Context) (string, error) {
 		}
 		return "", err
 	}
-	return resp.GitHubLogin, nil
+	return resp.Organization, nil
 }
 
 func (pc *client) ListEnvironments(

--- a/cmd/esc/cli/client/client_test.go
+++ b/cmd/esc/cli/client/client_test.go
@@ -1124,3 +1124,26 @@ func TestDeleteEnvironmentTags(t *testing.T) {
 		assert.ErrorContains(t, err, http.StatusText(http.StatusNotFound))
 	})
 }
+
+func TestGetDefaultOrg(t *testing.T) {
+	t.Run("Not Found", func(t *testing.T) {
+		// GIVEN
+		client := newTestClient(t, http.MethodGet, "/api/user/organizations/default", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+
+			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
+				Code:    http.StatusNotFound,
+				Message: http.StatusText(http.StatusNotFound),
+			})
+			require.NoError(t, err)
+		})
+
+		// WHEN
+		orgName, err := client.GetDefaultOrg(context.Background())
+
+		// THEN
+		// We should gracefully swallow the 404.
+		assert.NoError(t, err)
+		assert.Empty(t, orgName)
+	})
+}

--- a/cmd/esc/cli/esc.go
+++ b/cmd/esc/cli/esc.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -175,4 +176,28 @@ func (esc *escCommand) confirmPrompt(prompt, name string) bool {
 	reader := bufio.NewReader(esc.stdin)
 	line, _ := reader.ReadString('\n')
 	return strings.TrimSpace(line) == name
+}
+
+// Looks up the default org.
+// Prefers default org that the user has configured locally in their ~/.pulumi/config.
+// If unset, then it will attempt to make an API call to the backend to determine the service's opinion
+// of which user organization should be the default; defaults to individual org otherwise if unset.
+func (esc *escCommand) lookupDefaultOrg(ctx context.Context, backendURL, username string) (string, error) {
+	userConfiguredDefaultOrg, err := esc.workspace.GetBackendConfigDefaultOrg(backendURL, username)
+	if err != nil || userConfiguredDefaultOrg != "" {
+		return userConfiguredDefaultOrg, err
+	}
+
+	// If client is unset, return the individual org.
+	if esc.client == nil {
+		return username, nil
+	}
+
+	backendDefaultOrg, err := esc.client.GetDefaultOrg(ctx)
+	if err != nil {
+		return backendDefaultOrg, err
+	} else if backendDefaultOrg == "" {
+		return username, nil
+	}
+	return backendDefaultOrg, err
 }

--- a/cmd/esc/cli/login.go
+++ b/cmd/esc/cli/login.go
@@ -172,14 +172,8 @@ func (esc *escCommand) getCachedClient(ctx context.Context) error {
 			return fmt.Errorf("could not determine current cloud: %w", err)
 		}
 
-		defaultOrg, err := esc.workspace.GetBackendConfigDefaultOrg(backendURL, nAccount.Username)
-		if err != nil {
-			return fmt.Errorf("could not determine default org: %w", err)
-		}
-
 		account = &workspace.Account{
-			Account:    *nAccount,
-			DefaultOrg: defaultOrg,
+			Account: *nAccount,
 		}
 	}
 
@@ -197,6 +191,14 @@ func (esc *escCommand) getCachedClient(ctx context.Context) error {
 	}
 
 	esc.client = esc.newClient(esc.userAgent, account.BackendURL, account.AccessToken, account.Insecure)
+
+	defaultOrg, err := esc.lookupDefaultOrg(ctx, backendURL, account.Username)
+	if err != nil {
+		return fmt.Errorf("looking up org to default to: %w", err)
+	} else if defaultOrg != "" {
+		esc.account.DefaultOrg = defaultOrg
+	}
+
 	return nil
 }
 
@@ -209,15 +211,9 @@ func (esc *escCommand) getCachedCredentials(ctx context.Context, backendURL stri
 		return false, nil
 	}
 
-	defaultOrg, err := esc.workspace.GetBackendConfigDefaultOrg(backendURL, account.Username)
-	if err != nil {
-		return false, err
-	}
-
 	esc.account = workspace.Account{
 		Account:    *account,
 		BackendURL: backendURL,
-		DefaultOrg: defaultOrg,
 	}
 	return true, nil
 }

--- a/cmd/esc/cli/login_test.go
+++ b/cmd/esc/cli/login_test.go
@@ -137,7 +137,7 @@ func TestEnvVarOverridesAccounts(t *testing.T) {
 
 	// Configure a default org to skip mocking a client call for default org
 	backendConfig := make(map[string]pulumi_workspace.BackendConfig, len(creds.Accounts))
-	for url, _ := range creds.Accounts {
+	for url := range creds.Accounts {
 		backendConfig[url] = pulumi_workspace.BackendConfig{DefaultOrg: "test-user-org"}
 	}
 

--- a/cmd/esc/cli/login_test.go
+++ b/cmd/esc/cli/login_test.go
@@ -134,13 +134,21 @@ func TestEnvVarOverridesAccounts(t *testing.T) {
 			},
 		},
 	}
+
+	// Configure a default org to skip mocking a client call for default org
+	backendConfig := make(map[string]pulumi_workspace.BackendConfig, len(creds.Accounts))
+	for url, _ := range creds.Accounts {
+		backendConfig[url] = pulumi_workspace.BackendConfig{DefaultOrg: "test-user-org"}
+	}
+
 	esc := &escCommand{
 		command: "esc",
 		login:   &testLoginManager{creds: creds},
 		newClient: func(userAgent, backendURL, accessToken string, insecure bool) client.Client {
 			return client.New(userAgent, backendURL, accessToken, insecure)
 		},
-		workspace: workspace.New(testFS{}, &testPulumiWorkspace{}),
+		workspace: workspace.New(testFS{}, &testPulumiWorkspace{
+			config: pulumi_workspace.PulumiConfig{BackendConfig: backendConfig}}),
 	}
 
 	// Verify default

--- a/cmd/esc/cli/workspace/config.go
+++ b/cmd/esc/cli/workspace/config.go
@@ -23,6 +23,7 @@ func (w *Workspace) SetBackendConfigDefaultOrg(backendURL, defaultOrg string) er
 	return w.pulumi.SetBackendConfigDefaultOrg(backendURL, defaultOrg)
 }
 
+// Returns the default org as configured in the backend, returning an empty string if unset.
 func (w *Workspace) GetBackendConfigDefaultOrg(backendURL, username string) (string, error) {
 	config, err := w.pulumi.GetPulumiConfig()
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
@@ -31,5 +32,5 @@ func (w *Workspace) GetBackendConfigDefaultOrg(backendURL, username string) (str
 	if cfg, ok := config.BackendConfig[backendURL]; ok && cfg.DefaultOrg != "" {
 		return cfg.DefaultOrg, nil
 	}
-	return username, nil
+	return "", nil
 }


### PR DESCRIPTION
## Context

Fix https://github.com/pulumi/pulumi-service/issues/27575

A goal of Project Hockeystick is to have new Pulumi users to be able to trial premium Pulumi features immediately; as a part of this, we would want new Pulumi users to have their `esc` usage directly hook into to the trial org with Premium features enabled, rather than their individual org.

For details on the project, see the epic: https://github.com/pulumi/home/issues/3910

## Change

1. Adds integration against the new `GetDefaultOrg` API call: https://github.com/pulumi/pulumi-service/pull/27461
2. Adds fallback logic to make the API call if `~/.pulumi/config` does not have default org set for the given backend;
3. Move fallback logic of falling back to the individual org to after the API call is made.

## Local Testing

