### PR TITLE
Enforce reserved properties to be non-null objects

### DIFF
--- a/ast/testdata/parse/values-environment-variables-null/env.yaml
+++ b/ast/testdata/parse/values-environment-variables-null/env.yaml
@@ -1,0 +1,2 @@
+values:
+  environmentVariables: null

--- a/ast/testdata/parse/values-environment-variables-null/expected.json
+++ b/ast/testdata/parse/values-environment-variables-null/expected.json
@@ -1,0 +1,41 @@
+{
+    "decl": {
+        "Description": null,
+        "Imports": null,
+        "Values": {
+            "Entries": [
+                {
+                    "Key": {
+                        "Value": "environmentVariables"
+                    },
+                    "Value": {}
+                }
+            ]
+        }
+    },
+    "diags": [
+        {
+            "Severity": 1,
+            "Summary": "environmentVariables must be an object",
+            "Detail": "",
+            "Subject": {
+                "Filename": "values-environment-variables-null",
+                "Start": {
+                    "Line": 2,
+                    "Column": 3,
+                    "Byte": 10
+                },
+                "End": {
+                    "Line": 2,
+                    "Column": 29,
+                    "Byte": 36
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values"
+        }
+    ]
+}

--- a/ast/testdata/parse/values-files-null/env.yaml
+++ b/ast/testdata/parse/values-files-null/env.yaml
@@ -1,0 +1,2 @@
+values:
+  files: null

--- a/ast/testdata/parse/values-files-null/expected.json
+++ b/ast/testdata/parse/values-files-null/expected.json
@@ -1,0 +1,41 @@
+{
+    "decl": {
+        "Description": null,
+        "Imports": null,
+        "Values": {
+            "Entries": [
+                {
+                    "Key": {
+                        "Value": "files"
+                    },
+                    "Value": {}
+                }
+            ]
+        }
+    },
+    "diags": [
+        {
+            "Severity": 1,
+            "Summary": "files must be an object",
+            "Detail": "",
+            "Subject": {
+                "Filename": "values-files-null",
+                "Start": {
+                    "Line": 2,
+                    "Column": 3,
+                    "Byte": 10
+                },
+                "End": {
+                    "Line": 2,
+                    "Column": 14,
+                    "Byte": 21
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values"
+        }
+    ]
+}

--- a/ast/testdata/parse/values-pulumi-config-null/env.yaml
+++ b/ast/testdata/parse/values-pulumi-config-null/env.yaml
@@ -1,0 +1,2 @@
+values:
+  pulumiConfig: null

--- a/ast/testdata/parse/values-pulumi-config-null/expected.json
+++ b/ast/testdata/parse/values-pulumi-config-null/expected.json
@@ -1,0 +1,41 @@
+{
+    "decl": {
+        "Description": null,
+        "Imports": null,
+        "Values": {
+            "Entries": [
+                {
+                    "Key": {
+                        "Value": "pulumiConfig"
+                    },
+                    "Value": {}
+                }
+            ]
+        }
+    },
+    "diags": [
+        {
+            "Severity": 1,
+            "Summary": "pulumiConfig must be an object",
+            "Detail": "",
+            "Subject": {
+                "Filename": "values-pulumi-config-null",
+                "Start": {
+                    "Line": 2,
+                    "Column": 3,
+                    "Byte": 10
+                },
+                "End": {
+                    "Line": 2,
+                    "Column": 21,
+                    "Byte": 28
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values"
+        }
+    ]
+}


### PR DESCRIPTION
This PR enforces [reserved properties](https://www.pulumi.com/docs/esc/reference/reserved-properties/) to be non-null objects.

Previously only `imports` and `values` have been enforced to be non-null objects. Now also reserved properties are enforced to be non-null objects.

This example environment now errors:
``` 
values:
  foo: bar
  pulumiConfig: null
```