### PR TITLE
Added support for passing values read from a file using --file

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,8 +1,8 @@
 ### Improvements
 
+- `esc env set` now supports --file parameter to read content from a file or stdin [#556](https://github.com/pulumi/esc/pull/556)
 - `--draft` flag for `esc env set`, `esc env edit`, `esc env versions rollback` to create a change request rather than updating directly. **Warning: this feature is in preview, limited to specific orgs, and subject to change.**
   [#552](https://github.com/pulumi/esc/pull/552)
-- `esc env set` now supports --file parameter to read content from a file or stdin [#556](https://github.com/pulumi/esc/pull/556)
 
 ### Bug Fixes
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,6 +2,7 @@
 
 - `--draft` flag for `esc env set`, `esc env edit`, `esc env versions rollback` to create a change request rather than updating directly. **Warning: this feature is in preview, limited to specific orgs, and subject to change.**
   [#552](https://github.com/pulumi/esc/pull/552)
+- `esc env set` now supports --file parameter to read content from a file or stdin [#556](https://github.com/pulumi/esc/pull/556)
 
 ### Bug Fixes
 

--- a/cmd/esc/cli/env_get.go
+++ b/cmd/esc/cli/env_get.go
@@ -132,7 +132,7 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 		"Set to print just the definition.")
 	cmd.Flags().StringVar(
 		&value, "value", "",
-		"Set to print just the value in the given format. May be 'dotenv', 'json', 'detailed', or 'shell'")
+		"Set to print just the value in the given format. May be 'dotenv', 'json', 'detailed', 'shell' or 'string'")
 	cmd.Flags().BoolVar(
 		&showSecrets, "show-secrets", false,
 		"Show static secrets in plaintext rather than ciphertext")

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/pulumi/esc"
@@ -138,7 +139,12 @@ func (env *envCommand) renderValue(
 		}
 		return nil
 	case "string":
-		fmt.Fprintf(out, "%v\n", val.ToString(!showSecrets))
+		s := val.ToString(!showSecrets)
+		if strings.HasSuffix(s, "\n") {
+			fmt.Fprintf(out, "%v", s)
+		} else {
+			fmt.Fprintf(out, "%v\n", s)
+		}
 		return nil
 	default:
 		// NOTE: we shouldn't get here. This was checked at the beginning of the function.

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -79,7 +79,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 		"the lifetime of the opened environment in the form HhMm (e.g. 2h, 1h30m, 15m)")
 	cmd.Flags().StringVarP(
 		&format, "format", "f", "json",
-		"the output format to use. May be 'dotenv', 'json', 'yaml', 'detailed', or 'shell'")
+		"the output format to use. May be 'dotenv', 'json', 'yaml', 'detailed', 'shell' or 'string'")
 
 	return cmd
 }

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -72,7 +72,9 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 				switch file {
 				case "-":
 					content, err = io.ReadAll(env.esc.stdin)
-					break
+					if err != nil {
+						return fmt.Errorf("could not read from stdin: %w", err)
+					}
 				default:
 					content, err = os.ReadFile(file)
 					if err != nil {

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -72,6 +72,7 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 				switch file {
 				case "-":
 					content, err = io.ReadAll(env.esc.stdin)
+					break
 				default:
 					content, err = os.ReadFile(file)
 					if err != nil {

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -53,8 +52,11 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 				return fmt.Errorf("the set command does not accept versions")
 			}
 
-			if len(args) < 2 && file == "" {
+			switch {
+			case file == "" && len(args) < 2:
 				return fmt.Errorf("expected a path and a value")
+			case file != "" && len(args) < 1:
+				return fmt.Errorf("expected a path")
 			}
 
 			path, err := resource.ParsePropertyPath(args[0])
@@ -76,7 +78,7 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 						return fmt.Errorf("could not read from stdin: %w", err)
 					}
 				default:
-					content, err = os.ReadFile(file)
+					content, err = env.esc.fs.ReadFile(file)
 					if err != nil {
 						return fmt.Errorf("could not read file: %w", err)
 					}

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -80,10 +80,10 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 					if err != nil {
 						return fmt.Errorf("could not read file: %w", err)
 					}
+				}
 
-					if !utf8.Valid(content) {
-						return fmt.Errorf("file content must be valid UTF-8")
-					}
+				if !utf8.Valid(content) {
+					return fmt.Errorf("file content must be valid UTF-8")
 				}
 
 				input = string(content)

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -195,6 +195,7 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 	cmd.Flags().BoolVar(
 		&rawString, "string", false,
 		"true to treat the value as a string rather than attempting to parse it as YAML")
+	cmd.Flags().StringVarP(&file, "file", "f", "", "If set, the value is read from the specified file. Pass `-` to read from standard input.")
 	cmd.Flags().BoolVar(
 		&draft, "draft", false,
 		"true to create a draft rather than saving changes directly, returns a submitted Change Request ID and its URL")
@@ -202,7 +203,6 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 	if err != nil {
 		panic(err)
 	}
-	cmd.Flags().StringVar(&file, "file", "", "If set, the key value is read from the specified file. Pass `-` to read from standard input.")
 
 	return cmd
 }

--- a/cmd/esc/cli/fs.go
+++ b/cmd/esc/cli/fs.go
@@ -15,6 +15,7 @@ type escFS interface {
 	fs.FS
 
 	CreateTemp(dir, pattern string) (string, io.ReadWriteCloser, error)
+	ReadFile(filename string) ([]byte, error)
 	Remove(name string) error
 }
 
@@ -40,4 +41,8 @@ func (defaultFS) CreateTemp(dir, pattern string) (string, io.ReadWriteCloser, er
 
 func (defaultFS) Remove(name string) error {
 	return os.Remove(name)
+}
+
+func (defaultFS) ReadFile(name string) ([]byte, error) {
+	return os.ReadFile(name)
 }

--- a/cmd/esc/cli/testdata/env-set-file.yaml
+++ b/cmd/esc/cli/testdata/env-set-file.yaml
@@ -1,8 +1,11 @@
 run: |
-  echo 'hello' | esc env set default/test foo -f=-
+  echo "hello" | esc env set default/test foo -f=-
   esc env get default/test
-  echo 'hello world' >test.file
+  echo "hello world" >test.file
   esc env set default/test foo -f=test.file
+  esc env get default/test
+  esc env get default/test --value string
+  esc env set default/test foo -f=test.file --string
   esc env get default/test
   esc env set default/test -f=test.file || echo -n ""
   esc env set -f=test.file || echo -n ""
@@ -42,6 +45,24 @@ values:
 
 ```
 
+> esc env get default/test --value string
+"foo"="hello world"
+> esc env set default/test foo -f=test.file --string
+> esc env get default/test
+# Value
+```json
+{
+  "foo": "hello world\n"
+}
+```
+# Definition
+```yaml
+values:
+  foo: |
+    hello world
+
+```
+
 > esc env set default/test -f=test.file
 > esc env set -f=test.file
 
@@ -49,6 +70,9 @@ values:
 > esc env set default/test foo -f=-
 > esc env get default/test
 > esc env set default/test foo -f=test.file
+> esc env get default/test
+> esc env get default/test --value string
+> esc env set default/test foo -f=test.file --string
 > esc env get default/test
 > esc env set default/test -f=test.file
 Error: expected a path

--- a/cmd/esc/cli/testdata/env-set-file.yaml
+++ b/cmd/esc/cli/testdata/env-set-file.yaml
@@ -1,0 +1,56 @@
+run: |
+  echo 'hello' | esc env set default/test foo -f=-
+  esc env get default/test
+  echo 'hello world' >test.file
+  esc env set default/test foo -f=test.file
+  esc env get default/test
+  esc env set default/test -f=test.file || echo -n ""
+  esc env set -f=test.file || echo -n ""
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env set default/test foo -f=-
+> esc env get default/test
+# Value
+```json
+{
+  "foo": "hello"
+}
+```
+# Definition
+```yaml
+values:
+  foo: hello
+
+```
+
+> esc env set default/test foo -f=test.file
+> esc env get default/test
+# Value
+```json
+{
+  "foo": "hello world"
+}
+```
+# Definition
+```yaml
+values:
+  foo: hello world
+
+```
+
+> esc env set default/test -f=test.file
+> esc env set -f=test.file
+
+---
+> esc env set default/test foo -f=-
+> esc env get default/test
+> esc env set default/test foo -f=test.file
+> esc env get default/test
+> esc env set default/test -f=test.file
+Error: expected a path
+> esc env set -f=test.file
+Error: accepts between 1 and 3 arg(s), received 0

--- a/cmd/esc/cli/testdata/env-set-file.yaml
+++ b/cmd/esc/cli/testdata/env-set-file.yaml
@@ -9,6 +9,11 @@ run: |
   esc env get default/test
   esc env set default/test -f=test.file || echo -n ""
   esc env set -f=test.file || echo -n ""
+  esc env set default/test -f=binary foo || echo -n ""
+  esc env set -f=- default/test foo <binary || echo -n ""
+process:
+  fs:
+    binary: !!binary sFOZJGpvmbYHwHRLnCYSnQ==
 environments:
   test-user/default/test:
     values:
@@ -65,6 +70,8 @@ values:
 
 > esc env set default/test -f=test.file
 > esc env set -f=test.file
+> esc env set default/test -f=binary foo
+> esc env set -f=- default/test foo
 
 ---
 > esc env set default/test foo -f=-
@@ -78,3 +85,7 @@ values:
 Error: expected a path
 > esc env set -f=test.file
 Error: accepts between 1 and 3 arg(s), received 0
+> esc env set default/test -f=binary foo
+Error: file content must be valid UTF-8
+> esc env set -f=- default/test foo
+Error: file content must be valid UTF-8

--- a/cmd/esc/cli/testdata/env-set-file.yaml
+++ b/cmd/esc/cli/testdata/env-set-file.yaml
@@ -11,9 +11,15 @@ run: |
   esc env set -f=test.file || echo -n ""
   esc env set default/test -f=binary foo || echo -n ""
   esc env set -f=- default/test foo <binary || echo -n ""
+  esc env set --string -f=multiline default/test foo
+  esc env get default/test foo --value string
 process:
   fs:
     binary: !!binary sFOZJGpvmbYHwHRLnCYSnQ==
+    multiline: |
+      this is a
+      multiline
+      file
 environments:
   test-user/default/test:
     values:
@@ -72,6 +78,11 @@ values:
 > esc env set -f=test.file
 > esc env set default/test -f=binary foo
 > esc env set -f=- default/test foo
+> esc env set --string -f=multiline default/test foo
+> esc env get default/test foo --value string
+this is a
+multiline
+file
 
 ---
 > esc env set default/test foo -f=-
@@ -89,3 +100,5 @@ Error: accepts between 1 and 3 arg(s), received 0
 Error: file content must be valid UTF-8
 > esc env set -f=- default/test foo
 Error: file content must be valid UTF-8
+> esc env set --string -f=multiline default/test foo
+> esc env get default/test foo --value string


### PR DESCRIPTION
# Description

This PR adds supports for `--file <path>` modifier in `esc env set`. 
This modifier will read the file in <path> and, if it's a valid string content, will use that to set the value of the specified key.

## Usage

```sh
$ esc env set --file /path/to/file.txt myorg/myproj/myenv "mykey"
```

the `--file` flag also supports passing "-" to read from `stdin` so its consistent with the behavior of `--file` flag in `esc env edit`

```sh
$ cat /path/to/file.txt | esc env set --file - myorg/myproj/myenv
```

The flag can be combined with other flags. For example to store a file as a rawstring content and secret:

```sh
$ esc env set --secret --string --file /path/to/file.pem myorg/myproj/myenv "mykey"
```

To simplify reading file content, we fixed a bug where a new line is always being added at the end of the value when using `--value string` in `esc env open` and `esc env get`. 

Users will be able to get the file content from esc.

eg.

```sh
$ esc env set --secret --string --file /path/to/file.pem myorg/myproj/myenv "mypemfile"
$ esc env get --show-secrets --value string myorg/myproj/myenv "mypemfile" >> /path/to/file_1.pem
$ diff /path/to/file_1.pem /path/to/file.pem
$
```


## Known Issues

`--file` does not currently supports binary files (or any other file that does not contain valid utf-8 characters). These files require special treatment and might be included in another change (see #483)