### PR TITLE
esc: make traces optional

### DIFF
--- a/cmd/esc/cli/testdata/open-detailed.yaml
+++ b/cmd/esc/cli/testdata/open-detailed.yaml
@@ -68,20 +68,6 @@ environments:
         }
       }
     }
-  },
-  "trace": {
-    "def": {
-      "begin": {
-        "line": 0,
-        "column": 0,
-        "byte": 0
-      },
-      "end": {
-        "line": 0,
-        "column": 0,
-        "byte": 0
-      }
-    }
   }
 }
 

--- a/environment.go
+++ b/environment.go
@@ -177,6 +177,12 @@ type Environment struct {
 	ExecutionContext *EvaluatedExecutionContext `json:"executionContext,omitempty"`
 }
 
+// WithoutMetadata returns a copy of the receiver without expression, schema, context, and trace metadata. Only the
+// Properties field will be present.
+func (e Environment) WithoutMetadata() Environment {
+	return Environment{Properties: NewValue(e.Properties).WithoutTraceMetadata().Value.(map[string]Value)}
+}
+
 // GetEnvironmentVariables returns any environment variables defined by the environment.
 //
 // Environment variables are any scalar values in the top-level `environmentVariables` property. Boolean and

--- a/eval/testdata/eval/rotate-paths/expected.json
+++ b/eval/testdata/eval/rotate-paths/expected.json
@@ -6336,20 +6336,6 @@
                             }
                         }
                     }
-                },
-                "trace": {
-                    "def": {
-                        "begin": {
-                            "line": 0,
-                            "column": 0,
-                            "byte": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "column": 0,
-                            "byte": 0
-                        }
-                    }
                 }
             }
         },
@@ -6393,20 +6379,6 @@
                             }
                         }
                     }
-                },
-                "trace": {
-                    "def": {
-                        "begin": {
-                            "line": 0,
-                            "column": 0,
-                            "byte": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "column": 0,
-                            "byte": 0
-                        }
-                    }
                 }
             }
         },
@@ -6448,20 +6420,6 @@
                                     "byte": 227
                                 }
                             }
-                        }
-                    }
-                },
-                "trace": {
-                    "def": {
-                        "begin": {
-                            "line": 0,
-                            "column": 0,
-                            "byte": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "column": 0,
-                            "byte": 0
                         }
                     }
                 }

--- a/eval/testdata/eval/rotate-state/expected.json
+++ b/eval/testdata/eval/rotate-state/expected.json
@@ -4229,20 +4229,6 @@
                             }
                         }
                     }
-                },
-                "trace": {
-                    "def": {
-                        "begin": {
-                            "line": 0,
-                            "column": 0,
-                            "byte": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "column": 0,
-                            "byte": 0
-                        }
-                    }
                 }
             }
         },
@@ -4268,36 +4254,7 @@
                             }
                         }
                     },
-                    "previous": {
-                        "trace": {
-                            "def": {
-                                "begin": {
-                                    "line": 0,
-                                    "column": 0,
-                                    "byte": 0
-                                },
-                                "end": {
-                                    "line": 0,
-                                    "column": 0,
-                                    "byte": 0
-                                }
-                            }
-                        }
-                    }
-                },
-                "trace": {
-                    "def": {
-                        "begin": {
-                            "line": 0,
-                            "column": 0,
-                            "byte": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "column": 0,
-                            "byte": 0
-                        }
-                    }
+                    "previous": {}
                 }
             }
         },
@@ -4339,20 +4296,6 @@
                                     "byte": 205
                                 }
                             }
-                        }
-                    }
-                },
-                "trace": {
-                    "def": {
-                        "begin": {
-                            "line": 0,
-                            "column": 0,
-                            "byte": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "column": 0,
-                            "byte": 0
                         }
                     }
                 }

--- a/eval/value.go
+++ b/eval/value.go
@@ -352,7 +352,7 @@ func (v *value) export(environment string) esc.Value {
 		Value:   pv,
 		Secret:  v.secret,
 		Unknown: v.unknown,
-		Trace: esc.Trace{
+		Trace: &esc.Trace{
 			Def:  v.def.defRange(environment),
 			Base: base,
 		},

--- a/value.go
+++ b/value.go
@@ -45,7 +45,7 @@ type Value struct {
 
 	// Trace holds information about the expression that computed this value and the value (if any) with which it was
 	// merged.
-	Trace Trace `json:"trace"`
+	Trace *Trace `json:"trace,omitempty"`
 }
 
 // NewValue creates a new value with the given representation.
@@ -72,6 +72,7 @@ func NewSecret[T ValueType](v T) Value {
 	return Value{Value: v, Secret: true}
 }
 
+// MakeSecret converts this value to a secret.
 func (v Value) MakeSecret() Value {
 	switch v := v.Value.(type) {
 	case bool:
@@ -103,7 +104,7 @@ func (v *Value) UnmarshalJSON(data []byte) error {
 		Value   json.RawMessage `json:"value,omitempty"`
 		Secret  bool            `json:"secret,omitempty"`
 		Unknown bool            `json:"unknown,omitempty"`
-		Trace   Trace           `json:"trace"`
+		Trace   *Trace          `json:"trace,omitempty"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -182,6 +183,29 @@ func fromJSON(path string, v any) (Value, error) {
 	default:
 		return Value{}, fmt.Errorf("%v: unsupported value of type %T", path, v)
 	}
+}
+
+// WithoutTraceMetadata returns a copy of the receiver with all trace metadata recursively removed.
+func (v Value) WithoutTraceMetadata() Value {
+	vv := v
+	vv.Trace = nil
+
+	switch pv := v.Value.(type) {
+	case []Value:
+		a := make([]Value, len(pv))
+		for i, v := range pv {
+			a[i] = v.WithoutTraceMetadata()
+		}
+		vv.Value = a
+	case map[string]Value:
+		m := make(map[string]Value, len(pv))
+		for k, v := range pv {
+			m[k] = v.WithoutTraceMetadata()
+		}
+		vv.Value = m
+	}
+
+	return vv
 }
 
 // ToJSON converts a Value into a plain-old-JSON value (i.e. a value of type nil, bool, json.Number, string, []any, or


### PR DESCRIPTION
And add a couple of helper methods: one to remove trace metadata from values and one to remove all metadata from an Environment. This allows embedders to more easily provide less heavyweight representations of evaluated values.