### PR TITLE
syntax: add a node for document trivia

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,5 +11,7 @@
   [#477](https://github.com/pulumi/esc/pull/477)
 - Adding cascading secrets into `NewSecret` method
   [#488](https://github.com/pulumi/esc/pull/488)
+- Top-level comments are no longer dropped when encrypting secrets.
+  [#512](https://github.com/pulumi/esc/pull/512)
 
 ### Breaking changes

--- a/ast/environment.go
+++ b/ast/environment.go
@@ -309,12 +309,23 @@ func parseField(name string, dest reflect.Value, node syntax.Node) syntax.Diagno
 }
 
 func parseRecord(objName string, dest recordDecl, node syntax.Node, noMatchWarning bool) syntax.Diagnostics {
+	syn := node
+
+	// Peek through documents.
+	if doc, ok := node.(*syntax.DocumentNode); ok {
+		// Allow empty documents.
+		if node = doc.Content(); node == nil {
+			*dest.recordSyntax() = doc
+			return nil
+		}
+	}
+
 	obj, ok := node.(*syntax.ObjectNode)
 	if !ok {
 		return syntax.Diagnostics{syntax.NodeError(node, fmt.Sprintf("%v must be an object", objName))}
 	}
-	*dest.recordSyntax() = obj
-	contract.Assertf(*dest.recordSyntax() == obj, "%s.recordSyntax took by value, so the assignment failed", objName)
+	*dest.recordSyntax() = syn
+	contract.Assertf(*dest.recordSyntax() == syn, "%s.recordSyntax took by value, so the assignment failed", objName)
 
 	v := reflect.ValueOf(dest).Elem()
 	t := v.Type()

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -117,7 +117,7 @@ func RotateEnvironment(
 	environments EnvironmentLoader,
 	execContext *esc.ExecContext,
 	paths []resource.PropertyPath,
-) (*esc.Environment, *RotationResult, syntax.Diagnostics) {
+) (*esc.Environment, RotationResult, syntax.Diagnostics) {
 	rotateDocPaths := make(map[string]bool, len(paths))
 	for _, path := range paths {
 		rotateDocPaths["values."+path.String()] = true
@@ -138,7 +138,7 @@ func evalEnvironment(
 	execContext *esc.ExecContext,
 	showSecrets bool,
 	rotatePaths map[string]bool,
-) (*esc.Environment, *RotationResult, syntax.Diagnostics) {
+) (*esc.Environment, RotationResult, syntax.Diagnostics) {
 	if env == nil || (len(env.Values.GetEntries()) == 0 && len(env.Imports.GetElements()) == 0) {
 		return nil, nil, nil
 	}
@@ -165,7 +165,7 @@ func evalEnvironment(
 		Properties:       v.export(name).Value.(map[string]esc.Value),
 		Schema:           s,
 		ExecutionContext: executionContext,
-	}, &ec.rotationResult, diags
+	}, ec.rotationResult, diags
 }
 
 type imported struct {

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -416,7 +416,7 @@ func TestEval(t *testing.T) {
 				var rotated *esc.Environment
 				var patches []*Patch
 				var rotateDiags syntax.Diagnostics
-				var rotationResult *RotationResult
+				var rotationResult RotationResult
 				if doRotate {
 					rotated, rotationResult, rotateDiags = RotateEnvironment(context.Background(), environmentName, env, rot128{}, testProviders{},
 						&testEnvironments{basePath}, execContext, rotatePaths)

--- a/eval/rotation.go
+++ b/eval/rotation.go
@@ -35,9 +35,9 @@ type Rotation struct {
 	Patch  *Patch             // updated rotation state generated during evaluation, to be written back to the environment definition
 }
 
-func (r *RotationResult) Patches() []*Patch {
+func (r RotationResult) Patches() []*Patch {
 	var patches []*Patch
-	for _, rotation := range *r {
+	for _, rotation := range r {
 		if rotation.Patch != nil {
 			patches = append(patches, rotation.Patch)
 		}

--- a/eval/testdata/crypt/omnibus.ciphertext.yaml
+++ b/eval/testdata/crypt/omnibus.ciphertext.yaml
@@ -1,3 +1,5 @@
+# Doc header
+
 imports:
   - a
 values:
@@ -27,3 +29,5 @@ values:
     fn::open::test: ${open}
   interp: hello, ${toString}
   access: ${open["baz"]}
+
+# Doc footer

--- a/eval/testdata/crypt/omnibus.plaintext.yaml
+++ b/eval/testdata/crypt/omnibus.plaintext.yaml
@@ -1,3 +1,5 @@
+# Doc header
+
 imports:
   - a
 values:
@@ -26,3 +28,5 @@ values:
     fn::open::test: ${open}
   interp: hello, ${toString}
   access: ${open["baz"]}
+
+# Doc footer

--- a/syntax/encoding/node_test.go
+++ b/syntax/encoding/node_test.go
@@ -27,10 +27,11 @@ type NodeProperty struct {
 }
 
 type Node struct {
-	Literal any            `json:"literal,omitempty"`
-	Array   []Node         `json:"array,omitempty"`
-	Object  []NodeProperty `json:"object,omitempty"`
-	Range   *hcl.Range     `json:"range,omitempty"`
+	Literal  any            `json:"literal,omitempty"`
+	Array    []Node         `json:"array,omitempty"`
+	Object   []NodeProperty `json:"object,omitempty"`
+	Document *Node          `json:"document,omitempty"`
+	Range    *hcl.Range     `json:"range,omitempty"`
 }
 
 func NewNode(n syntax.Node) Node {
@@ -58,6 +59,9 @@ func NewNode(n syntax.Node) Node {
 			obj[i] = NodeProperty{Key: NewNode(prop.Key), Value: NewNode(prop.Value)}
 		}
 		return Node{Object: obj, Range: n.Syntax().Range()}
+	case *syntax.DocumentNode:
+		content := NewNode(n.Content())
+		return Node{Document: &content, Range: n.Syntax().Range()}
 	default:
 		panic(fmt.Errorf("unexpected node of type %T", n))
 	}

--- a/syntax/encoding/testdata/yaml/alias/decoded.json
+++ b/syntax/encoding/testdata/yaml/alias/decoded.json
@@ -1,60 +1,75 @@
 {
     "syntax": {
-        "object": [
-            {
-                "key": {
-                    "literal": "foo",
-                    "range": {
-                        "Filename": "alias",
-                        "Start": {
-                            "Line": 1,
-                            "Column": 1,
-                            "Byte": 0
-                        },
-                        "End": {
-                            "Line": 1,
-                            "Column": 4,
-                            "Byte": 3
+        "document": {
+            "object": [
+                {
+                    "key": {
+                        "literal": "foo",
+                        "range": {
+                            "Filename": "alias",
+                            "Start": {
+                                "Line": 1,
+                                "Column": 1,
+                                "Byte": 0
+                            },
+                            "End": {
+                                "Line": 1,
+                                "Column": 4,
+                                "Byte": 3
+                            }
+                        }
+                    },
+                    "value": {
+                        "literal": "bar",
+                        "range": {
+                            "Filename": "alias",
+                            "Start": {
+                                "Line": 1,
+                                "Column": 6,
+                                "Byte": 5
+                            },
+                            "End": {
+                                "Line": 1,
+                                "Column": 9,
+                                "Byte": 8
+                            }
                         }
                     }
                 },
-                "value": {
-                    "literal": "bar",
-                    "range": {
-                        "Filename": "alias",
-                        "Start": {
-                            "Line": 1,
-                            "Column": 6,
-                            "Byte": 5
-                        },
-                        "End": {
-                            "Line": 1,
-                            "Column": 9,
-                            "Byte": 8
+                {
+                    "key": {
+                        "literal": "bar",
+                        "range": {
+                            "Filename": "alias",
+                            "Start": {
+                                "Line": 2,
+                                "Column": 1,
+                                "Byte": 16
+                            },
+                            "End": {
+                                "Line": 2,
+                                "Column": 4,
+                                "Byte": 19
+                            }
                         }
-                    }
+                    },
+                    "value": {}
                 }
-            },
-            {
-                "key": {
-                    "literal": "bar",
-                    "range": {
-                        "Filename": "alias",
-                        "Start": {
-                            "Line": 2,
-                            "Column": 1,
-                            "Byte": 16
-                        },
-                        "End": {
-                            "Line": 2,
-                            "Column": 4,
-                            "Byte": 19
-                        }
-                    }
+            ],
+            "range": {
+                "Filename": "alias",
+                "Start": {
+                    "Line": 1,
+                    "Column": 1,
+                    "Byte": 0
                 },
-                "value": {}
+                "End": {
+                    "Line": 2,
+                    "Column": 11,
+                    "Byte": 26
+                }
             }
-        ],
+        },
         "range": {
             "Filename": "alias",
             "Start": {

--- a/syntax/encoding/testdata/yaml/basic/decoded.json
+++ b/syntax/encoding/testdata/yaml/basic/decoded.json
@@ -1,650 +1,665 @@
 {
     "syntax": {
-        "object": [
-            {
-                "key": {
-                    "literal": "null-value",
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 2,
-                            "Column": 1,
-                            "Byte": 19
-                        },
-                        "End": {
-                            "Line": 2,
-                            "Column": 11,
-                            "Byte": 29
-                        }
-                    }
-                },
-                "value": {
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 2,
-                            "Column": 15,
-                            "Byte": 33
-                        },
-                        "End": {
-                            "Line": 2,
-                            "Column": 19,
-                            "Byte": 37
-                        }
-                    }
-                }
-            },
-            {
-                "key": {
-                    "literal": "boolean-value",
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 3,
-                            "Column": 1,
-                            "Byte": 38
-                        },
-                        "End": {
-                            "Line": 3,
-                            "Column": 14,
-                            "Byte": 51
-                        }
-                    }
-                },
-                "value": {
-                    "literal": true,
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 3,
-                            "Column": 16,
-                            "Byte": 53
-                        },
-                        "End": {
-                            "Line": 3,
-                            "Column": 20,
-                            "Byte": 57
-                        }
-                    }
-                }
-            },
-            {
-                "key": {
-                    "literal": "integer-value",
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 4,
-                            "Column": 1,
-                            "Byte": 58
-                        },
-                        "End": {
-                            "Line": 4,
-                            "Column": 14,
-                            "Byte": 71
-                        }
-                    }
-                },
-                "value": {
-                    "literal": 42,
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 4,
-                            "Column": 16,
-                            "Byte": 73
-                        },
-                        "End": {
-                            "Line": 4,
-                            "Column": 18,
-                            "Byte": 75
-                        }
-                    }
-                }
-            },
-            {
-                "key": {
-                    "literal": "number-value",
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 5,
-                            "Column": 1,
-                            "Byte": 76
-                        },
-                        "End": {
-                            "Line": 5,
-                            "Column": 13,
-                            "Byte": 88
-                        }
-                    }
-                },
-                "value": {
-                    "literal": 3.14,
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 5,
-                            "Column": 15,
-                            "Byte": 90
-                        },
-                        "End": {
-                            "Line": 5,
-                            "Column": 19,
-                            "Byte": 94
-                        }
-                    }
-                }
-            },
-            {
-                "key": {
-                    "literal": "string-value",
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 6,
-                            "Column": 1,
-                            "Byte": 95
-                        },
-                        "End": {
-                            "Line": 6,
-                            "Column": 13,
-                            "Byte": 107
-                        }
-                    }
-                },
-                "value": {
-                    "literal": "hello, world",
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 6,
-                            "Column": 15,
-                            "Byte": 109
-                        },
-                        "End": {
-                            "Line": 6,
-                            "Column": 27,
-                            "Byte": 121
-                        }
-                    }
-                }
-            },
-            {
-                "key": {
-                    "literal": "array-value",
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 7,
-                            "Column": 1,
-                            "Byte": 122
-                        },
-                        "End": {
-                            "Line": 7,
-                            "Column": 12,
-                            "Byte": 133
-                        }
-                    }
-                },
-                "value": {
-                    "array": [
-                        {
-                            "literal": "some",
-                            "range": {
-                                "Filename": "basic",
-                                "Start": {
-                                    "Line": 8,
-                                    "Column": 5,
-                                    "Byte": 139
-                                },
-                                "End": {
-                                    "Line": 8,
-                                    "Column": 9,
-                                    "Byte": 143
-                                }
-                            }
-                        },
-                        {
-                            "literal": "array",
-                            "range": {
-                                "Filename": "basic",
-                                "Start": {
-                                    "Line": 9,
-                                    "Column": 5,
-                                    "Byte": 148
-                                },
-                                "End": {
-                                    "Line": 9,
-                                    "Column": 10,
-                                    "Byte": 153
-                                }
-                            }
-                        },
-                        {
-                            "literal": "entries",
-                            "range": {
-                                "Filename": "basic",
-                                "Start": {
-                                    "Line": 10,
-                                    "Column": 5,
-                                    "Byte": 158
-                                },
-                                "End": {
-                                    "Line": 10,
-                                    "Column": 12,
-                                    "Byte": 165
-                                }
-                            }
-                        }
-                    ],
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 8,
-                            "Column": 3,
-                            "Byte": 137
-                        },
-                        "End": {
-                            "Line": 10,
-                            "Column": 12,
-                            "Byte": 165
-                        }
-                    }
-                }
-            },
-            {
-                "key": {
-                    "literal": "object-value",
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 13,
-                            "Column": 1,
-                            "Byte": 190
-                        },
-                        "End": {
-                            "Line": 13,
-                            "Column": 13,
-                            "Byte": 202
-                        }
-                    }
-                },
-                "value": {
-                    "object": [
-                        {
-                            "key": {
-                                "literal": "foo",
-                                "range": {
-                                    "Filename": "basic",
-                                    "Start": {
-                                        "Line": 14,
-                                        "Column": 3,
-                                        "Byte": 206
-                                    },
-                                    "End": {
-                                        "Line": 14,
-                                        "Column": 6,
-                                        "Byte": 209
-                                    }
-                                }
+        "document": {
+            "object": [
+                {
+                    "key": {
+                        "literal": "null-value",
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 2,
+                                "Column": 1,
+                                "Byte": 19
                             },
-                            "value": {
-                                "literal": "bar",
-                                "range": {
-                                    "Filename": "basic",
-                                    "Start": {
-                                        "Line": 14,
-                                        "Column": 8,
-                                        "Byte": 211
-                                    },
-                                    "End": {
-                                        "Line": 14,
-                                        "Column": 11,
-                                        "Byte": 214
-                                    }
-                                }
+                            "End": {
+                                "Line": 2,
+                                "Column": 11,
+                                "Byte": 29
                             }
-                        },
-                        {
-                            "key": {
-                                "literal": "baz",
-                                "range": {
-                                    "Filename": "basic",
-                                    "Start": {
-                                        "Line": 15,
-                                        "Column": 3,
-                                        "Byte": 217
-                                    },
-                                    "End": {
-                                        "Line": 15,
-                                        "Column": 6,
-                                        "Byte": 220
-                                    }
-                                }
+                        }
+                    },
+                    "value": {
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 2,
+                                "Column": 15,
+                                "Byte": 33
                             },
-                            "value": {
-                                "literal": "qux",
-                                "range": {
-                                    "Filename": "basic",
-                                    "Start": {
-                                        "Line": 15,
-                                        "Column": 8,
-                                        "Byte": 222
-                                    },
-                                    "End": {
-                                        "Line": 15,
-                                        "Column": 11,
-                                        "Byte": 225
-                                    }
-                                }
+                            "End": {
+                                "Line": 2,
+                                "Column": 19,
+                                "Byte": 37
                             }
-                        },
-                        {
-                            "key": {
-                                "literal": "nested-object",
-                                "range": {
-                                    "Filename": "basic",
-                                    "Start": {
-                                        "Line": 16,
-                                        "Column": 3,
-                                        "Byte": 228
-                                    },
-                                    "End": {
-                                        "Line": 16,
-                                        "Column": 16,
-                                        "Byte": 241
-                                    }
-                                }
+                        }
+                    }
+                },
+                {
+                    "key": {
+                        "literal": "boolean-value",
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 3,
+                                "Column": 1,
+                                "Byte": 38
                             },
-                            "value": {
-                                "object": [
-                                    {
-                                        "key": {
-                                            "literal": "alpha",
-                                            "range": {
-                                                "Filename": "basic",
-                                                "Start": {
-                                                    "Line": 17,
-                                                    "Column": 5,
-                                                    "Byte": 247
-                                                },
-                                                "End": {
-                                                    "Line": 17,
-                                                    "Column": 10,
-                                                    "Byte": 252
-                                                }
-                                            }
-                                        },
-                                        "value": {
-                                            "literal": "beta",
-                                            "range": {
-                                                "Filename": "basic",
-                                                "Start": {
-                                                    "Line": 17,
-                                                    "Column": 12,
-                                                    "Byte": 254
-                                                },
-                                                "End": {
-                                                    "Line": 17,
-                                                    "Column": 16,
-                                                    "Byte": 258
-                                                }
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "key": {
-                                            "literal": "gamma",
-                                            "range": {
-                                                "Filename": "basic",
-                                                "Start": {
-                                                    "Line": 18,
-                                                    "Column": 5,
-                                                    "Byte": 263
-                                                },
-                                                "End": {
-                                                    "Line": 18,
-                                                    "Column": 10,
-                                                    "Byte": 268
-                                                }
-                                            }
-                                        },
-                                        "value": {
-                                            "array": [
-                                                {
-                                                    "literal": "delta",
-                                                    "range": {
-                                                        "Filename": "basic",
-                                                        "Start": {
-                                                            "Line": 19,
-                                                            "Column": 9,
-                                                            "Byte": 278
-                                                        },
-                                                        "End": {
-                                                            "Line": 19,
-                                                            "Column": 14,
-                                                            "Byte": 283
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "literal": "epslion",
-                                                    "range": {
-                                                        "Filename": "basic",
-                                                        "Start": {
-                                                            "Line": 20,
-                                                            "Column": 9,
-                                                            "Byte": 312
-                                                        },
-                                                        "End": {
-                                                            "Line": 20,
-                                                            "Column": 16,
-                                                            "Byte": 319
-                                                        }
-                                                    }
-                                                }
-                                            ],
-                                            "range": {
-                                                "Filename": "basic",
-                                                "Start": {
-                                                    "Line": 19,
-                                                    "Column": 7,
-                                                    "Byte": 276
-                                                },
-                                                "End": {
-                                                    "Line": 20,
-                                                    "Column": 16,
-                                                    "Byte": 319
-                                                }
-                                            }
-                                        }
-                                    }
-                                ],
+                            "End": {
+                                "Line": 3,
+                                "Column": 14,
+                                "Byte": 51
+                            }
+                        }
+                    },
+                    "value": {
+                        "literal": true,
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 3,
+                                "Column": 16,
+                                "Byte": 53
+                            },
+                            "End": {
+                                "Line": 3,
+                                "Column": 20,
+                                "Byte": 57
+                            }
+                        }
+                    }
+                },
+                {
+                    "key": {
+                        "literal": "integer-value",
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 4,
+                                "Column": 1,
+                                "Byte": 58
+                            },
+                            "End": {
+                                "Line": 4,
+                                "Column": 14,
+                                "Byte": 71
+                            }
+                        }
+                    },
+                    "value": {
+                        "literal": 42,
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 4,
+                                "Column": 16,
+                                "Byte": 73
+                            },
+                            "End": {
+                                "Line": 4,
+                                "Column": 18,
+                                "Byte": 75
+                            }
+                        }
+                    }
+                },
+                {
+                    "key": {
+                        "literal": "number-value",
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 5,
+                                "Column": 1,
+                                "Byte": 76
+                            },
+                            "End": {
+                                "Line": 5,
+                                "Column": 13,
+                                "Byte": 88
+                            }
+                        }
+                    },
+                    "value": {
+                        "literal": 3.14,
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 5,
+                                "Column": 15,
+                                "Byte": 90
+                            },
+                            "End": {
+                                "Line": 5,
+                                "Column": 19,
+                                "Byte": 94
+                            }
+                        }
+                    }
+                },
+                {
+                    "key": {
+                        "literal": "string-value",
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 6,
+                                "Column": 1,
+                                "Byte": 95
+                            },
+                            "End": {
+                                "Line": 6,
+                                "Column": 13,
+                                "Byte": 107
+                            }
+                        }
+                    },
+                    "value": {
+                        "literal": "hello, world",
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 6,
+                                "Column": 15,
+                                "Byte": 109
+                            },
+                            "End": {
+                                "Line": 6,
+                                "Column": 27,
+                                "Byte": 121
+                            }
+                        }
+                    }
+                },
+                {
+                    "key": {
+                        "literal": "array-value",
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 7,
+                                "Column": 1,
+                                "Byte": 122
+                            },
+                            "End": {
+                                "Line": 7,
+                                "Column": 12,
+                                "Byte": 133
+                            }
+                        }
+                    },
+                    "value": {
+                        "array": [
+                            {
+                                "literal": "some",
                                 "range": {
                                     "Filename": "basic",
                                     "Start": {
-                                        "Line": 17,
+                                        "Line": 8,
                                         "Column": 5,
-                                        "Byte": 247
+                                        "Byte": 139
                                     },
                                     "End": {
-                                        "Line": 20,
-                                        "Column": 16,
-                                        "Byte": 319
-                                    }
-                                }
-                            }
-                        }
-                    ],
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 14,
-                            "Column": 3,
-                            "Byte": 206
-                        },
-                        "End": {
-                            "Line": 20,
-                            "Column": 16,
-                            "Byte": 319
-                        }
-                    }
-                }
-            },
-            {
-                "key": {
-                    "literal": "flow-array",
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 22,
-                            "Column": 1,
-                            "Byte": 321
-                        },
-                        "End": {
-                            "Line": 22,
-                            "Column": 11,
-                            "Byte": 331
-                        }
-                    }
-                },
-                "value": {
-                    "array": [
-                        {
-                            "literal": 1,
-                            "range": {
-                                "Filename": "basic",
-                                "Start": {
-                                    "Line": 22,
-                                    "Column": 15,
-                                    "Byte": 335
-                                },
-                                "End": {
-                                    "Line": 22,
-                                    "Column": 16,
-                                    "Byte": 336
-                                }
-                            }
-                        },
-                        {
-                            "literal": 2,
-                            "range": {
-                                "Filename": "basic",
-                                "Start": {
-                                    "Line": 22,
-                                    "Column": 18,
-                                    "Byte": 338
-                                },
-                                "End": {
-                                    "Line": 22,
-                                    "Column": 19,
-                                    "Byte": 339
-                                }
-                            }
-                        },
-                        {
-                            "literal": 3,
-                            "range": {
-                                "Filename": "basic",
-                                "Start": {
-                                    "Line": 22,
-                                    "Column": 21,
-                                    "Byte": 341
-                                },
-                                "End": {
-                                    "Line": 22,
-                                    "Column": 22,
-                                    "Byte": 342
-                                }
-                            }
-                        }
-                    ],
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 22,
-                            "Column": 13,
-                            "Byte": 333
-                        },
-                        "End": {
-                            "Line": 22,
-                            "Column": 22,
-                            "Byte": 342
-                        }
-                    }
-                }
-            },
-            {
-                "key": {
-                    "literal": "flow-object",
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 23,
-                            "Column": 1,
-                            "Byte": 345
-                        },
-                        "End": {
-                            "Line": 23,
-                            "Column": 12,
-                            "Byte": 356
-                        }
-                    }
-                },
-                "value": {
-                    "object": [
-                        {
-                            "key": {
-                                "literal": "hello",
-                                "range": {
-                                    "Filename": "basic",
-                                    "Start": {
-                                        "Line": 23,
-                                        "Column": 16,
-                                        "Byte": 360
-                                    },
-                                    "End": {
-                                        "Line": 23,
-                                        "Column": 21,
-                                        "Byte": 365
+                                        "Line": 8,
+                                        "Column": 9,
+                                        "Byte": 143
                                     }
                                 }
                             },
-                            "value": {
-                                "literal": "world",
+                            {
+                                "literal": "array",
                                 "range": {
                                     "Filename": "basic",
                                     "Start": {
-                                        "Line": 23,
-                                        "Column": 23,
-                                        "Byte": 367
+                                        "Line": 9,
+                                        "Column": 5,
+                                        "Byte": 148
                                     },
                                     "End": {
-                                        "Line": 23,
-                                        "Column": 28,
-                                        "Byte": 372
+                                        "Line": 9,
+                                        "Column": 10,
+                                        "Byte": 153
+                                    }
+                                }
+                            },
+                            {
+                                "literal": "entries",
+                                "range": {
+                                    "Filename": "basic",
+                                    "Start": {
+                                        "Line": 10,
+                                        "Column": 5,
+                                        "Byte": 158
+                                    },
+                                    "End": {
+                                        "Line": 10,
+                                        "Column": 12,
+                                        "Byte": 165
                                     }
                                 }
                             }
-                        }
-                    ],
-                    "range": {
-                        "Filename": "basic",
-                        "Start": {
-                            "Line": 23,
-                            "Column": 14,
-                            "Byte": 358
-                        },
-                        "End": {
-                            "Line": 23,
-                            "Column": 28,
-                            "Byte": 372
+                        ],
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 8,
+                                "Column": 3,
+                                "Byte": 137
+                            },
+                            "End": {
+                                "Line": 10,
+                                "Column": 12,
+                                "Byte": 165
+                            }
                         }
                     }
