### PR TITLE
CI: reduce scope of permissions of test & lint jobs

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -6,7 +6,8 @@ on:
       - 'CHANGELOG.md'
       - 'CHANGELOG_PENDING.md'
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   lint:

--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -3,7 +3,8 @@ name: Lint
 on:
   workflow_call:
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stage-test.yml
+++ b/.github/workflows/stage-test.yml
@@ -15,7 +15,8 @@ on:
         required: false
         type: boolean
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
The last release failed with a permission problem: https://github.com/pulumi/esc/actions/runs/14630282476

The publish-release workflow [uses a subjob for lint](https://github.com/pulumi/esc/blob/7d7a7cc1acbeb7418e5da19b81af49cf840ce991/.github/workflows/publish-release.yaml#L30).  the lint job says it wants [permissions: read-all](https://github.com/pulumi/esc/blob/7d7a7cc1acbeb7418e5da19b81af49cf840ce991/.github/workflows/stage-lint.yml#L6) but the parent workflow [has a subset of permissions](https://github.com/pulumi/esc/blob/7d7a7cc1acbeb7418e5da19b81af49cf840ce991/.github/workflows/publish-release.yaml#L12-L26). I suspect that the `models: read` permission is new and didn't used to be included in `read-all`.  Now that it is the parent permissions no longer cover what the child says it requires.

The lint/test jobs shouldn't need such broad permissions anyways, so this scopes them down to just being able to checkout the repo.

