### PR TITLE
cli: Add ESC-specific environment variables to `esc run` command.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,14 @@
 ### Improvements
 
+* Added ESC-specific environment variables to `esc run` command:
+  * `PULUMI_ESC_ORG`
+  * `PULUMI_ESC_PROJECT`
+  * `PULUMI_ESC_ENVIRONMENT`
+
+  These environment variables can be excluded with the `--exclude-env-vars` flag.
+
+  These environment variables allow to detect whether the command executed by `esc run` is running in an ESC environment.
+
 ### Bug Fixes
 
 ### Breaking changes

--- a/cmd/esc/cli/prepare.go
+++ b/cmd/esc/cli/prepare.go
@@ -100,13 +100,20 @@ func createTemporaryFiles(e *esc.Environment, opts PrepareOptions) (paths, envir
 	return paths, environ, secrets, nil
 }
 
+// EscEnvVars contains the environment variables to include when using `esc run`.
+type EscEnvVars struct {
+	Org         string
+	Project     string
+	Environment string
+}
+
 // PrepareOptions contains options for PrepareEnvironment.
 type PrepareOptions struct {
-	Quote   bool // True to quote environment variable values
-	Pretend bool // True to skip actually writing temporary files
-	Redact  bool // True to redact secrets. Ignored unless Pretend is set.
-
-	fs escFS // The filesystem for temporary files
+	Quote      bool     // True to quote environment variable values
+	Pretend    bool     // True to skip actually writing temporary files
+	Redact     bool     // True to redact secrets. Ignored unless Pretend is set.
+	EscEnvVars []string // ESC-specific environment variables to include
+	fs         escFS    // The filesystem for temporary files
 }
 
 // PrepareEnvironment prepares the envvar and temporary file projections for an environment. Returns the paths to
@@ -127,6 +134,9 @@ func PrepareEnvironment(e *esc.Environment, opts *PrepareOptions) (files, enviro
 	}
 
 	environ = append(envVars, fileVars...)
+	if opts.EscEnvVars != nil {
+		environ = append(environ, opts.EscEnvVars...)
+	}
 	secrets = append(envSecrets, fileSecrets...)
 	return filePaths, environ, secrets, nil
 }

--- a/cmd/esc/cli/testdata/run.yaml
+++ b/cmd/esc/cli/testdata/run.yaml
@@ -7,10 +7,14 @@ run: |
   esc env run -i default/test source-file
   esc env run default/test -- echo -n hunter2
   esc env run default/test -i -- echo -n hunter2
+  esc env run default/test dump-pulumi-esc-vars
+  esc env run -x default/test dump-pulumi-esc-vars
 process:
   commands:
     dump-env: |
       echo "secret: $SECRET, plain: $PLAIN, bool: $BOOL, num: $NUM, file: $FILE, boolFile: $BOOL_FILE, numFile: $NUM_FILE"
+    dump-pulumi-esc-vars: |
+      echo "PULUMI_ESC_ORG: ${PULUMI_ESC_ORG:="not set"}, PULUMI_ESC_PROJECT: ${PULUMI_ESC_PROJECT:="not set"}, PULUMI_ESC_ENVIRONMENT: ${PULUMI_ESC_ENVIRONMENT:="not set"}"
     echo: |
       echo $*
     source-file: |
@@ -50,7 +54,11 @@ secret: [secret], plain: plaintext
 secret: hunter2, plain: plaintext
 > esc env run default/test -- echo -n hunter2
 [secret]> esc env run default/test -i -- echo -n hunter2
-hunter2
+hunter2> esc env run default/test dump-pulumi-esc-vars
+PULUMI_ESC_ORG: test-user, PULUMI_ESC_PROJECT: default, PULUMI_ESC_ENVIRONMENT: test
+> esc env run -x default/test dump-pulumi-esc-vars
+PULUMI_ESC_ORG: not set, PULUMI_ESC_PROJECT: not set, PULUMI_ESC_ENVIRONMENT: not set
+
 ---
 > esc env run default/test dump-env
 > esc env run -i default/test dump-env
@@ -60,3 +68,5 @@ hunter2
 > esc env run -i default/test source-file
 > esc env run default/test -- echo -n hunter2
 > esc env run default/test -i -- echo -n hunter2
+> esc env run default/test dump-pulumi-esc-vars
+> esc env run -x default/test dump-pulumi-esc-vars


### PR DESCRIPTION
Added ESC-specific environment variables to `esc run` command:
  * `PULUMI_ESC_ORG`
  * `PULUMI_ESC_PROJECT`
  * `PULUMI_ESC_ENVIRONMENT`

These can be excluded with the `--exclude-env-vars` (`-x`) flag.

These environment variables allow to detect whether the command is running in an ESC environment. Particularly, this should allow us to detect when `pulumi` is repeatedly being invoked with `esc run` to suggest setting `environment` instead.