### PR TITLE
[approvals] Add draft flag to env set, edit, version rollback

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,10 +4,12 @@
   [#545](https://github.com/pulumi/esc/pull/546)
 - `esc env set` uses a more readable YAML format when setting a key in an empty map  
   [#548](https://github.com/pulumi/esc/pull/548)
+- `--draft` flag for `esc env set`, `esc env edit`, `esc env versions rollback` to create a change request rather than updating directly. **Warning: this feature is in preview, limited to specific orgs, and subject to change.**
+  [#552](https://github.com/pulumi/esc/pull/552)
 
 ### Bug Fixes
 
 - Fix `esc version`
- [#541](https://github.com/pulumi/esc/pull/541)
+  [#541](https://github.com/pulumi/esc/pull/541)
 
 ### Breaking changes

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -670,7 +670,20 @@ func (c *testPulumiClient) CreateEnvironmentDraft(
 	yaml []byte,
 	etag string,
 ) (string, []client.EnvironmentDiagnostic, error) {
-	return "", []client.EnvironmentDiagnostic{}, nil
+	_, latest, err := c.getEnvironment(orgName, projectName, envName, "")
+	if err != nil {
+		return "", nil, err
+	}
+
+	if etag != "" && etag != latest.etag {
+		return "", nil, errors.New("etag mismatch")
+	}
+
+	_, diags, err := c.checkEnvironment(ctx, orgName, envName, yaml, nil)
+	if err == nil && len(diags) == 0 {
+		return "00000000-0000-0000-0000-000000000000", []client.EnvironmentDiagnostic{}, nil
+	}
+	return "", diags, err
 }
 
 func (c *testPulumiClient) SubmitChangeRequest(
@@ -679,7 +692,7 @@ func (c *testPulumiClient) SubmitChangeRequest(
 	changeRequestID string,
 	description *string,
 ) error {
-	return errors.New("NYI")
+	return nil
 }
 
 func (c *testPulumiClient) DeleteEnvironment(ctx context.Context, orgName, projectName, envName string) error {

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -677,6 +677,7 @@ func (c *testPulumiClient) SubmitChangeRequest(
 	ctx context.Context,
 	orgName string,
 	changeRequestID string,
+	description *string,
 ) error {
 	return errors.New("NYI")
 }

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -458,7 +458,7 @@ func (c *testPulumiClient) Insecure() bool {
 
 // URL returns the URL of the API endpoint this client interacts with
 func (c *testPulumiClient) URL() string {
-	return "http://fake.pulumi.api"
+	return "https://api.fake.pulumi.com"
 }
 
 // GetPulumiAccountDetails returns the user implied by the API token associated with this client.
@@ -1382,13 +1382,13 @@ func loadTestcase(path string) (*cliTestcaseYAML, *cliTestcase, error) {
 	}
 
 	creds := workspace.Credentials{
-		Current: "http://fake.pulumi.api",
+		Current: "https://api.fake.pulumi.com",
 		Accounts: map[string]workspace.Account{
 			"https://api.pulumi.com": {
 				Username:    "test-user",
 				AccessToken: "access-token",
 			},
-			"http://fake.pulumi.api": {
+			"https://api.fake.pulumi.com": {
 				Username:    "test-user",
 				AccessToken: "access-token",
 			},

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -662,6 +662,25 @@ func (c *testPulumiClient) UpdateEnvironmentWithRevision(
 	return diags, env.revisionTags["latest"], err
 }
 
+func (c *testPulumiClient) CreateEnvironmentDraft(
+	ctx context.Context,
+	orgName string,
+	projectName string,
+	envName string,
+	yaml []byte,
+	etag string,
+) (string, []client.EnvironmentDiagnostic, error) {
+	return "", []client.EnvironmentDiagnostic{}, nil
+}
+
+func (c *testPulumiClient) SubmitChangeRequest(
+	ctx context.Context,
+	orgName string,
+	changeRequestID string,
+) error {
+	return errors.New("NYI")
+}
+
 func (c *testPulumiClient) DeleteEnvironment(ctx context.Context, orgName, projectName, envName string) error {
 	name := path.Join(orgName, projectName, envName)
 	if _, ok := c.environments[name]; !ok {

--- a/cmd/esc/cli/client/apitype.go
+++ b/cmd/esc/cli/client/apitype.go
@@ -139,6 +139,15 @@ type UpdateEnvironmentRevisionTagRequest struct {
 	Revision *int `json:"revision,omitempty"`
 }
 
+type CreateEnvironmentDraftResponse struct {
+	ChangeRequestID      string `json:"changeRequestId"`
+	LatestRevisionNumber int    `json:"latestRevisionNumber"`
+}
+
+type SubmitChangeRequestRequest struct {
+	Description *string `json:"description,omitempty"`
+}
+
 type EnvironmentTag struct {
 	ID          string    `json:"id"`
 	Name        string    `json:"name"`

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -170,10 +170,12 @@ type Client interface {
 	) (string, []EnvironmentDiagnostic, error)
 
 	// SubmitChangeRequest submits the change request with the specified ID in org orgName.
+	// Optionally provide a description for the change request.
 	SubmitChangeRequest(
 		ctx context.Context,
 		orgName string,
 		changeRequestID string,
+		description *string,
 	) error
 
 	// DeleteEnvironment deletes the environment envName in org orgName.
@@ -686,8 +688,9 @@ func (pc *client) SubmitChangeRequest(
 	ctx context.Context,
 	orgName string,
 	changeRequestID string,
+	description *string,
 ) error {
-	req := SubmitChangeRequestRequest{}
+	req := SubmitChangeRequestRequest{Description: description}
 	path := fmt.Sprintf("/api/preview/change-requests/%v/%v/submit", orgName, changeRequestID)
 	err := pc.restCall(ctx, http.MethodPost, path, nil, &req, nil)
 	return err

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -152,6 +152,30 @@ type Client interface {
 		etag string,
 	) ([]EnvironmentDiagnostic, error)
 
+	// CreateEnvironmentDraft creates a draft update of the YAML for the environment envName in org orgName.
+	// The resulting ChangeRequestID is returned.
+	//
+	// If the new environment definition contains errors, the creation will fail with diagnostics.
+	//
+	// If etag is not the empty string and the environment's current etag does not match the provided etag
+	// (i.e. because a different entity has called UpdateEnvironment), the creation will fail with a 409
+	// error.
+	CreateEnvironmentDraft(
+		ctx context.Context,
+		orgName string,
+		projectName string,
+		envName string,
+		yaml []byte,
+		etag string,
+	) (string, []EnvironmentDiagnostic, error)
+
+	// SubmitChangeRequest submits the change request with the specified ID in org orgName.
+	SubmitChangeRequest(
+		ctx context.Context,
+		orgName string,
+		changeRequestID string,
+	) error
+
 	// DeleteEnvironment deletes the environment envName in org orgName.
 	DeleteEnvironment(ctx context.Context, orgName, projectName, envName string) error
 
@@ -625,6 +649,48 @@ func (pc *client) UpdateEnvironmentWithRevision(
 	}
 
 	return nil, revision, nil
+}
+
+func (pc *client) CreateEnvironmentDraft(
+	ctx context.Context,
+	orgName string,
+	projectName string,
+	envName string,
+	yaml []byte,
+	tag string,
+) (string, []EnvironmentDiagnostic, error) {
+	header := http.Header{}
+	if tag != "" {
+		header.Set(etagHeader, tag)
+	}
+
+	var errResp EnvironmentErrorResponse
+	path := fmt.Sprintf("/api/preview/esc/environments/%v/%v/%v/drafts", orgName, projectName, envName)
+	var resp CreateEnvironmentDraftResponse
+	err := pc.restCallWithOptions(ctx, http.MethodPost, path, nil, json.RawMessage(yaml), &resp, httpCallOptions{
+		Header:        header,
+		ErrorResponse: &errResp,
+	})
+	if err != nil {
+		var diags *EnvironmentErrorResponse
+		if errors.As(err, &diags) && len(diags.Diagnostics) != 0 {
+			return "", diags.Diagnostics, nil
+		}
+		return "", nil, err
+	}
+
+	return resp.ChangeRequestID, nil, nil
+}
+
+func (pc *client) SubmitChangeRequest(
+	ctx context.Context,
+	orgName string,
+	changeRequestID string,
+) error {
+	req := SubmitChangeRequestRequest{}
+	path := fmt.Sprintf("/api/preview/change-requests/%v/%v/submit", orgName, changeRequestID)
+	err := pc.restCall(ctx, http.MethodPost, path, nil, &req, nil)
+	return err
 }
 
 func (pc *client) DeleteEnvironment(ctx context.Context, orgName, projectName, envName string) error {

--- a/cmd/esc/cli/client/client_test.go
+++ b/cmd/esc/cli/client/client_test.go
@@ -500,7 +500,7 @@ func TestCreateEnvironmentDraft(t *testing.T) {
 }
 
 func TestSubmitChangeRequest(t *testing.T) {
-	t.Run("OK", func(t *testing.T) {
+	t.Run("OK - nil description", func(t *testing.T) {
 		client := newTestClient(t, http.MethodPost, "/api/preview/change-requests/test-org/EXAMPLE/submit", func(w http.ResponseWriter, r *http.Request) {
 			expectedBody := SubmitChangeRequestRequest{}
 			expectedBodyJSON, err := json.Marshal(expectedBody)
@@ -512,7 +512,41 @@ func TestSubmitChangeRequest(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		err := client.SubmitChangeRequest(context.Background(), "test-org", "EXAMPLE")
+		err := client.SubmitChangeRequest(context.Background(), "test-org", "EXAMPLE", nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("OK - empty description", func(t *testing.T) {
+		client := newTestClient(t, http.MethodPost, "/api/preview/change-requests/test-org/EXAMPLE/submit", func(w http.ResponseWriter, r *http.Request) {
+			expectedBody := SubmitChangeRequestRequest{}
+			expectedBodyJSON, err := json.Marshal(expectedBody)
+			require.NoError(t, err)
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			assert.Equal(t, expectedBodyJSON, body)
+
+			w.WriteHeader(http.StatusOK)
+		})
+
+		err := client.SubmitChangeRequest(context.Background(), "test-org", "EXAMPLE", nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("OK - description provided", func(t *testing.T) {
+		client := newTestClient(t, http.MethodPost, "/api/preview/change-requests/test-org/EXAMPLE/submit", func(w http.ResponseWriter, r *http.Request) {
+			description := "test description"
+			expectedBody := SubmitChangeRequestRequest{Description: &description}
+			expectedBodyJSON, err := json.Marshal(expectedBody)
+			require.NoError(t, err)
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			assert.Equal(t, expectedBodyJSON, body)
+
+			w.WriteHeader(http.StatusOK)
+		})
+
+		description := "test description"
+		err := client.SubmitChangeRequest(context.Background(), "test-org", "EXAMPLE", &description)
 		require.NoError(t, err)
 	})
 
@@ -527,7 +561,7 @@ func TestSubmitChangeRequest(t *testing.T) {
 			require.NoError(t, err)
 		})
 
-		err := client.SubmitChangeRequest(context.Background(), "test-org", "EXAMPLE")
+		err := client.SubmitChangeRequest(context.Background(), "test-org", "EXAMPLE", nil)
 		assert.ErrorContains(t, err, "change request must be in draft status to submit ")
 	})
 }

--- a/cmd/esc/cli/client/client_test.go
+++ b/cmd/esc/cli/client/client_test.go
@@ -387,6 +387,151 @@ func TestUpdateEnvironment(t *testing.T) {
 	})
 }
 
+func TestCreateEnvironmentDraft(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		yaml := []byte("new definition")
+		tag := "old tag"
+
+		client := newTestClient(t, http.MethodPost, "/api/preview/esc/environments/test-org/test-project/test-env/drafts", func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, tag, r.Header.Get("ETag"))
+
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			assert.Equal(t, yaml, body)
+
+			err = json.NewEncoder(w).Encode(CreateEnvironmentDraftResponse{
+				ChangeRequestID:      "EXAMPLE",
+				LatestRevisionNumber: 32423432,
+			})
+			require.NoError(t, err)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		changeRequestID, diags, err := client.CreateEnvironmentDraft(context.Background(), "test-org", "test-project", "test-env", yaml, tag)
+		require.NoError(t, err)
+		assert.Equal(t, "EXAMPLE", changeRequestID)
+		assert.Len(t, diags, 0)
+	})
+
+	t.Run("Diags", func(t *testing.T) {
+		expected := []EnvironmentDiagnostic{
+			{
+				Range: &esc.Range{
+					Environment: "test-env",
+					Begin:       esc.Pos{Line: 42, Column: 1},
+					End:         esc.Pos{Line: 42, Column: 42},
+				},
+				Summary: "diag 1",
+			},
+			{
+				Range: &esc.Range{
+					Environment: "import-env",
+					Begin:       esc.Pos{Line: 1, Column: 2},
+					End:         esc.Pos{Line: 3, Column: 4},
+				},
+				Summary: "diag 2",
+			},
+		}
+
+		client := newTestClient(t, http.MethodPost, "/api/preview/esc/environments/test-org/test-project/test-env/drafts", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+
+			err := json.NewEncoder(w).Encode(EnvironmentErrorResponse{
+				Code:        400,
+				Message:     "bad request",
+				Diagnostics: expected,
+			})
+			require.NoError(t, err)
+		})
+
+		changeRequestID, diags, err := client.CreateEnvironmentDraft(context.Background(), "test-org", "test-project", "test-env", nil, "")
+		require.Equal(t, "", changeRequestID)
+		assert.Equal(t, expected, diags)
+		require.NoError(t, err)
+	})
+
+	t.Run("Diags only", func(t *testing.T) {
+		expected := []EnvironmentDiagnostic{
+			{
+				Range: &esc.Range{
+					Environment: "test-env",
+					Begin:       esc.Pos{Line: 42, Column: 1},
+					End:         esc.Pos{Line: 42, Column: 42},
+				},
+				Summary: "diag 1",
+			},
+			{
+				Range: &esc.Range{
+					Environment: "import-env",
+					Begin:       esc.Pos{Line: 1, Column: 2},
+					End:         esc.Pos{Line: 3, Column: 4},
+				},
+				Summary: "diag 2",
+			},
+		}
+
+		client := newTestClient(t, http.MethodPost, "/api/preview/esc/environments/test-org/test-project/test-env/drafts", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+
+			err := json.NewEncoder(w).Encode(EnvironmentErrorResponse{Diagnostics: expected})
+			require.NoError(t, err)
+		})
+
+		changeRequestID, diags, err := client.CreateEnvironmentDraft(context.Background(), "test-org", "test-project", "test-env", nil, "")
+		require.Equal(t, "", changeRequestID)
+		assert.Equal(t, expected, diags)
+		require.NoError(t, err)
+	})
+
+	t.Run("Conflict", func(t *testing.T) {
+		client := newTestClient(t, http.MethodPost, "/api/preview/esc/environments/test-org/test-project/test-env/drafts", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusConflict)
+
+			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
+				Code:    409,
+				Message: "conflict",
+			})
+			require.NoError(t, err)
+		})
+		changeRequestID, _, err := client.CreateEnvironmentDraft(context.Background(), "test-org", "test-project", "test-env", nil, "")
+		require.Equal(t, "", changeRequestID)
+		assert.ErrorContains(t, err, "conflict")
+	})
+}
+
+func TestSubmitChangeRequest(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		client := newTestClient(t, http.MethodPost, "/api/preview/change-requests/test-org/EXAMPLE/submit", func(w http.ResponseWriter, r *http.Request) {
+			expectedBody := SubmitChangeRequestRequest{}
+			expectedBodyJSON, err := json.Marshal(expectedBody)
+			require.NoError(t, err)
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			assert.Equal(t, expectedBodyJSON, body)
+
+			w.WriteHeader(http.StatusOK)
+		})
+
+		err := client.SubmitChangeRequest(context.Background(), "test-org", "EXAMPLE")
+		require.NoError(t, err)
+	})
+
+	t.Run("Already submitted", func(t *testing.T) {
+		client := newTestClient(t, http.MethodPost, "/api/preview/change-requests/test-org/EXAMPLE/submit", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+
+			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
+				Code:    400,
+				Message: "Bad Request: change request must be in draft status to submit (current status: ready): invalid request",
+			})
+			require.NoError(t, err)
+		})
+
+		err := client.SubmitChangeRequest(context.Background(), "test-org", "EXAMPLE")
+		assert.ErrorContains(t, err, "change request must be in draft status to submit ")
+	})
+}
+
 func TestDeleteEnvironment(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		client := newTestClient(t, http.MethodDelete, "/api/esc/environments/test-org/test-project/test-env", func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -403,3 +403,41 @@ func (esc *escCommand) changeRequestURL(ref environmentRef, changeRequestID stri
 		changeRequestID,
 	)
 }
+
+// updateEnvironment updates an environment. If draft is true, a change request is created and submitted.
+// Progress is logged to stdout. However, diagnostics are not logged, that is left up to the caller.
+func (esc *escCommand) updateEnvironment(
+	ctx context.Context,
+	ref environmentRef,
+	draft bool,
+	yaml []byte,
+	tag string,
+	envUpdateSuccessMessage string,
+) ([]client.EnvironmentDiagnostic, error) {
+	if draft {
+		changeRequestID, diags, err := esc.client.CreateEnvironmentDraft(ctx, ref.orgName, ref.projectName, ref.envName, yaml, tag)
+		if err != nil {
+			return nil, fmt.Errorf("creating environment draft: %w", err)
+		}
+		if len(diags) == 0 {
+			fmt.Fprintf(esc.stdout, "Change request created: %v\n", changeRequestID)
+			fmt.Fprintf(esc.stdout, "Change request URL: %v\n", esc.changeRequestURL(ref, changeRequestID))
+
+			err = esc.client.SubmitChangeRequest(ctx, ref.orgName, changeRequestID, nil)
+			if err != nil {
+				return nil, fmt.Errorf("submitting change request: %w", err)
+			}
+			fmt.Fprintln(esc.stdout, "Change request submitted")
+		}
+		return diags, nil
+	} else {
+		diags, err := esc.client.UpdateEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName, yaml, tag)
+		if err != nil {
+			return nil, fmt.Errorf("updating environment definition: %w", err)
+		}
+		if len(diags) == 0 && envUpdateSuccessMessage != "" {
+			fmt.Fprintln(esc.stdout, envUpdateSuccessMessage)
+		}
+		return diags, nil
+	}
+}

--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -389,3 +389,17 @@ func (cmd *envCommand) writePropertyEnvironmentDiagnostics(out io.Writer, diags 
 
 	return nil
 }
+
+// changeRequestURL returns a URL to the change request in the Pulumi Cloud Console, rooted at cloudURL.
+// If there is an error, returns "".
+func (esc *escCommand) changeRequestURL(ref environmentRef, changeRequestID string) string {
+	return esc.cloudConsoleURL(
+		esc.client.URL(),
+		ref.orgName,
+		"esc",
+		ref.projectName,
+		ref.envName,
+		"change-requests",
+		changeRequestID,
+	)
+}

--- a/cmd/esc/cli/env_edit.go
+++ b/cmd/esc/cli/env_edit.go
@@ -85,7 +85,7 @@ func newEnvEditCmd(env *envCommand) *cobra.Command {
 						fmt.Fprintf(edit.env.esc.stdout, "Change request created: %v\n", changeRequestID)
 						fmt.Fprintf(edit.env.esc.stdout, "Change request URL: %v\n", edit.env.esc.changeRequestURL(ref, changeRequestID))
 
-						err = edit.env.esc.client.SubmitChangeRequest(ctx, ref.orgName, changeRequestID)
+						err = edit.env.esc.client.SubmitChangeRequest(ctx, ref.orgName, changeRequestID, nil)
 						if err != nil {
 							return fmt.Errorf("submitting change request: %w", err)
 						}
@@ -141,7 +141,7 @@ func newEnvEditCmd(env *envCommand) *cobra.Command {
 						fmt.Fprintf(edit.env.esc.stdout, "Change request created: %v\n", changeRequestID)
 						fmt.Fprintf(edit.env.esc.stdout, "Change request URL: %v\n", edit.env.esc.changeRequestURL(ref, changeRequestID))
 
-						err = edit.env.esc.client.SubmitChangeRequest(ctx, ref.orgName, changeRequestID)
+						err = edit.env.esc.client.SubmitChangeRequest(ctx, ref.orgName, changeRequestID, nil)
 						if err != nil {
 							return fmt.Errorf("submitting change request: %w", err)
 						}

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -152,7 +152,7 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 				fmt.Fprintf(env.esc.stdout, "Change request created: %v\n", changeRequestID)
 				fmt.Fprintf(env.esc.stdout, "Change request URL: %v\n", env.esc.changeRequestURL(ref, changeRequestID))
 
-				err = env.esc.client.SubmitChangeRequest(ctx, ref.orgName, changeRequestID)
+				err = env.esc.client.SubmitChangeRequest(ctx, ref.orgName, changeRequestID, nil)
 				if err != nil {
 					return fmt.Errorf("submitting change request: %w", err)
 				}

--- a/cmd/esc/cli/env_version_rollback.go
+++ b/cmd/esc/cli/env_version_rollback.go
@@ -57,7 +57,7 @@ func newEnvVersionRollbackCmd(env *envCommand) *cobra.Command {
 				fmt.Fprintf(env.esc.stdout, "Change request created: %v\n", changeRequestID)
 				fmt.Fprintf(env.esc.stdout, "Change request URL: %v\n", env.esc.changeRequestURL(ref, changeRequestID))
 
-				err = env.esc.client.SubmitChangeRequest(ctx, ref.orgName, changeRequestID)
+				err = env.esc.client.SubmitChangeRequest(ctx, ref.orgName, changeRequestID, nil)
 				if err != nil {
 					return fmt.Errorf("submitting change request: %w", err)
 				}

--- a/cmd/esc/cli/testdata/env-edit-editor-invalid-draft.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-invalid-draft.yaml
@@ -1,0 +1,24 @@
+run: esc env edit default/test --draft
+process:
+  environ:
+    EDITOR: my-editor
+  commands:
+    my-editor: |
+      echo -e "imports:\n" >$1
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env edit default/test --draft
+
+---
+> esc env edit default/test --draft
+Error: imports must be a list
+
+  on test line 1:
+   1: imports:
+
+Press ENTER to continue editing or ^D to exit
+Aborting edit.

--- a/cmd/esc/cli/testdata/env-edit-editor-ok-draft.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-ok-draft.yaml
@@ -1,0 +1,21 @@
+run: |
+  esc env edit default/test --draft
+process:
+  environ:
+    EDITOR: my-editor
+  commands:
+    my-editor: |
+      echo -e "values:\n  foo: baz\n" >$1
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env edit default/test --draft
+Change request created: 00000000-0000-0000-0000-000000000000
+Change request URL: https://app.fake.pulumi.com/test-user/esc/default/test/change-requests/00000000-0000-0000-0000-000000000000
+Change request submitted
+
+---
+> esc env edit default/test --draft

--- a/cmd/esc/cli/testdata/env-set-draft.yaml
+++ b/cmd/esc/cli/testdata/env-set-draft.yaml
@@ -1,0 +1,20 @@
+run: |
+  esc env init default/test
+  esc env set default/test foo.bar.baz qux --draft
+  esc env set default/test path "[a" --draft
+error: exit status 1
+
+---
+> esc env init default/test
+Environment created: test-user/default/test
+> esc env set default/test foo.bar.baz qux --draft
+Change request created: 00000000-0000-0000-0000-000000000000
+Change request URL: https://app.fake.pulumi.com/test-user/esc/default/test/change-requests/00000000-0000-0000-0000-000000000000
+Change request submitted
+> esc env set default/test path [a --draft
+
+---
+> esc env init default/test
+> esc env set default/test foo.bar.baz qux --draft
+> esc env set default/test path [a --draft
+Error: invalid value: yaml: line 1: did not find expected ',' or ']'

--- a/cmd/esc/cli/testdata/env-version-rollback-draft.yaml
+++ b/cmd/esc/cli/testdata/env-version-rollback-draft.yaml
@@ -1,0 +1,52 @@
+run: |
+  esc env version rollback default/test@stable --draft
+  esc env version rollback default/test@2 --draft
+error: exit status 1
+environments:
+  test-user/default/a: {}
+  test-user/default/b: {}
+  test-user/default/test:
+    revisions:
+      - yaml:
+          imports:
+            - c
+          values: {}
+      - yaml:
+          values:
+            string: hello, world!
+        tags:
+          - stable
+      - yaml:
+          imports:
+            - a
+            - b
+          values:
+            # comment
+            "null": null
+            boolean: true
+            number: 42
+            string: esc
+            array: [hello, world]
+            object: {hello: world}
+            open:
+              fn::open::test: echo
+            secret:
+              fn::secret:
+                ciphertext: ZXNjeAAAAAHz5ePy5fTB4+Pl8/PL5fnJxPD7
+
+---
+> esc env version rollback default/test@stable --draft
+Change request created: 00000000-0000-0000-0000-000000000000
+Change request URL: https://app.fake.pulumi.com/test-user/esc/default/test/change-requests/00000000-0000-0000-0000-000000000000
+Change request submitted
+> esc env version rollback default/test@2 --draft
+
+---
+> esc env version rollback default/test@stable --draft
+> esc env version rollback default/test@2 --draft
+Error: not found
+
+  on test line 2:
+   2:     - c
+
+Error: could not roll back: too many errors

--- a/cmd/esc/cli/testdata/login-logout.yaml
+++ b/cmd/esc/cli/testdata/login-logout.yaml
@@ -1,7 +1,7 @@
 run: |
   esc login
   esc login https://api.pulumi.com
-  esc login http://fake.pulumi.api
+  esc login https://api.fake.pulumi.com
   esc logout
   esc login || echo ok
   esc login https://api.pulumi.com
@@ -10,13 +10,13 @@ run: |
 
 ---
 > esc login
-Logged in to http://fake.pulumi.api as test-user ()
+Logged in to https://api.fake.pulumi.com as test-user (https://app.fake.pulumi.com/test-user)
 > esc login https://api.pulumi.com
 Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
-> esc login http://fake.pulumi.api
-Logged in to http://fake.pulumi.api as test-user ()
+> esc login https://api.fake.pulumi.com
+Logged in to https://api.fake.pulumi.com as test-user (https://app.fake.pulumi.com/test-user)
 > esc logout
-Logged out of http://fake.pulumi.api
+Logged out of https://api.fake.pulumi.com
 > esc login
 Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
 > esc login https://api.pulumi.com
@@ -29,7 +29,7 @@ Logged in to pulumi.com as test-user (https://app.pulumi.com/test-user)
 ---
 > esc login
 > esc login https://api.pulumi.com
-> esc login http://fake.pulumi.api
+> esc login https://api.fake.pulumi.com
 > esc logout
 > esc login
 > esc login https://api.pulumi.com


### PR DESCRIPTION
Automatically submit change request for simplicity. The console does the same currently.

The flag is hidden for now while the feature and APIs are in preview.

Closes https://github.com/pulumi/pulumi-service/issues/28046

Examples:
```
> esc env set example/g values.example abc2 --draft
Change request created: a9b6ab9b-54b6-4ad6-8236-0d0d1e4eba48
Change request URL: https://app.pulumi.com/pulumipus-org/esc/example/g/change-requests/a9b6ab9b-54b6-4ad6-8236-0d0d1e4eba48
Change request submitted

> esc env edit example/g --draft
Change request created: bc15bae8-2afb-4a63-8d50-ffefef7fbe77
Change request URL: https://app.pulumi.com/pulumipus-org/esc/example/g/change-requests/bc15bae8-2afb-4a63-8d50-ffefef7fbe77
Change request submitted

> esc env version rollback example/g@1 --draft
Change request created: a0f6c39d-c249-44c4-b9e7-2cdf26397705
Change request URL: https://app.pulumi.com/pulumipus-org/esc/example/g/change-requests/a0f6c39d-c249-44c4-b9e7-2cdf26397705
Change request submitted
```