### PR TITLE
Fix esc version

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,4 +2,7 @@
 
 ### Bug Fixes
 
+- Fix `esc version`
+ [#541](https://github.com/pulumi/esc/pull/541)
+
 ### Breaking changes

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ format:
 	find . -iname "*.go" -print0 | xargs -r0 gofmt -s -w
 
 build:: ensure
-	${GO} install -ldflags "-X github.com/pulumi/esc/cmd/internal/version.Version=${VERSION}" ./cmd/esc
+	${GO} install -ldflags "-X github.com/pulumi/esc/cmd/esc/cli/version.Version=${VERSION}" ./cmd/esc
 
 build_debug:: ensure
-	${GO} install -gcflags="all=-N -l" -ldflags "-X github.com/pulumi/esc/cmd/internal/version.Version=${VERSION}" ./cmd/esc
+	${GO} install -gcflags="all=-N -l" -ldflags "-X github.com/pulumi/esc/cmd/esc/cli/version.Version=${VERSION}" ./cmd/esc
 
 test:: build
 	${GO} test --timeout 30m -short -count 1 -parallel ${CONCURRENCY} ./...


### PR DESCRIPTION
Fixes https://github.com/pulumi/esc/issues/520

We were using the wrong path for setting version during build, which was causing `esc version` to not output anything.