### PR TITLE
[Approvals] open and edit draft environments

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,10 @@
 ### Improvements
 
+- Update a draft via `--draft=<change-request-id>` for `env edit`, `env set`, and `env version rollback`
+  [#565](https://github.com/pulumi/esc/pull/565)
+- Open a draft via `--draft=<change-request-id>` for `env run` and `env open`
+  [#565](https://github.com/pulumi/esc/pull/565)
+
 ### Bug Fixes
 
 ### Breaking changes

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,12 +1,5 @@
 ### Improvements
 
-- `esc env set` now supports --file parameter to read content from a file or stdin [#556](https://github.com/pulumi/esc/pull/556)
-- `--draft` flag for `esc env set`, `esc env edit`, `esc env versions rollback` to create a change request rather than updating directly. **Warning: this feature is in preview, limited to specific orgs, and subject to change.**
-  [#552](https://github.com/pulumi/esc/pull/552)
-
 ### Bug Fixes
-
-- Fix decryption error with keys with dashes
-  [#559](https://github.com/pulumi/esc/pull/559)
 
 ### Breaking changes

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,8 +1,8 @@
 ### Improvements
 
-- Update a draft via `--draft=<change-request-id>` for `env edit`, `env set`, and `env version rollback`
+- Update a draft via `--draft=<change-request-id>` for `env edit`, `env set`, and `env version rollback`. **Warning: this feature is in preview, limited to specific orgs, and subject to change.**
   [#565](https://github.com/pulumi/esc/pull/565)
-- Open a draft via `--draft=<change-request-id>` for `env run` and `env open`
+- Open a draft via `--draft=<change-request-id>` for `env run` and `env open`. **Warning: this feature is in preview, limited to specific orgs, and subject to change.**
   [#565](https://github.com/pulumi/esc/pull/565)
 
 ### Bug Fixes

--- a/cmd/esc/cli/client/apitype.go
+++ b/cmd/esc/cli/client/apitype.go
@@ -144,6 +144,11 @@ type CreateEnvironmentDraftResponse struct {
 	LatestRevisionNumber int    `json:"latestRevisionNumber"`
 }
 
+type UpdateEnvironmentDraftResponse struct {
+	ChangeRequestID      string `json:"changeRequestId"`
+	LatestRevisionNumber int    `json:"latestRevisionNumber"`
+}
+
 type SubmitChangeRequestRequest struct {
 	Description *string `json:"description,omitempty"`
 }

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -117,11 +117,9 @@ type Client interface {
 		decrypt bool,
 	) (yaml []byte, etag string, revision int, err error)
 
-	// GetEnvironmentDraft returns the YAML + ETag for the draft env specified. If decrypt is
-	// true, any { fn::secret: { ciphertext: "..." } } constructs in the definition will be decrypted and
-	// replaced with { fn::secret: "plaintext" }.
+	// GetEnvironmentDraft returns the YAML + ETag for the draft env specified.
 	//
-	// The etag returned by GetEnvironmentDraft can be passed to UpdateEnvironmentDraft in order to avoid RMW issues
+	// The returned etag  must be passed to UpdateEnvironmentDraft in order to avoid RMW issues
 	// when editing drafts.
 	GetEnvironmentDraft(
 		ctx context.Context,
@@ -187,9 +185,8 @@ type Client interface {
 	//
 	// If the updated environment definition contains errors, the creation will fail with diagnostics.
 	//
-	// If etag is not the empty string and the draft's current etag does not match the provided etag
-	// (i.e. because a different entity has called UpdateEnvironment), the creation will fail with a 409
-	// error.
+	// If the draft's current etag does not match the provided etag (i.e. because a different entity
+	// has called UpdateEnvironment), the creation will fail with a 409 error.
 	UpdateEnvironmentDraft(
 		ctx context.Context,
 		orgName string,
@@ -761,9 +758,7 @@ func (pc *client) UpdateEnvironmentDraft(
 	etag string,
 ) ([]EnvironmentDiagnostic, error) {
 	header := http.Header{}
-	if etag != "" {
-		header.Set("If-Match", etag)
-	}
+	header.Set("If-Match", etag)
 
 	var errResp EnvironmentErrorResponse
 	path := fmt.Sprintf("/api/preview/esc/environments/%v/%v/%v/drafts/%v", orgName, projectName, envName, changeRequestID)

--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -404,8 +404,10 @@ func (esc *escCommand) changeRequestURL(ref environmentRef, changeRequestID stri
 	)
 }
 
-// updateEnvironment updates an environment. If draft is "new", a change request is created and submitted.
-// If draft is an ID, an existing change request is updated.
+// updateEnvironment updates an environment.
+// If draft is empty, the environment is directly updated.
+// If draft is "new", a change request is created and submitted.
+// If draft is a change request ID, an existing change request is updated.
 // Progress is logged to stdout. However, diagnostics are not logged, that is left up to the caller.
 func (esc *escCommand) updateEnvironment(
 	ctx context.Context,

--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -404,17 +404,18 @@ func (esc *escCommand) changeRequestURL(ref environmentRef, changeRequestID stri
 	)
 }
 
-// updateEnvironment updates an environment. If draft is true, a change request is created and submitted.
+// updateEnvironment updates an environment. If draft is "new", a change request is created and submitted.
+// If draft is an ID, an existing change request is updated.
 // Progress is logged to stdout. However, diagnostics are not logged, that is left up to the caller.
 func (esc *escCommand) updateEnvironment(
 	ctx context.Context,
 	ref environmentRef,
-	draft bool,
+	draft string,
 	yaml []byte,
 	tag string,
 	envUpdateSuccessMessage string,
 ) ([]client.EnvironmentDiagnostic, error) {
-	if draft {
+	if draft == "new" {
 		changeRequestID, diags, err := esc.client.CreateEnvironmentDraft(ctx, ref.orgName, ref.projectName, ref.envName, yaml, tag)
 		if err != nil {
 			return nil, fmt.Errorf("creating environment draft: %w", err)
@@ -430,6 +431,18 @@ func (esc *escCommand) updateEnvironment(
 			fmt.Fprintln(esc.stdout, "Change request submitted")
 		}
 		return diags, nil
+	} else if draft != "" {
+		changeRequestID := draft
+		diags, err := esc.client.UpdateEnvironmentDraft(ctx, ref.orgName, ref.projectName, ref.envName, changeRequestID, yaml, tag)
+		if err != nil {
+			return nil, fmt.Errorf("updating environment draft: %w", err)
+		}
+		if len(diags) == 0 {
+			fmt.Fprintln(esc.stdout, "Change request updated")
+			fmt.Fprintf(esc.stdout, "Change request URL: %v\n", esc.changeRequestURL(ref, changeRequestID))
+		}
+		return diags, nil
+
 	} else {
 		diags, err := esc.client.UpdateEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName, yaml, tag)
 		if err != nil {

--- a/cmd/esc/cli/env_run.go
+++ b/cmd/esc/cli/env_run.go
@@ -93,6 +93,7 @@ func (w *redactor) Close() error {
 func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 	var interactive bool
 	var duration time.Duration
+	var draft string
 
 	shell := valueOrDefault(filepath.Base(envcmd.esc.environ.Get("SHELL")), "sh")
 
@@ -145,7 +146,7 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 			}
 			args = args[1:]
 
-			env, diags, err := envcmd.openEnvironment(ctx, ref, duration)
+			env, diags, err := envcmd.openEnvironment(ctx, ref, duration, draft)
 			if err != nil {
 				return err
 			}
@@ -213,6 +214,13 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 
 	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "true to treat the command as interactive and disable output filters")
 	cmd.Flags().DurationVarP(&duration, "lifetime", "l", 2*time.Hour, "the lifetime of the opened environment")
+	cmd.Flags().StringVar(
+		&draft, "draft", "",
+		"open an environment draft with --draft=<change-request-id>")
+	err := cmd.Flags().MarkHidden("draft") // hide while in preview
+	if err != nil {
+		panic(err)
+	}
 
 	return cmd
 }

--- a/cmd/esc/cli/testdata/env-edit-editor-invalid-show-secrets-draft.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-invalid-show-secrets-draft.yaml
@@ -1,0 +1,19 @@
+run: esc env edit default/test --draft=EXAMPLE --show-secrets
+process:
+  environ:
+    EDITOR: my-editor
+  commands:
+    my-editor: |
+      echo -e "values:\n  foo: baz\n" >$1
+error: exit status 1
+environments:
+  test-user/default/test:
+    values:
+      foo: bar
+
+---
+> esc env edit default/test --draft=EXAMPLE --show-secrets
+
+---
+> esc env edit default/test --draft=EXAMPLE --show-secrets
+Error: --show-secrets is not supported for updating drafts

--- a/cmd/esc/cli/testdata/env-set-draft.yaml
+++ b/cmd/esc/cli/testdata/env-set-draft.yaml
@@ -1,6 +1,7 @@
 run: |
   esc env init default/test
   esc env set default/test foo.bar.baz qux --draft
+  esc env set default/test foo.bar.baz quy --draft=EXAMPLE
   esc env set default/test path "[a" --draft
 error: exit status 1
 
@@ -11,10 +12,14 @@ Environment created: test-user/default/test
 Change request created: 00000000-0000-0000-0000-000000000000
 Change request URL: https://app.fake.pulumi.com/test-user/esc/default/test/change-requests/00000000-0000-0000-0000-000000000000
 Change request submitted
+> esc env set default/test foo.bar.baz quy --draft=EXAMPLE
+Change request updated
+Change request URL: https://app.fake.pulumi.com/test-user/esc/default/test/change-requests/EXAMPLE
 > esc env set default/test path [a --draft
 
 ---
 > esc env init default/test
 > esc env set default/test foo.bar.baz qux --draft
+> esc env set default/test foo.bar.baz quy --draft=EXAMPLE
 > esc env set default/test path [a --draft
 Error: invalid value: yaml: line 1: did not find expected ',' or ']'

--- a/cmd/esc/cli/testdata/env-version-rollback-draft.yaml
+++ b/cmd/esc/cli/testdata/env-version-rollback-draft.yaml
@@ -1,5 +1,6 @@
 run: |
   esc env version rollback default/test@stable --draft
+  esc env version rollback default/test@1 --draft=EXAMPLE
   esc env version rollback default/test@2 --draft
 error: exit status 1
 environments:
@@ -39,10 +40,14 @@ environments:
 Change request created: 00000000-0000-0000-0000-000000000000
 Change request URL: https://app.fake.pulumi.com/test-user/esc/default/test/change-requests/00000000-0000-0000-0000-000000000000
 Change request submitted
+> esc env version rollback default/test@1 --draft=EXAMPLE
+Change request updated
+Change request URL: https://app.fake.pulumi.com/test-user/esc/default/test/change-requests/EXAMPLE
 > esc env version rollback default/test@2 --draft
 
 ---
 > esc env version rollback default/test@stable --draft
+> esc env version rollback default/test@1 --draft=EXAMPLE
 > esc env version rollback default/test@2 --draft
 Error: not found
 

--- a/cmd/esc/cli/testdata/open-draft.yaml
+++ b/cmd/esc/cli/testdata/open-draft.yaml
@@ -1,0 +1,24 @@
+run: |
+  esc env init default/test
+  esc env set default/test password 1234 --secret --draft
+  esc open default/test 
+  esc open default/test --draft=EXAMPLE
+
+---
+> esc env init default/test
+Environment created: test-user/default/test
+> esc env set default/test password 1234 --secret --draft
+Change request created: 00000000-0000-0000-0000-000000000000
+Change request URL: https://app.fake.pulumi.com/test-user/esc/default/test/change-requests/00000000-0000-0000-0000-000000000000
+Change request submitted
+> esc open default/test
+> esc open default/test --draft=EXAMPLE
+{
+  "password": "1234"
+}
+
+---
+> esc env init default/test
+> esc env set default/test password 1234 --secret --draft
+> esc open default/test
+> esc open default/test --draft=EXAMPLE

--- a/cmd/esc/cli/testdata/run-draft.yaml
+++ b/cmd/esc/cli/testdata/run-draft.yaml
@@ -1,0 +1,36 @@
+run: |
+  esc env run --draft=EXAMPLE default/test dump-env
+process:
+  commands:
+    dump-env: |
+      echo "secret: $SECRET, plain: $PLAIN, bool: $BOOL, num: $NUM, file: $FILE, boolFile: $BOOL_FILE, numFile: $NUM_FILE"
+    echo: |
+      echo $*
+    source-file: |
+      source $FILE
+      echo "secret: $F_SECRET, plain: $F_PLAIN"
+environments:
+  test-user/default/test_DRAFT:
+    values:
+      secret: {"fn::secret": "hunter2"}
+      plain: plaintext
+      yup: true
+      pi: 3.14
+      environmentVariables:
+        SECRET: ${secret}
+        PLAIN: ${plain}
+        BOOL: ${yup}
+        NUM: ${pi}
+      files:
+        FILE: |
+          export F_SECRET=${secret}
+          export F_PLAIN=${plain}
+        BOOL_FILE: ${yup}
+        NUM_FILE: ${pi}
+
+---
+> esc env run --draft=EXAMPLE default/test dump-env
+secret: [secret], plain: plaintext, bool: true, num: 3.14, file: temp/esc-temp-1, boolFile: temp/esc-temp-0, numFile: temp/esc-temp-2
+
+---
+> esc env run --draft=EXAMPLE default/test dump-env


### PR DESCRIPTION
- Update a draft via `--draft` for `env edit`, `env set`, and `env version rollback`
- Open a draft via `--draft` for `env run` and `env open`

Closes pulumi/pulumi-service#30603