### PR TITLE
[Approvals] Use non preview routes

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
+- Internal preparation for the upcoming Approvals launch
+  [#569](https://github.com/pulumi/esc/pull/569)
+
 ### Bug Fixes
 
 ### Breaking changes

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -709,7 +709,7 @@ func (pc *client) CreateEnvironmentDraft(
 	}
 
 	var errResp EnvironmentErrorResponse
-	path := fmt.Sprintf("/api/preview/esc/environments/%v/%v/%v/drafts", orgName, projectName, envName)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/drafts", orgName, projectName, envName)
 	var resp CreateEnvironmentDraftResponse
 	err := pc.restCallWithOptions(ctx, http.MethodPost, path, nil, json.RawMessage(yaml), &resp, httpCallOptions{
 		Header:        header,
@@ -733,7 +733,7 @@ func (pc *client) GetEnvironmentDraft(
 	envName string,
 	changeRequestID string,
 ) ([]byte, string, error) {
-	path := fmt.Sprintf("/api/preview/esc/environments/%v/%v/%v/drafts/%v", orgName, projectName, envName, changeRequestID)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/drafts/%v", orgName, projectName, envName, changeRequestID)
 
 	var resp *http.Response
 	if err := pc.restCall(ctx, http.MethodGet, path, nil, nil, &resp); err != nil {
@@ -761,7 +761,7 @@ func (pc *client) UpdateEnvironmentDraft(
 	header.Set("If-Match", etag)
 
 	var errResp EnvironmentErrorResponse
-	path := fmt.Sprintf("/api/preview/esc/environments/%v/%v/%v/drafts/%v", orgName, projectName, envName, changeRequestID)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/drafts/%v", orgName, projectName, envName, changeRequestID)
 	var resp UpdateEnvironmentDraftResponse
 	err := pc.restCallWithOptions(ctx, http.MethodPatch, path, nil, json.RawMessage(yaml), &resp, httpCallOptions{
 		Header:        header,
@@ -785,7 +785,7 @@ func (pc *client) SubmitChangeRequest(
 	description *string,
 ) error {
 	req := SubmitChangeRequestRequest{Description: description}
-	path := fmt.Sprintf("/api/preview/change-requests/%v/%v/submit", orgName, changeRequestID)
+	path := fmt.Sprintf("/api/change-requests/%v/%v/submit", orgName, changeRequestID)
 	err := pc.restCall(ctx, http.MethodPost, path, nil, &req, nil)
 	return err
 }
@@ -840,7 +840,7 @@ func (pc *client) OpenEnvironmentDraft(
 	changeRequestID string,
 	duration time.Duration,
 ) (string, []EnvironmentDiagnostic, error) {
-	path := fmt.Sprintf("/api/preview/esc/environments/%v/%v/%v/drafts/%v/open", orgName, projectName, envName, changeRequestID)
+	path := fmt.Sprintf("/api/esc/environments/%v/%v/%v/drafts/%v/open", orgName, projectName, envName, changeRequestID)
 
 	queryObj := struct {
 		Duration string `url:"duration"`

--- a/cmd/esc/cli/client/client_test.go
+++ b/cmd/esc/cli/client/client_test.go
@@ -392,7 +392,7 @@ func TestCreateEnvironmentDraft(t *testing.T) {
 		yaml := []byte("new definition")
 		tag := "old tag"
 
-		client := newTestClient(t, http.MethodPost, "/api/preview/esc/environments/test-org/test-project/test-env/drafts", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/test-project/test-env/drafts", func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, tag, r.Header.Get("ETag"))
 
 			body, err := io.ReadAll(r.Body)
@@ -433,7 +433,7 @@ func TestCreateEnvironmentDraft(t *testing.T) {
 			},
 		}
 
-		client := newTestClient(t, http.MethodPost, "/api/preview/esc/environments/test-org/test-project/test-env/drafts", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/test-project/test-env/drafts", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 
 			err := json.NewEncoder(w).Encode(EnvironmentErrorResponse{
@@ -470,7 +470,7 @@ func TestCreateEnvironmentDraft(t *testing.T) {
 			},
 		}
 
-		client := newTestClient(t, http.MethodPost, "/api/preview/esc/environments/test-org/test-project/test-env/drafts", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/test-project/test-env/drafts", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 
 			err := json.NewEncoder(w).Encode(EnvironmentErrorResponse{Diagnostics: expected})
@@ -484,7 +484,7 @@ func TestCreateEnvironmentDraft(t *testing.T) {
 	})
 
 	t.Run("Conflict", func(t *testing.T) {
-		client := newTestClient(t, http.MethodPost, "/api/preview/esc/environments/test-org/test-project/test-env/drafts", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/esc/environments/test-org/test-project/test-env/drafts", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusConflict)
 
 			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
@@ -501,7 +501,7 @@ func TestCreateEnvironmentDraft(t *testing.T) {
 
 func TestSubmitChangeRequest(t *testing.T) {
 	t.Run("OK - nil description", func(t *testing.T) {
-		client := newTestClient(t, http.MethodPost, "/api/preview/change-requests/test-org/EXAMPLE/submit", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/change-requests/test-org/EXAMPLE/submit", func(w http.ResponseWriter, r *http.Request) {
 			expectedBody := SubmitChangeRequestRequest{}
 			expectedBodyJSON, err := json.Marshal(expectedBody)
 			require.NoError(t, err)
@@ -517,7 +517,7 @@ func TestSubmitChangeRequest(t *testing.T) {
 	})
 
 	t.Run("OK - empty description", func(t *testing.T) {
-		client := newTestClient(t, http.MethodPost, "/api/preview/change-requests/test-org/EXAMPLE/submit", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/change-requests/test-org/EXAMPLE/submit", func(w http.ResponseWriter, r *http.Request) {
 			expectedBody := SubmitChangeRequestRequest{}
 			expectedBodyJSON, err := json.Marshal(expectedBody)
 			require.NoError(t, err)
@@ -533,7 +533,7 @@ func TestSubmitChangeRequest(t *testing.T) {
 	})
 
 	t.Run("OK - description provided", func(t *testing.T) {
-		client := newTestClient(t, http.MethodPost, "/api/preview/change-requests/test-org/EXAMPLE/submit", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/change-requests/test-org/EXAMPLE/submit", func(w http.ResponseWriter, r *http.Request) {
 			description := "test description"
 			expectedBody := SubmitChangeRequestRequest{Description: &description}
 			expectedBodyJSON, err := json.Marshal(expectedBody)
@@ -551,7 +551,7 @@ func TestSubmitChangeRequest(t *testing.T) {
 	})
 
 	t.Run("Already submitted", func(t *testing.T) {
-		client := newTestClient(t, http.MethodPost, "/api/preview/change-requests/test-org/EXAMPLE/submit", func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(t, http.MethodPost, "/api/change-requests/test-org/EXAMPLE/submit", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 
 			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{


### PR DESCRIPTION
- [x] Merge this only after testing with the non preview routes in prod.

Closes pulumi/pulumi-service#30757

We don't want these to be used by the CLI when the feature moves to GA in a PR that will be merged later.