### PR TITLE
cli: use a more efficient fork of aho-corasick

### DIFF
--- a/cmd/esc/cli/env_run.go
+++ b/cmd/esc/cli/env_run.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	aho_corasick "github.com/petar-dambovaliev/aho-corasick"
+	aho_corasick "github.com/pgavlin/aho-corasick"
 
 	"github.com/pulumi/esc"
 	"github.com/pulumi/esc/ast"
@@ -64,10 +64,7 @@ func (w *redactor) Write(b []byte) (int, error) {
 		_, err := w.line.Write(b[:newline+1])
 		contract.IgnoreError(err)
 
-		redacted := w.replacer.ReplaceAllFunc(w.line.String(), func(m aho_corasick.Match) (string, bool) {
-			return "[secret]", true
-		})
-
+		redacted := w.replacer.ReplaceAllWith(w.line.String(), "[secret]")
 		if _, err = w.w.Write([]byte(redacted)); err != nil {
 			w.line.Truncate(n)
 			return written, err

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.22.0
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/muesli/termenv v0.15.2
-	github.com/petar-dambovaliev/aho-corasick v0.0.0-20230725210150-fb29fc3c913e
+	github.com/pgavlin/aho-corasick v0.5.1
 	github.com/pgavlin/fx/v2 v2.0.3
 	github.com/pulumi/pulumi/pkg/v3 v3.154.0
 	github.com/pulumi/pulumi/sdk/v3 v3.154.0

--- a/go.sum
+++ b/go.sum
@@ -394,8 +394,8 @@ github.com/opentracing/basictracer-go v1.1.0/go.mod h1:V2HZueSJEp879yv285Aap1BS6
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/petar-dambovaliev/aho-corasick v0.0.0-20230725210150-fb29fc3c913e h1:POJco99aNgosh92lGqmx7L1ei+kCymivB/419SD15PQ=
-github.com/petar-dambovaliev/aho-corasick v0.0.0-20230725210150-fb29fc3c913e/go.mod h1:EHPiTAKtiFmrMldLUNswFwfZ2eJIYBHktdaUTZxYWRw=
+github.com/pgavlin/aho-corasick v0.5.1 h1:ujv4DzpWK8G+MhoPAKYAir7znMHtcRQLDVa0cwFRvHw=
+github.com/pgavlin/aho-corasick v0.5.1/go.mod h1:UyKgVsAp5Un59BCpzrpFkPyETFMn1tGjdbRYvoq0l2g=
 github.com/pgavlin/diff v0.0.0-20230503175810-113847418e2e h1:Or25BtWLCyWKjnLyuMDrQsc6VcCs1V2AiKdOnxHEeEk=
 github.com/pgavlin/diff v0.0.0-20230503175810-113847418e2e/go.mod h1:WGwlmuPAiQTGQUjxyAfP7j4JgbgiFvFpI/qRtsQtS/4=
 github.com/pgavlin/fx v0.1.6 h1:r9jEg69DhNoCd3Xh0+5mIbdbS3PqWrVWujkY76MFRTU=


### PR DESCRIPTION
Use a more memory-efficient fork of the Aho-Corasick replacer (with a slightly nicer API to boot).