### PR TITLE
Always expect environment name as first argument for run

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
+- `esc run` will expect environment to be pased before `--`
+  [#545](https://github.com/pulumi/esc/pull/545)
+
 ### Bug Fixes
 
 - Fix `esc version`

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,6 @@
 ### Improvements
 
-- `esc run` will expect environment to be pased before `--`
+- `esc run` expects environment to be passed before `--`
   [#545](https://github.com/pulumi/esc/pull/545)
 
 ### Bug Fixes

--- a/cmd/esc/cli/env_run.go
+++ b/cmd/esc/cli/env_run.go
@@ -97,11 +97,8 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 	shell := valueOrDefault(filepath.Base(envcmd.esc.environ.Get("SHELL")), "sh")
 
 	cmd := &cobra.Command{
-		Use: "run [<org-name>/][<project-name>/]<environment-name> [flags] [--] [command]",
-		Args: func(cmd *cobra.Command, args []string) error {
-			// Custom args validation to detect -- usage
-			return nil
-		},
+		Use:   "run [<org-name>/][<project-name>/]<environment-name> [flags] [--] [command]",
+		Args:  cobra.ArbitraryArgs,
 		Short: "Open the environment with the given name and run a command.",
 		Long: fmt.Sprintf("Open the environment with the given name and run a command\n"+
 			"\n"+

--- a/cmd/esc/cli/env_run.go
+++ b/cmd/esc/cli/env_run.go
@@ -130,7 +130,8 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 				return err
 			}
 
-			if len(args) == 0 {
+			// If -- was used but there's no arguments, it means no environment was specified before the command
+			if len(args) == 0 || cmd.ArgsLenAtDash() == 0 {
 				return fmt.Errorf("no environment specified")
 			}
 

--- a/cmd/esc/cli/testdata/run-no-env-error-with-separator.yaml
+++ b/cmd/esc/cli/testdata/run-no-env-error-with-separator.yaml
@@ -7,4 +7,4 @@ error: exit status 1
 
 ---
 > esc run -- cat file.txt
-Error: resolving command: command not found
+Error: no environment specified

--- a/cmd/esc/cli/testdata/run-no-env-error-with-separator.yaml
+++ b/cmd/esc/cli/testdata/run-no-env-error-with-separator.yaml
@@ -1,0 +1,10 @@
+run: |
+  esc run -- cat file.txt
+error: exit status 1
+
+---
+> esc run -- cat file.txt
+
+---
+> esc run -- cat file.txt
+Error: resolving command: command not found

--- a/cmd/esc/cli/testdata/run-no-env-error-with-separator.yaml
+++ b/cmd/esc/cli/testdata/run-no-env-error-with-separator.yaml
@@ -1,10 +1,10 @@
 run: |
-  esc run -- cat file.txt
+  esc run -- pulumi preview
 error: exit status 1
 
 ---
-> esc run -- cat file.txt
+> esc run -- pulumi preview
 
 ---
-> esc run -- cat file.txt
+> esc run -- pulumi preview
 Error: no environment specified

--- a/cmd/esc/cli/testdata/run-no-env-error.yaml
+++ b/cmd/esc/cli/testdata/run-no-env-error.yaml
@@ -1,10 +1,10 @@
 run: |
-  esc run cat
+  esc run -- pulumi preview
 error: exit status 1
 
 ---
-> esc run cat
+> esc run -- pulumi preview
 
 ---
-> esc run cat
-Error: no command specified
+> esc run -- pulumi preview
+Error: no environment specified

--- a/cmd/esc/cli/testdata/run-no-env-error.yaml
+++ b/cmd/esc/cli/testdata/run-no-env-error.yaml
@@ -1,0 +1,10 @@
+run: |
+  esc run cat
+error: exit status 1
+
+---
+> esc run cat
+
+---
+> esc run cat
+Error: no command specified


### PR DESCRIPTION
Fixes #478 

This PR checks ensures that the first argument for _run_ is always an environment. This is required for when `--` is used since in the current behavior will threat the first argument after `--` as the environment.

**Before:**
<img width="548" alt="image" src="https://github.com/user-attachments/assets/68204bd4-5199-4a0f-87d3-c70b2c7e3edb" />

**After:**
<img width="364" alt="image" src="https://github.com/user-attachments/assets/c537656e-fb52-4f56-83a2-341ed5f305f6" />


