### PR TITLE
cli: fix sorting in env ls

### DIFF
--- a/cmd/esc/cli/env_ls.go
+++ b/cmd/esc/cli/env_ls.go
@@ -39,10 +39,15 @@ func newEnvLsCmd(env *envCommand) *cobra.Command {
 			}
 
 			sort.Slice(allEnvs, func(i, j int) bool {
-				if allEnvs[i].Organization == allEnvs[j].Organization {
-					return allEnvs[i].Name < allEnvs[j].Name
+				ei, ej := allEnvs[i], allEnvs[j]
+
+				if ei.Organization == ej.Organization {
+					if ei.Project == ej.Project {
+						return ei.Name < ej.Name
+					}
+					return ei.Project < ej.Project
 				}
-				return allEnvs[i].Organization < allEnvs[j].Organization
+				return ei.Organization < ej.Organization
 			})
 
 			for _, e := range allEnvs {

--- a/cmd/esc/cli/testdata/env-ls.yaml
+++ b/cmd/esc/cli/testdata/env-ls.yaml
@@ -3,6 +3,9 @@ environments:
   test-org-2/default/env: true
   test-org/default/env: true
   test-org/default/env-2: true
+  test-org/project-a/env: true
+  test-org/project-a/env-2: true
+  test-org/project-b/env: true
   test-user/default/env: true
   test-user/default/env-2: true
 
@@ -12,6 +15,9 @@ default/env
 default/env-2
 test-org/default/env
 test-org/default/env-2
+test-org/project-a/env
+test-org/project-a/env-2
+test-org/project-b/env
 test-org-2/default/env
 
 ---


### PR DESCRIPTION
Sorting does not take the project name into account. These changes fix
the behavior of `env ls` so that environments are sorted by
organization, then project, then name.