+                },
+                {
+                    "key": {
+                        "literal": "object-value",
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 13,
+                                "Column": 1,
+                                "Byte": 190
+                            },
+                            "End": {
+                                "Line": 13,
+                                "Column": 13,
+                                "Byte": 202
+                            }
+                        }
+                    },
+                    "value": {
+                        "object": [
+                            {
+                                "key": {
+                                    "literal": "foo",
+                                    "range": {
+                                        "Filename": "basic",
+                                        "Start": {
+                                            "Line": 14,
+                                            "Column": 3,
+                                            "Byte": 206
+                                        },
+                                        "End": {
+                                            "Line": 14,
+                                            "Column": 6,
+                                            "Byte": 209
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "literal": "bar",
+                                    "range": {
+                                        "Filename": "basic",
+                                        "Start": {
+                                            "Line": 14,
+                                            "Column": 8,
+                                            "Byte": 211
+                                        },
+                                        "End": {
+                                            "Line": 14,
+                                            "Column": 11,
+                                            "Byte": 214
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "key": {
+                                    "literal": "baz",
+                                    "range": {
+                                        "Filename": "basic",
+                                        "Start": {
+                                            "Line": 15,
+                                            "Column": 3,
+                                            "Byte": 217
+                                        },
+                                        "End": {
+                                            "Line": 15,
+                                            "Column": 6,
+                                            "Byte": 220
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "literal": "qux",
+                                    "range": {
+                                        "Filename": "basic",
+                                        "Start": {
+                                            "Line": 15,
+                                            "Column": 8,
+                                            "Byte": 222
+                                        },
+                                        "End": {
+                                            "Line": 15,
+                                            "Column": 11,
+                                            "Byte": 225
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "key": {
+                                    "literal": "nested-object",
+                                    "range": {
+                                        "Filename": "basic",
+                                        "Start": {
+                                            "Line": 16,
+                                            "Column": 3,
+                                            "Byte": 228
+                                        },
+                                        "End": {
+                                            "Line": 16,
+                                            "Column": 16,
+                                            "Byte": 241
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "object": [
+                                        {
+                                            "key": {
+                                                "literal": "alpha",
+                                                "range": {
+                                                    "Filename": "basic",
+                                                    "Start": {
+                                                        "Line": 17,
+                                                        "Column": 5,
+                                                        "Byte": 247
+                                                    },
+                                                    "End": {
+                                                        "Line": 17,
+                                                        "Column": 10,
+                                                        "Byte": 252
+                                                    }
+                                                }
+                                            },
+                                            "value": {
+                                                "literal": "beta",
+                                                "range": {
+                                                    "Filename": "basic",
+                                                    "Start": {
+                                                        "Line": 17,
+                                                        "Column": 12,
+                                                        "Byte": 254
+                                                    },
+                                                    "End": {
+                                                        "Line": 17,
+                                                        "Column": 16,
+                                                        "Byte": 258
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "key": {
+                                                "literal": "gamma",
+                                                "range": {
+                                                    "Filename": "basic",
+                                                    "Start": {
+                                                        "Line": 18,
+                                                        "Column": 5,
+                                                        "Byte": 263
+                                                    },
+                                                    "End": {
+                                                        "Line": 18,
+                                                        "Column": 10,
+                                                        "Byte": 268
+                                                    }
+                                                }
+                                            },
+                                            "value": {
+                                                "array": [
+                                                    {
+                                                        "literal": "delta",
+                                                        "range": {
+                                                            "Filename": "basic",
+                                                            "Start": {
+                                                                "Line": 19,
+                                                                "Column": 9,
+                                                                "Byte": 278
+                                                            },
+                                                            "End": {
+                                                                "Line": 19,
+                                                                "Column": 14,
+                                                                "Byte": 283
+                                                            }
+                                                        }
+                                                    },
+                                                    {
+                                                        "literal": "epslion",
+                                                        "range": {
+                                                            "Filename": "basic",
+                                                            "Start": {
+                                                                "Line": 20,
+                                                                "Column": 9,
+                                                                "Byte": 312
+                                                            },
+                                                            "End": {
+                                                                "Line": 20,
+                                                                "Column": 16,
+                                                                "Byte": 319
+                                                            }
+                                                        }
+                                                    }
+                                                ],
+                                                "range": {
+                                                    "Filename": "basic",
+                                                    "Start": {
+                                                        "Line": 19,
+                                                        "Column": 7,
+                                                        "Byte": 276
+                                                    },
+                                                    "End": {
+                                                        "Line": 20,
+                                                        "Column": 16,
+                                                        "Byte": 319
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "range": {
+                                        "Filename": "basic",
+                                        "Start": {
+                                            "Line": 17,
+                                            "Column": 5,
+                                            "Byte": 247
+                                        },
+                                        "End": {
+                                            "Line": 20,
+                                            "Column": 16,
+                                            "Byte": 319
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 14,
+                                "Column": 3,
+                                "Byte": 206
+                            },
+                            "End": {
+                                "Line": 20,
+                                "Column": 16,
+                                "Byte": 319
+                            }
+                        }
+                    }
+                },
+                {
+                    "key": {
+                        "literal": "flow-array",
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 22,
+                                "Column": 1,
+                                "Byte": 321
+                            },
+                            "End": {
+                                "Line": 22,
+                                "Column": 11,
+                                "Byte": 331
+                            }
+                        }
+                    },
+                    "value": {
+                        "array": [
+                            {
+                                "literal": 1,
+                                "range": {
+                                    "Filename": "basic",
+                                    "Start": {
+                                        "Line": 22,
+                                        "Column": 15,
+                                        "Byte": 335
+                                    },
+                                    "End": {
+                                        "Line": 22,
+                                        "Column": 16,
+                                        "Byte": 336
+                                    }
+                                }
+                            },
+                            {
+                                "literal": 2,
+                                "range": {
+                                    "Filename": "basic",
+                                    "Start": {
+                                        "Line": 22,
+                                        "Column": 18,
+                                        "Byte": 338
+                                    },
+                                    "End": {
+                                        "Line": 22,
+                                        "Column": 19,
+                                        "Byte": 339
+                                    }
+                                }
+                            },
+                            {
+                                "literal": 3,
+                                "range": {
+                                    "Filename": "basic",
+                                    "Start": {
+                                        "Line": 22,
+                                        "Column": 21,
+                                        "Byte": 341
+                                    },
+                                    "End": {
+                                        "Line": 22,
+                                        "Column": 22,
+                                        "Byte": 342
+                                    }
+                                }
+                            }
+                        ],
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 22,
+                                "Column": 13,
+                                "Byte": 333
+                            },
+                            "End": {
+                                "Line": 22,
+                                "Column": 22,
+                                "Byte": 342
+                            }
+                        }
+                    }
+                },
+                {
+                    "key": {
+                        "literal": "flow-object",
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 23,
+                                "Column": 1,
+                                "Byte": 345
+                            },
+                            "End": {
+                                "Line": 23,
+                                "Column": 12,
+                                "Byte": 356
+                            }
+                        }
+                    },
+                    "value": {
+                        "object": [
+                            {
+                                "key": {
+                                    "literal": "hello",
+                                    "range": {
+                                        "Filename": "basic",
+                                        "Start": {
+                                            "Line": 23,
+                                            "Column": 16,
+                                            "Byte": 360
+                                        },
+                                        "End": {
+                                            "Line": 23,
+                                            "Column": 21,
+                                            "Byte": 365
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "literal": "world",
+                                    "range": {
+                                        "Filename": "basic",
+                                        "Start": {
+                                            "Line": 23,
+                                            "Column": 23,
+                                            "Byte": 367
+                                        },
+                                        "End": {
+                                            "Line": 23,
+                                            "Column": 28,
+                                            "Byte": 372
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "range": {
+                            "Filename": "basic",
+                            "Start": {
+                                "Line": 23,
+                                "Column": 14,
+                                "Byte": 358
+                            },
+                            "End": {
+                                "Line": 23,
+                                "Column": 28,
+                                "Byte": 372
+                            }
+                        }
+                    }
+                }
+            ],
+            "range": {
+                "Filename": "basic",
+                "Start": {
+                    "Line": 2,
+                    "Column": 1,
+                    "Byte": 19
+                },
+                "End": {
+                    "Line": 23,
+                    "Column": 28,
+                    "Byte": 372
                 }
             }
-        ],
+        },
         "range": {
             "Filename": "basic",
             "Start": {

--- a/syntax/encoding/testdata/yaml/bigint/decoded.json
+++ b/syntax/encoding/testdata/yaml/bigint/decoded.json
@@ -1,75 +1,90 @@
 {
     "syntax": {
-        "object": [
-            {
-                "key": {
-                    "literal": "int64",
-                    "range": {
-                        "Filename": "bigint",
-                        "Start": {
-                            "Line": 1,
-                            "Column": 1,
-                            "Byte": 0
-                        },
-                        "End": {
-                            "Line": 1,
-                            "Column": 6,
-                            "Byte": 5
+        "document": {
+            "object": [
+                {
+                    "key": {
+                        "literal": "int64",
+                        "range": {
+                            "Filename": "bigint",
+                            "Start": {
+                                "Line": 1,
+                                "Column": 1,
+                                "Byte": 0
+                            },
+                            "End": {
+                                "Line": 1,
+                                "Column": 6,
+                                "Byte": 5
+                            }
+                        }
+                    },
+                    "value": {
+                        "literal": 9223372036854775807,
+                        "range": {
+                            "Filename": "bigint",
+                            "Start": {
+                                "Line": 1,
+                                "Column": 8,
+                                "Byte": 7
+                            },
+                            "End": {
+                                "Line": 1,
+                                "Column": 27,
+                                "Byte": 26
+                            }
                         }
                     }
                 },
-                "value": {
-                    "literal": 9223372036854775807,
-                    "range": {
-                        "Filename": "bigint",
-                        "Start": {
-                            "Line": 1,
-                            "Column": 8,
-                            "Byte": 7
-                        },
-                        "End": {
-                            "Line": 1,
-                            "Column": 27,
-                            "Byte": 26
+                {
+                    "key": {
+                        "literal": "uint64",
+                        "range": {
+                            "Filename": "bigint",
+                            "Start": {
+                                "Line": 2,
+                                "Column": 1,
+                                "Byte": 27
+                            },
+                            "End": {
+                                "Line": 2,
+                                "Column": 7,
+                                "Byte": 33
+                            }
+                        }
+                    },
+                    "value": {
+                        "literal": 18446744073709551615,
+                        "range": {
+                            "Filename": "bigint",
+                            "Start": {
+                                "Line": 2,
+                                "Column": 9,
+                                "Byte": 35
+                            },
+                            "End": {
+                                "Line": 2,
+                                "Column": 29,
+                                "Byte": 55
+                            }
                         }
                     }
                 }
-            },
-            {
-                "key": {
-                    "literal": "uint64",
-                    "range": {
-                        "Filename": "bigint",
-                        "Start": {
-                            "Line": 2,
-                            "Column": 1,
-                            "Byte": 27
-                        },
-                        "End": {
-                            "Line": 2,
-                            "Column": 7,
-                            "Byte": 33
-                        }
-                    }
+            ],
+            "range": {
+                "Filename": "bigint",
+                "Start": {
+                    "Line": 1,
+                    "Column": 1,
+                    "Byte": 0
                 },
-                "value": {
-                    "literal": 18446744073709551615,
-                    "range": {
-                        "Filename": "bigint",
-                        "Start": {
-                            "Line": 2,
-                            "Column": 9,
-                            "Byte": 35
-                        },
-                        "End": {
-                            "Line": 2,
-                            "Column": 29,
-                            "Byte": 55
-                        }
-                    }
+                "End": {
+                    "Line": 2,
+                    "Column": 29,
+                    "Byte": 55
                 }
             }
-        ],
+        },
         "range": {
             "Filename": "bigint",
             "Start": {

--- a/syntax/encoding/testdata/yaml/blocks/decoded.json
+++ b/syntax/encoding/testdata/yaml/blocks/decoded.json
@@ -1,75 +1,90 @@
 {
     "syntax": {
-        "object": [
-            {
-                "key": {
-                    "literal": "fold",
-                    "range": {
-                        "Filename": "blocks",
-                        "Start": {
-                            "Line": 1,
-                            "Column": 1,
-                            "Byte": 0
-                        },
-                        "End": {
-                            "Line": 1,
-                            "Column": 5,
-                            "Byte": 4
+        "document": {
+            "object": [
+                {
+                    "key": {
+                        "literal": "fold",
+                        "range": {
+                            "Filename": "blocks",
+                            "Start": {
+                                "Line": 1,
+                                "Column": 1,
+                                "Byte": 0
+                            },
+                            "End": {
+                                "Line": 1,
+                                "Column": 5,
+                                "Byte": 4
+                            }
+                        }
+                    },
+                    "value": {
+                        "literal": "replace newlines with spaces\n",
+                        "range": {
+                            "Filename": "blocks",
+                            "Start": {
+                                "Line": 1,
+                                "Column": 7,
+                                "Byte": 6
+                            },
+                            "End": {
+                                "Line": 1,
+                                "Column": 36,
+                                "Byte": 35
+                            }
                         }
                     }
                 },
-                "value": {
-                    "literal": "replace newlines with spaces\n",
-                    "range": {
-                        "Filename": "blocks",
-                        "Start": {
-                            "Line": 1,
-                            "Column": 7,
-                            "Byte": 6
-                        },
-                        "End": {
-                            "Line": 1,
-                            "Column": 36,
-                            "Byte": 35
+                {
+                    "key": {
+                        "literal": "literal",
+                        "range": {
+                            "Filename": "blocks",
+                            "Start": {
+                                "Line": 6,
+                                "Column": 1,
+                                "Byte": 45
+                            },
+                            "End": {
+                                "Line": 6,
+                                "Column": 8,
+                                "Byte": 52
+                            }
+                        }
+                    },
+                    "value": {
+                        "literal": "keep\nnewlines\nintact\n",
+                        "range": {
+                            "Filename": "blocks",
+                            "Start": {
+                                "Line": 6,
+                                "Column": 10,
+                                "Byte": 54
+                            },
+                            "End": {
+                                "Line": 9,
+                                "Column": 10,
+                                "Byte": 83
+                            }
                         }
                     }
                 }
-            },
-            {
-                "key": {
-                    "literal": "literal",
-                    "range": {
-                        "Filename": "blocks",
-                        "Start": {
-                            "Line": 6,
-                            "Column": 1,
-                            "Byte": 45
-                        },
-                        "End": {
-                            "Line": 6,
-                            "Column": 8,
-                            "Byte": 52
-                        }
-                    }
+            ],
+            "range": {
+                "Filename": "blocks",
+                "Start": {
+                    "Line": 1,
+                    "Column": 1,
+                    "Byte": 0
                 },
-                "value": {
-                    "literal": "keep\nnewlines\nintact\n",
-                    "range": {
-                        "Filename": "blocks",
-                        "Start": {
-                            "Line": 6,
-                            "Column": 10,
-                            "Byte": 54
-                        },
-                        "End": {
-                            "Line": 9,
-                            "Column": 10,
-                            "Byte": 83
-                        }
-                    }
+                "End": {
+                    "Line": 9,
+                    "Column": 10,
+                    "Byte": 83
                 }
             }
-        ],
+        },
         "range": {
             "Filename": "blocks",
             "Start": {

--- a/syntax/encoding/testdata/yaml/comments/decoded.json
+++ b/syntax/encoding/testdata/yaml/comments/decoded.json
@@ -1,0 +1,102 @@
+{
+    "syntax": {
+        "document": {
+            "object": [
+                {
+                    "key": {
+                        "literal": "k1",
+                        "range": {
+                            "Filename": "comments",
+                            "Start": {
+                                "Line": 6,
+                                "Column": 3,
+                                "Byte": 53
+                            },
+                            "End": {
+                                "Line": 6,
+                                "Column": 5,
+                                "Byte": 55
+                            }
+                        }
+                    },
+                    "value": {
+                        "literal": "v1",
+                        "range": {
+                            "Filename": "comments",
+                            "Start": {
+                                "Line": 6,
+                                "Column": 7,
+                                "Byte": 57
+                            },
+                            "End": {
+                                "Line": 6,
+                                "Column": 9,
+                                "Byte": 59
+                            }
+                        }
+                    }
+                },
+                {
+                    "key": {
+                        "literal": "k2",
+                        "range": {
+                            "Filename": "comments",
+                            "Start": {
+                                "Line": 10,
+                                "Column": 3,
+                                "Byte": 113
+                            },
+                            "End": {
+                                "Line": 10,
+                                "Column": 5,
+                                "Byte": 115
+                            }
+                        }
+                    },
+                    "value": {
+                        "literal": "v2",
+                        "range": {
+                            "Filename": "comments",
+                            "Start": {
+                                "Line": 10,
+                                "Column": 7,
+                                "Byte": 117
+                            },
+                            "End": {
+                                "Line": 10,
+                                "Column": 9,
+                                "Byte": 119
+                            }
+                        }
+                    }
+                }
+            ],
+            "range": {
+                "Filename": "comments",
+                "Start": {
+                    "Line": 4,
+                    "Column": 1,
+                    "Byte": 32
+                },
+                "End": {
+                    "Line": 10,
+                    "Column": 9,
+                    "Byte": 119
+                }
+            }
+        },
+        "range": {
+            "Filename": "comments",
+            "Start": {
+                "Line": 4,
+                "Column": 1,
+                "Byte": 32
+            },
+            "End": {
+                "Line": 10,
+                "Column": 9,
+                "Byte": 119
+            }
+        }
+    }
+}

--- a/syntax/encoding/testdata/yaml/comments/doc.yaml
+++ b/syntax/encoding/testdata/yaml/comments/doc.yaml
@@ -1,0 +1,15 @@
+# Document head
+
+# Mapping head
+{
+  # Entry head 1
+  k1: v1, # Entry line 1
+  # Entry foot 1
+
+  # Entry head 2
+  k2: v2, # Entry line 2
+  # Entry foot 2
+}
+# Mapping foot
+
+# Document foot

--- a/syntax/encoding/testdata/yaml/comments/encoded.yaml
+++ b/syntax/encoding/testdata/yaml/comments/encoded.yaml
@@ -1,0 +1,15 @@
+# Document head
+
+# Mapping head
+{
+  # Entry head 1
+  k1: v1, # Entry line 1
+  # Entry foot 1
+
+  # Entry head 2
+  k2: v2, # Entry line 2
+  # Entry foot 2
+}
+# Mapping foot
+
+# Document foot

--- a/syntax/encoding/testdata/yaml/tags/decoded.json
+++ b/syntax/encoding/testdata/yaml/tags/decoded.json
@@ -1,313 +1,328 @@
 {
     "syntax": {
-        "object": [
-            {
-                "key": {
-                    "literal": "null-value",
-                    "range": {
-                        "Filename": "tags",
-                        "Start": {
-                            "Line": 1,
-                            "Column": 1,
-                            "Byte": 0
-                        },
-                        "End": {
-                            "Line": 1,
-                            "Column": 11,
-                            "Byte": 10
-                        }
-                    }
-                },
-                "value": {
-                    "literal": "null",
-                    "range": {
-                        "Filename": "tags",
-                        "Start": {
-                            "Line": 1,
-                            "Column": 15,
-                            "Byte": 14
-                        },
-                        "End": {
-                            "Line": 1,
-                            "Column": 24,
-                            "Byte": 23
-                        }
-                    }
-                }
-            },
-            {
-                "key": {
-                    "literal": "boolean-value",
-                    "range": {
-                        "Filename": "tags",
-                        "Start": {
-                            "Line": 2,
-                            "Column": 1,
-                            "Byte": 24
-                        },
-                        "End": {
-                            "Line": 2,
-                            "Column": 14,
-                            "Byte": 37
-                        }
-                    }
-                },
-                "value": {
-                    "literal": "true",
-                    "range": {
-                        "Filename": "tags",
-                        "Start": {
-                            "Line": 2,
-                            "Column": 16,
-                            "Byte": 39
-                        },
-                        "End": {
-                            "Line": 2,
-                            "Column": 25,
-                            "Byte": 48
-                        }
-                    }
-                }
-            },
-            {
-                "key": {
-                    "literal": "integer-value",
-                    "range": {
-                        "Filename": "tags",
-                        "Start": {
-                            "Line": 3,
-                            "Column": 1,
-                            "Byte": 49
-                        },
-                        "End": {
-                            "Line": 3,
-                            "Column": 14,
-                            "Byte": 62
-                        }
-                    }
-                },
-                "value": {
-                    "literal": "42",
-                    "range": {
-                        "Filename": "tags",
-                        "Start": {
-                            "Line": 3,
-                            "Column": 16,
-                            "Byte": 64
-                        },
-                        "End": {
-                            "Line": 3,
-                            "Column": 23,
-                            "Byte": 71
-                        }
-                    }
-                }
-            },
-            {
-                "key": {
-                    "literal": "number-value",
-                    "range": {
-                        "Filename": "tags",
-                        "Start": {
-                            "Line": 4,
-                            "Column": 1,
-                            "Byte": 72
-                        },
-                        "End": {
-                            "Line": 4,
-                            "Column": 13,
-                            "Byte": 84
-                        }
-                    }
-                },
-                "value": {
-                    "literal": "3.14",
-                    "range": {
-                        "Filename": "tags",
-                        "Start": {
-                            "Line": 4,
-                            "Column": 15,
-                            "Byte": 86
-                        },
-                        "End": {
-                            "Line": 4,
-                            "Column": 24,
-                            "Byte": 95
-                        }
-                    }
-                }
-            },
-            {
-                "key": {
-                    "literal": "string-value",
-                    "range": {
-                        "Filename": "tags",
-                        "Start": {
-                            "Line": 5,
-                            "Column": 1,
-                            "Byte": 96
-                        },
-                        "End": {
-                            "Line": 5,
-                            "Column": 13,
-                            "Byte": 108
-                        }
-                    }
-                },
-                "value": {
-                    "literal": "hello, world",
-                    "range": {
-                        "Filename": "tags",
-                        "Start": {
-                            "Line": 5,
-                            "Column": 15,
-                            "Byte": 110
-                        },
-                        "End": {
-                            "Line": 5,
-                            "Column": 32,
-                            "Byte": 127
-                        }
-                    }
-                }
-            },
-            {
-                "key": {
-                    "literal": "array-value",
-                    "range": {
-                        "Filename": "tags",
-                        "Start": {
-                            "Line": 6,
-                            "Column": 1,
-                            "Byte": 128
-                        },
-                        "End": {
-                            "Line": 6,
-                            "Column": 12,
-                            "Byte": 139
-                        }
-                    }
-                },
-                "value": {
-                    "array": [
-                        {
-                            "literal": 0,
-                            "range": {
-                                "Filename": "tags",
-                                "Start": {
-                                    "Line": 6,
-                                    "Column": 20,
-                                    "Byte": 147
-                                },
-                                "End": {
-                                    "Line": 6,
-                                    "Column": 21,
-                                    "Byte": 148
-                                }
-                            }
-                        },
-                        {
-                            "literal": 1,
-                            "range": {
-                                "Filename": "tags",
-                                "Start": {
-                                    "Line": 6,
-                                    "Column": 23,
-                                    "Byte": 150
-                                },
-                                "End": {
-                                    "Line": 6,
-                                    "Column": 24,
-                                    "Byte": 151
-                                }
+        "document": {
+            "object": [
+                {
+                    "key": {
+                        "literal": "null-value",
+                        "range": {
+                            "Filename": "tags",
+                            "Start": {
+                                "Line": 1,
+                                "Column": 1,
+                                "Byte": 0
+                            },
+                            "End": {
+                                "Line": 1,
+                                "Column": 11,
+                                "Byte": 10
                             }
                         }
-                    ],
-                    "range": {
-                        "Filename": "tags",
-                        "Start": {
-                            "Line": 6,
-                            "Column": 14,
-                            "Byte": 141
-                        },
-                        "End": {
-                            "Line": 6,
-                            "Column": 24,
-                            "Byte": 151
-                        }
-                    }
-                }
-            },
-            {
-                "key": {
-                    "literal": "object-value",
-                    "range": {
-                        "Filename": "tags",
-                        "Start": {
-                            "Line": 7,
-                            "Column": 1,
-                            "Byte": 153
-                        },
-                        "End": {
-                            "Line": 7,
-                            "Column": 13,
-                            "Byte": 165
+                    },
+                    "value": {
+                        "literal": "null",
+                        "range": {
+                            "Filename": "tags",
+                            "Start": {
+                                "Line": 1,
+                                "Column": 15,
+                                "Byte": 14
+                            },
+                            "End": {
+                                "Line": 1,
+                                "Column": 24,
+                                "Byte": 23
+                            }
                         }
                     }
                 },
-                "value": {
-                    "object": [
-                        {
-                            "key": {
-                                "literal": "a",
+                {
+                    "key": {
+                        "literal": "boolean-value",
+                        "range": {
+                            "Filename": "tags",
+                            "Start": {
+                                "Line": 2,
+                                "Column": 1,
+                                "Byte": 24
+                            },
+                            "End": {
+                                "Line": 2,
+                                "Column": 14,
+                                "Byte": 37
+                            }
+                        }
+                    },
+                    "value": {
+                        "literal": "true",
+                        "range": {
+                            "Filename": "tags",
+                            "Start": {
+                                "Line": 2,
+                                "Column": 16,
+                                "Byte": 39
+                            },
+                            "End": {
+                                "Line": 2,
+                                "Column": 25,
+                                "Byte": 48
+                            }
+                        }
+                    }
+                },
+                {
+                    "key": {
+                        "literal": "integer-value",
+                        "range": {
+                            "Filename": "tags",
+                            "Start": {
+                                "Line": 3,
+                                "Column": 1,
+                                "Byte": 49
+                            },
+                            "End": {
+                                "Line": 3,
+                                "Column": 14,
+                                "Byte": 62
+                            }
+                        }
+                    },
+                    "value": {
+                        "literal": "42",
+                        "range": {
+                            "Filename": "tags",
+                            "Start": {
+                                "Line": 3,
+                                "Column": 16,
+                                "Byte": 64
+                            },
+                            "End": {
+                                "Line": 3,
+                                "Column": 23,
+                                "Byte": 71
+                            }
+                        }
+                    }
+                },
+                {
+                    "key": {
+                        "literal": "number-value",
+                        "range": {
+                            "Filename": "tags",
+                            "Start": {
+                                "Line": 4,
+                                "Column": 1,
+                                "Byte": 72
+                            },
+                            "End": {
+                                "Line": 4,
+                                "Column": 13,
+                                "Byte": 84
+                            }
+                        }
+                    },
+                    "value": {
+                        "literal": "3.14",
+                        "range": {
+                            "Filename": "tags",
+                            "Start": {
+                                "Line": 4,
+                                "Column": 15,
+                                "Byte": 86
+                            },
+                            "End": {
+                                "Line": 4,
+                                "Column": 24,
+                                "Byte": 95
+                            }
+                        }
+                    }
+                },
+                {
+                    "key": {
+                        "literal": "string-value",
+                        "range": {
+                            "Filename": "tags",
+                            "Start": {
+                                "Line": 5,
+                                "Column": 1,
+                                "Byte": 96
+                            },
+                            "End": {
+                                "Line": 5,
+                                "Column": 13,
+                                "Byte": 108
+                            }
+                        }
+                    },
+                    "value": {
+                        "literal": "hello, world",
+                        "range": {
+                            "Filename": "tags",
+                            "Start": {
+                                "Line": 5,
+                                "Column": 15,
+                                "Byte": 110
+                            },
+                            "End": {
+                                "Line": 5,
+                                "Column": 32,
+                                "Byte": 127
+                            }
+                        }
+                    }
+                },
+                {
+                    "key": {
+                        "literal": "array-value",
+                        "range": {
+                            "Filename": "tags",
+                            "Start": {
+                                "Line": 6,
+                                "Column": 1,
+                                "Byte": 128
+                            },
+                            "End": {
+                                "Line": 6,
+                                "Column": 12,
+                                "Byte": 139
+                            }
+                        }
+                    },
+                    "value": {
+                        "array": [
+                            {
+                                "literal": 0,
                                 "range": {
                                     "Filename": "tags",
                                     "Start": {
-                                        "Line": 7,
-                                        "Column": 22,
-                                        "Byte": 174
+                                        "Line": 6,
+                                        "Column": 20,
+                                        "Byte": 147
                                     },
                                     "End": {
-                                        "Line": 7,
-                                        "Column": 23,
-                                        "Byte": 175
+                                        "Line": 6,
+                                        "Column": 21,
+                                        "Byte": 148
                                     }
                                 }
                             },
-                            "value": {
-                                "literal": "b",
+                            {
+                                "literal": 1,
                                 "range": {
                                     "Filename": "tags",
                                     "Start": {
-                                        "Line": 7,
-                                        "Column": 25,
-                                        "Byte": 177
+                                        "Line": 6,
+                                        "Column": 23,
+                                        "Byte": 150
                                     },
                                     "End": {
-                                        "Line": 7,
-                                        "Column": 26,
-                                        "Byte": 178
+                                        "Line": 6,
+                                        "Column": 24,
+                                        "Byte": 151
                                     }
                                 }
                             }
+                        ],
+                        "range": {
+                            "Filename": "tags",
+                            "Start": {
+                                "Line": 6,
+                                "Column": 14,
+                                "Byte": 141
+                            },
+                            "End": {
+                                "Line": 6,
+                                "Column": 24,
+                                "Byte": 151
+                            }
                         }
-                    ],
-                    "range": {
-                        "Filename": "tags",
-                        "Start": {
-                            "Line": 7,
-                            "Column": 15,
-                            "Byte": 167
-                        },
-                        "End": {
-                            "Line": 7,
-                            "Column": 26,
-                            "Byte": 178
+                    }
+                },
+                {
+                    "key": {
+                        "literal": "object-value",
+                        "range": {
+                            "Filename": "tags",
+                            "Start": {
+                                "Line": 7,
+                                "Column": 1,
+                                "Byte": 153
+                            },
+                            "End": {
+                                "Line": 7,
+                                "Column": 13,
+                                "Byte": 165
+                            }
+                        }
+                    },
+                    "value": {
+                        "object": [
+                            {
+                                "key": {
+                                    "literal": "a",
+                                    "range": {
+                                        "Filename": "tags",
+                                        "Start": {
+                                            "Line": 7,
+                                            "Column": 22,
+                                            "Byte": 174
+                                        },
+                                        "End": {
+                                            "Line": 7,
+                                            "Column": 23,
+                                            "Byte": 175
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "literal": "b",
+                                    "range": {
+                                        "Filename": "tags",
+                                        "Start": {
+                                            "Line": 7,
+                                            "Column": 25,
+                                            "Byte": 177
+                                        },
+                                        "End": {
+                                            "Line": 7,
+                                            "Column": 26,
+                                            "Byte": 178
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "range": {
+                            "Filename": "tags",
+                            "Start": {
+                                "Line": 7,
+                                "Column": 15,
+                                "Byte": 167
+                            },
+                            "End": {
+                                "Line": 7,
+                                "Column": 26,
+                                "Byte": 178
+                            }
                         }
                     }
                 }
+            ],
+            "range": {
+                "Filename": "tags",
+                "Start": {
+                    "Line": 1,
+                    "Column": 1,
+                    "Byte": 0
+                },
+                "End": {
+                    "Line": 7,
+                    "Column": 26,
+                    "Byte": 178
+                }
             }
-        ],
+        },
         "range": {
             "Filename": "tags",
             "Start": {

--- a/syntax/encoding/testdata/yaml/top-level-array/decoded.json
+++ b/syntax/encoding/testdata/yaml/top-level-array/decoded.json
@@ -1,55 +1,70 @@
 {
     "syntax": {
-        "array": [
-            {
-                "literal": "list",
-                "range": {
-                    "Filename": "top-level-array",
-                    "Start": {
-                        "Line": 1,
-                        "Column": 3,
-                        "Byte": 2
-                    },
-                    "End": {
-                        "Line": 1,
-                        "Column": 7,
-                        "Byte": 6
+        "document": {
+            "array": [
+                {
+                    "literal": "list",
+                    "range": {
+                        "Filename": "top-level-array",
+                        "Start": {
+                            "Line": 1,
+                            "Column": 3,
+                            "Byte": 2
+                        },
+                        "End": {
+                            "Line": 1,
+                            "Column": 7,
+                            "Byte": 6
+                        }
+                    }
+                },
+                {
+                    "literal": "of",
+                    "range": {
+                        "Filename": "top-level-array",
+                        "Start": {
+                            "Line": 2,
+                            "Column": 3,
+                            "Byte": 9
+                        },
+                        "End": {
+                            "Line": 2,
+                            "Column": 5,
+                            "Byte": 11
+                        }
+                    }
+                },
+                {
+                    "literal": "values",
+                    "range": {
+                        "Filename": "top-level-array",
+                        "Start": {
+                            "Line": 3,
+                            "Column": 3,
+                            "Byte": 14
+                        },
+                        "End": {
+                            "Line": 3,
+                            "Column": 9,
+                            "Byte": 20
+                        }
                     }
                 }
-            },
-            {
-                "literal": "of",
-                "range": {
-                    "Filename": "top-level-array",
-                    "Start": {
-                        "Line": 2,
-                        "Column": 3,
-                        "Byte": 9
-                    },
-                    "End": {
-                        "Line": 2,
-                        "Column": 5,
-                        "Byte": 11
-                    }
-                }
-            },
-            {
-                "literal": "values",
-                "range": {
-                    "Filename": "top-level-array",
-                    "Start": {
-                        "Line": 3,
-                        "Column": 3,
-                        "Byte": 14
-                    },
-                    "End": {
-                        "Line": 3,
-                        "Column": 9,
-                        "Byte": 20
-                    }
+            ],
+            "range": {
+                "Filename": "top-level-array",
+                "Start": {
+                    "Line": 1,
+                    "Column": 1,
+                    "Byte": 0
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 9,
+                    "Byte": 20
                 }
             }
-        ],
+        },
         "range": {
             "Filename": "top-level-array",
             "Start": {

--- a/syntax/encoding/testdata/yaml/unicode/decoded.json
+++ b/syntax/encoding/testdata/yaml/unicode/decoded.json
@@ -1,246 +1,261 @@
 {
     "syntax": {
-        "object": [
-            {
-                "key": {
-                    "literal": "values",
-                    "range": {
-                        "Filename": "unicode",
-                        "Start": {
-                            "Line": 1,
-                            "Column": 1,
-                            "Byte": 0
-                        },
-                        "End": {
-                            "Line": 1,
-                            "Column": 7,
-                            "Byte": 6
+        "document": {
+            "object": [
+                {
+                    "key": {
+                        "literal": "values",
+                        "range": {
+                            "Filename": "unicode",
+                            "Start": {
+                                "Line": 1,
+                                "Column": 1,
+                                "Byte": 0
+                            },
+                            "End": {
+                                "Line": 1,
+                                "Column": 7,
+                                "Byte": 6
+                            }
                         }
-                    }
-                },
-                "value": {
-                    "object": [
-                        {
-                            "key": {
-                                "literal": "hello",
-                                "range": {
-                                    "Filename": "unicode",
-                                    "Start": {
-                                        "Line": 2,
-                                        "Column": 3,
-                                        "Byte": 10
-                                    },
-                                    "End": {
-                                        "Line": 2,
-                                        "Column": 8,
-                                        "Byte": 15
-                                    }
-                                }
-                            },
-                            "value": {
-                                "literal": "世界",
-                                "range": {
-                                    "Filename": "unicode",
-                                    "Start": {
-                                        "Line": 2,
-                                        "Column": 10,
-                                        "Byte": 17
-                                    },
-                                    "End": {
-                                        "Line": 2,
-                                        "Column": 16,
-                                        "Byte": 23
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "key": {
-                                "literal": "世界",
-                                "range": {
-                                    "Filename": "unicode",
-                                    "Start": {
-                                        "Line": 3,
-                                        "Column": 3,
-                                        "Byte": 26
-                                    },
-                                    "End": {
-                                        "Line": 3,
-                                        "Column": 9,
-                                        "Byte": 34
-                                    }
-                                }
-                            },
-                            "value": {
-                                "literal": "hello",
-                                "range": {
-                                    "Filename": "unicode",
-                                    "Start": {
-                                        "Line": 3,
-                                        "Column": 7,
-                                        "Byte": 32
-                                    },
-                                    "End": {
-                                        "Line": 3,
-                                        "Column": 12,
-                                        "Byte": 37
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "key": {
-                                "literal": "linear-b",
-                                "range": {
-                                    "Filename": "unicode",
-                                    "Start": {
-                                        "Line": 4,
-                                        "Column": 3,
-                                        "Byte": 42
-                                    },
-                                    "End": {
-                                        "Line": 4,
-                                        "Column": 11,
-                                        "Byte": 50
-                                    }
-                                }
-                            },
-                            "value": {
-                                "array": [
-                                    {
-                                        "literal": "𐀀",
-                                        "range": {
-                                            "Filename": "unicode",
-                                            "Start": {
-                                                "Line": 5,
-                                                "Column": 7,
-                                                "Byte": 58
-                                            },
-                                            "End": {
-                                                "Line": 5,
-                                                "Column": 11,
-                                                "Byte": 62
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "literal": "𐀁",
-                                        "range": {
-                                            "Filename": "unicode",
-                                            "Start": {
-                                                "Line": 6,
-                                                "Column": 7,
-                                                "Byte": 69
-                                            },
-                                            "End": {
-                                                "Line": 6,
-                                                "Column": 11,
-                                                "Byte": 73
-                                            }
+                    },
+                    "value": {
+                        "object": [
+                            {
+                                "key": {
+                                    "literal": "hello",
+                                    "range": {
+                                        "Filename": "unicode",
+                                        "Start": {
+                                            "Line": 2,
+                                            "Column": 3,
+                                            "Byte": 10
+                                        },
+                                        "End": {
+                                            "Line": 2,
+                                            "Column": 8,
+                                            "Byte": 15
                                         }
                                     }
-                                ],
-                                "range": {
-                                    "Filename": "unicode",
-                                    "Start": {
-                                        "Line": 5,
-                                        "Column": 5,
-                                        "Byte": 56
-                                    },
-                                    "End": {
-                                        "Line": 6,
-                                        "Column": 11,
-                                        "Byte": 73
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "key": {
-                                "literal": "danmark",
-                                "range": {
-                                    "Filename": "unicode",
-                                    "Start": {
-                                        "Line": 7,
-                                        "Column": 3,
-                                        "Byte": 76
-                                    },
-                                    "End": {
-                                        "Line": 7,
-                                        "Column": 10,
-                                        "Byte": 83
+                                },
+                                "value": {
+                                    "literal": "世界",
+                                    "range": {
+                                        "Filename": "unicode",
+                                        "Start": {
+                                            "Line": 2,
+                                            "Column": 10,
+                                            "Byte": 17
+                                        },
+                                        "End": {
+                                            "Line": 2,
+                                            "Column": 16,
+                                            "Byte": 23
+                                        }
                                     }
                                 }
                             },
-                            "value": {
-                                "object": [
-                                    {
-                                        "key": {
-                                            "literal": "hovedstad",
+                            {
+                                "key": {
+                                    "literal": "世界",
+                                    "range": {
+                                        "Filename": "unicode",
+                                        "Start": {
+                                            "Line": 3,
+                                            "Column": 3,
+                                            "Byte": 26
+                                        },
+                                        "End": {
+                                            "Line": 3,
+                                            "Column": 9,
+                                            "Byte": 34
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "literal": "hello",
+                                    "range": {
+                                        "Filename": "unicode",
+                                        "Start": {
+                                            "Line": 3,
+                                            "Column": 7,
+                                            "Byte": 32
+                                        },
+                                        "End": {
+                                            "Line": 3,
+                                            "Column": 12,
+                                            "Byte": 37
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "key": {
+                                    "literal": "linear-b",
+                                    "range": {
+                                        "Filename": "unicode",
+                                        "Start": {
+                                            "Line": 4,
+                                            "Column": 3,
+                                            "Byte": 42
+                                        },
+                                        "End": {
+                                            "Line": 4,
+                                            "Column": 11,
+                                            "Byte": 50
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "array": [
+                                        {
+                                            "literal": "𐀀",
                                             "range": {
                                                 "Filename": "unicode",
                                                 "Start": {
-                                                    "Line": 8,
-                                                    "Column": 5,
-                                                    "Byte": 89
+                                                    "Line": 5,
+                                                    "Column": 7,
+                                                    "Byte": 58
                                                 },
                                                 "End": {
-                                                    "Line": 8,
-                                                    "Column": 14,
-                                                    "Byte": 98
+                                                    "Line": 5,
+                                                    "Column": 11,
+                                                    "Byte": 62
                                                 }
                                             }
                                         },
-                                        "value": {
-                                            "literal": "københavn",
+                                        {
+                                            "literal": "𐀁",
                                             "range": {
                                                 "Filename": "unicode",
                                                 "Start": {
-                                                    "Line": 8,
-                                                    "Column": 16,
-                                                    "Byte": 100
+                                                    "Line": 6,
+                                                    "Column": 7,
+                                                    "Byte": 69
                                                 },
                                                 "End": {
-                                                    "Line": 8,
-                                                    "Column": 26,
-                                                    "Byte": 110
+                                                    "Line": 6,
+                                                    "Column": 11,
+                                                    "Byte": 73
                                                 }
                                             }
                                         }
+                                    ],
+                                    "range": {
+                                        "Filename": "unicode",
+                                        "Start": {
+                                            "Line": 5,
+                                            "Column": 5,
+                                            "Byte": 56
+                                        },
+                                        "End": {
+                                            "Line": 6,
+                                            "Column": 11,
+                                            "Byte": 73
+                                        }
                                     }
-                                ],
-                                "range": {
-                                    "Filename": "unicode",
-                                    "Start": {
-                                        "Line": 8,
-                                        "Column": 5,
-                                        "Byte": 89
-                                    },
-                                    "End": {
-                                        "Line": 8,
-                                        "Column": 26,
-                                        "Byte": 110
+                                }
+                            },
+                            {
+                                "key": {
+                                    "literal": "danmark",
+                                    "range": {
+                                        "Filename": "unicode",
+                                        "Start": {
+                                            "Line": 7,
+                                            "Column": 3,
+                                            "Byte": 76
+                                        },
+                                        "End": {
+                                            "Line": 7,
+                                            "Column": 10,
+                                            "Byte": 83
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "object": [
+                                        {
+                                            "key": {
+                                                "literal": "hovedstad",
+                                                "range": {
+                                                    "Filename": "unicode",
+                                                    "Start": {
+                                                        "Line": 8,
+                                                        "Column": 5,
+                                                        "Byte": 89
+                                                    },
+                                                    "End": {
+                                                        "Line": 8,
+                                                        "Column": 14,
+                                                        "Byte": 98
+                                                    }
+                                                }
+                                            },
+                                            "value": {
+                                                "literal": "københavn",
+                                                "range": {
+                                                    "Filename": "unicode",
+                                                    "Start": {
+                                                        "Line": 8,
+                                                        "Column": 16,
+                                                        "Byte": 100
+                                                    },
+                                                    "End": {
+                                                        "Line": 8,
+                                                        "Column": 26,
+                                                        "Byte": 110
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "range": {
+                                        "Filename": "unicode",
+                                        "Start": {
+                                            "Line": 8,
+                                            "Column": 5,
+                                            "Byte": 89
+                                        },
+                                        "End": {
+                                            "Line": 8,
+                                            "Column": 26,
+                                            "Byte": 110
+                                        }
                                     }
                                 }
                             }
-                        }
-                    ],
-                    "range": {
-                        "Filename": "unicode",
-                        "Start": {
-                            "Line": 2,
-                            "Column": 3,
-                            "Byte": 10
-                        },
-                        "End": {
-                            "Line": 8,
-                            "Column": 26,
-                            "Byte": 110
+                        ],
+                        "range": {
+                            "Filename": "unicode",
+                            "Start": {
+                                "Line": 2,
+                                "Column": 3,
+                                "Byte": 10
+                            },
+                            "End": {
+                                "Line": 8,
+                                "Column": 26,
+                                "Byte": 110
+                            }
                         }
                     }
                 }
+            ],
+            "range": {
+                "Filename": "unicode",
+                "Start": {
+                    "Line": 1,
+                    "Column": 1,
+                    "Byte": 0
+                },
+                "End": {
+                    "Line": 8,
+                    "Column": 26,
+                    "Byte": 110
+                }
             }
-        ],
+        },
         "range": {
             "Filename": "unicode",
             "Start": {

--- a/syntax/encoding/yaml_test.go
+++ b/syntax/encoding/yaml_test.go
@@ -164,7 +164,7 @@ baz: qux
 	rootNode, diags := DecodeYAML("yaml", yaml.NewDecoder(strings.NewReader(doc)), nil)
 	assert.Empty(t, diags)
 
-	root := rootNode.(*syntax.ObjectNode)
+	root := rootNode.(*syntax.DocumentNode).Content().(*syntax.ObjectNode)
 
 	root.SetIndex(0, syntax.ObjectProperty(syntax.String("foo"), syntax.NumberSyntax(root.Index(0).Value.Syntax(), 42)))
 	root.SetIndex(1, syntax.ObjectProperty(syntax.StringSyntax(comment("head comment"), "baz"), syntax.String("qux")))

--- a/syntax/nodes.go
+++ b/syntax/nodes.go
@@ -342,3 +342,48 @@ func (n *ObjectNode) String() string {
 	}
 	return fmt.Sprintf("{ %s }", strings.Join(s, ", "))
 }
+
+// A DocumentNode represents a complete document. A DocumentNode wraps a single nodes and mostly exists as a holder for
+// additional syntactical trivia or metadata (e.g. comments). A DocumentNode should only appear at the root of a syntax tree.
+type DocumentNode struct {
+	node
+
+	content Node
+}
+
+// DocumentSyntax creates a new document with the given contents and associated syntax.
+func DocumentSyntax(syntax Syntax, content Node) *DocumentNode {
+	return &DocumentNode{node: node{syntax: syntax}, content: content}
+}
+
+// Document creates a new document with the given content.
+func Document(content Node) *DocumentNode {
+	return DocumentSyntax(NoSyntax, content)
+}
+
+// Content returns the document's content.
+func (n *DocumentNode) Content() Node {
+	return n.content
+}
+
+// SetContent sets the document's content.
+func (n *DocumentNode) SetContent(content Node) {
+	n.content = content
+}
+
+func (n *DocumentNode) GoString() string {
+	var b strings.Builder
+	b.WriteString("syntax.Document(")
+	if n.content != nil {
+		b.WriteString(n.content.GoString())
+	}
+	b.WriteString(")")
+	return b.String()
+}
+
+func (n *DocumentNode) String() string {
+	if n.content == nil {
+		return "( )"
+	}
+	return fmt.Sprintf("( %v )", n.content)
+}

--- a/syntax/nodes.go
+++ b/syntax/nodes.go
@@ -343,7 +343,7 @@ func (n *ObjectNode) String() string {
 	return fmt.Sprintf("{ %s }", strings.Join(s, ", "))
 }
 
-// A DocumentNode represents a complete document. A DocumentNode wraps a single nodes and mostly exists as a holder for
+// A DocumentNode represents a complete document. A DocumentNode wraps a single node and mostly exists as a holder for
 // additional syntactical trivia or metadata (e.g. comments). A DocumentNode should only appear at the root of a syntax tree.
 type DocumentNode struct {
 	node

--- a/syntax/walk.go
+++ b/syntax/walk.go
@@ -37,6 +37,15 @@ func Walk(n Node, visitor func(n Node) (Node, Diagnostics, error)) (Node, Diagno
 			}
 			n.entries[i] = ObjectProperty(e.Key, v)
 		}
+	case *DocumentNode:
+		if n.content != nil {
+			c, d, err := Walk(n.content, visitor)
+			diags.Extend(d...)
+			if err != nil {
+				return nil, diags, err
+			}
+			n.content = c
+		}
 	}
 
 	n, d, err := visitor(n)


### PR DESCRIPTION
These changes add a new node type, DocumentNode, to the syntax package. This node allows concrete syntaxes to attach document-level syntactical trivia (e.g. comments, metadata, etc.) that is not otherwise associated with a node.

These changes also replace `*RotationResult` with `RotationResult`, as the result is already nilable. This fixes an issue when running the eval tests with `PULUMI_ACCEPT` set.

Fixes #260.