### PR TITLE
Add support for fn::concat to concatenate arrays

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -276,6 +276,7 @@ type exprNode interface {
 // - {Null, Boolean, Number, String}Expr -> literalExpr
 // - InterpolateExpr                     -> interpolateExpr
 // - SymbolExpr                          -> symbolExpr
+// - ConcatExpr                          -> concatExpr
 // - FromBase64Expr                      -> fromBase64Expr
 // - FromJSONExpr                        -> fromJSONExpr
 // - JoinExpr                            -> joinExpr
@@ -324,6 +325,12 @@ func declare[Expr exprNode](e *evalContext, path string, x Expr, base *value) *e
 		}
 		property := &propertyAccess{accessors: accessors}
 		return newExpr(path, &symbolExpr{node: x, property: property}, schema.Always().Schema(), base)
+	case *ast.ConcatExpr:
+		repr := &concatExpr{
+			node:   x,
+			arrays: declare(e, "", x.Arrays, nil),
+		}
+		return newExpr(path, repr, schema.Array().Items(schema.Always()).Schema(), base)
 	case *ast.FromBase64Expr:
 		repr := &fromBase64Expr{node: x, string: declare(e, "", x.String, nil)}
 		return newExpr(path, repr, schema.String().Schema(), base)
@@ -584,6 +591,8 @@ func (e *evalContext) evaluateExpr(x *expr, accept *schema.Schema) *value {
 		val = e.evaluateInterpolate(x, repr)
 	case *symbolExpr:
 		val = e.evaluatePropertyAccess(x, repr.property.accessors, accept)
+	case *concatExpr:
+		val = e.evaluateBuiltinConcat(x, repr)
 	case *fromBase64Expr:
 		val = e.evaluateBuiltinFromBase64(x, repr)
 	case *fromJSONExpr:
@@ -1216,6 +1225,31 @@ func (e *evalContext) shouldRotate(docPath string) bool {
 func asObjectOrNil(v any) map[string]esc.Value {
 	cast, _ := v.(map[string]esc.Value)
 	return cast
+}
+
+// evaluateBuiltinConcat evaluates a call to the fn::concat builtin.
+func (e *evalContext) evaluateBuiltinConcat(x *expr, repr *concatExpr) *value {
+	v := &value{def: x, schema: x.schema}
+
+	arrays, ok := e.evaluateTypedExpr(repr.arrays, schema.Array().Items(schema.Array().Items(schema.Always())).Schema())
+	if !ok {
+		v.unknown = true
+		return v
+	}
+
+	v.combine(arrays)
+	if !v.unknown {
+		var result []*value
+		for _, arrayVal := range arrays.repr.([]*value) {
+			if arrayVal.repr != nil {
+				if arr, isArray := arrayVal.repr.([]*value); isArray {
+					result = append(result, arr...)
+				}
+			}
+		}
+		v.repr = result
+	}
+	return v
 }
 
 // evaluateBuiltinJoin evaluates a call to the fn::join builtin.

--- a/eval/expr.go
+++ b/eval/expr.go
@@ -175,6 +175,13 @@ func (x *expr) export(environment string) esc.Expr {
 			ArgSchema: schema.Always().Schema(),
 			Arg:       repr.string.export(environment),
 		}
+	case *concatExpr:
+		ex.Builtin = &esc.BuiltinExpr{
+			Name:      repr.node.Name().Value,
+			NameRange: convertRange(repr.node.Name().Syntax().Syntax().Range(), environment),
+			ArgSchema: schema.Array().Items(schema.Array().Items(schema.Always())).Schema(),
+			Arg:       repr.arrays.export(environment),
+		}
 	case *joinExpr:
 		argRange := convertRange(repr.node.Args().Syntax().Syntax().Range(), environment)
 		ex.Builtin = &esc.BuiltinExpr{
@@ -471,6 +478,17 @@ type joinExpr struct {
 }
 
 func (x *joinExpr) syntax() ast.Expr {
+	return x.node
+}
+
+// concatExpr represents a call to the fn::concat builtin.
+type concatExpr struct {
+	node *ast.ConcatExpr
+
+	arrays *expr
+}
+
+func (x *concatExpr) syntax() ast.Expr {
 	return x.node
 }
 

--- a/eval/testdata/eval/builtin-concat-errors/env.yaml
+++ b/eval/testdata/eval/builtin-concat-errors/env.yaml
@@ -1,0 +1,7 @@
+values:
+  invalidInput:
+    fn::concat: "not an array"
+  invalidNested:
+    fn::concat: [1, 2, 3]
+  mixedInvalid:
+    fn::concat: [[1, 2], "invalid", [3, 4]]

--- a/eval/testdata/eval/builtin-concat-errors/expected.json
+++ b/eval/testdata/eval/builtin-concat-errors/expected.json
@@ -1,0 +1,27 @@
+{
+    "loadDiags": [
+        {
+            "Severity": 1,
+            "Summary": "the argument to fn::concat must be an array of arrays",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-concat-errors",
+                "Start": {
+                    "Line": 4,
+                    "Column": 17,
+                    "Byte": 83
+                },
+                "End": {
+                    "Line": 4,
+                    "Column": 29,
+                    "Byte": 95
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.invalidInput[\"fn::concat\"]"
+        }
+    ]
+}

--- a/eval/testdata/eval/builtin-concat/env.yaml
+++ b/eval/testdata/eval/builtin-concat/env.yaml
@@ -1,0 +1,32 @@
+values:
+  # Basic concat test - concatenate two arrays
+  basic:
+    fn::concat: [[1, 2], [3, 4]]
+  
+  # Concat with strings  
+  strings:
+    fn::concat: [["hello", "world"], ["foo", "bar"]]
+  
+  # Empty arrays
+  empty:
+    fn::concat: [[], [1, 2], []]
+  
+  # Single array
+  single:
+    fn::concat: [[1, 2, 3]]
+  
+  # Multiple arrays
+  multiple:
+    fn::concat: [[1], [2], [3], [4, 5]]
+  
+  # Mixed types
+  mixed:
+    fn::concat: [["string", 42], [true, null], [{"key": "value"}]]
+  
+  # Nested arrays (arrays of arrays)
+  nested:
+    fn::concat: [[[1, 2]], [[3, 4]]]
+  
+  # Empty input
+  emptyInput:
+    fn::concat: []

--- a/eval/testdata/eval/builtin-concat/expected.json
+++ b/eval/testdata/eval/builtin-concat/expected.json
@@ -1,0 +1,5810 @@
+{
+    "check": {
+        "exprs": {
+            "basic": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 4,
+                        "column": 5,
+                        "byte": 68
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 31,
+                        "byte": 94
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 4,
+                            "column": 5,
+                            "byte": 68
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 15,
+                            "byte": 78
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 4,
+                                "column": 17,
+                                "byte": 80
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 31,
+                                "byte": 94
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 4
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 18,
+                                        "byte": 81
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 23,
+                                        "byte": 86
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 4,
+                                                "column": 19,
+                                                "byte": 82
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 20,
+                                                "byte": 83
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        "literal": 1
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 4,
+                                                "column": 22,
+                                                "byte": 85
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 23,
+                                                "byte": 86
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        "literal": 2
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 26,
+                                        "byte": 89
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 31,
+                                        "byte": 94
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 4
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 4,
+                                                "column": 27,
+                                                "byte": 90
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 28,
+                                                "byte": 91
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        "literal": 3
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 4,
+                                                "column": 30,
+                                                "byte": 93
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 31,
+                                                "byte": 94
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 4
+                                        },
+                                        "literal": 4
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "empty": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 12,
+                        "column": 5,
+                        "byte": 223
+                    },
+                    "end": {
+                        "line": 12,
+                        "column": 30,
+                        "byte": 248
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 12,
+                            "column": 5,
+                            "byte": 223
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 15,
+                            "byte": 233
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 12,
+                                "column": 17,
+                                "byte": 235
+                            },
+                            "end": {
+                                "line": 12,
+                                "column": 30,
+                                "byte": 248
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 18,
+                                        "byte": 236
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 18,
+                                        "byte": 236
+                                    }
+                                },
+                                "schema": {
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 22,
+                                        "byte": 240
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 27,
+                                        "byte": 245
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 12,
+                                                "column": 23,
+                                                "byte": 241
+                                            },
+                                            "end": {
+                                                "line": 12,
+                                                "column": 24,
+                                                "byte": 242
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        "literal": 1
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 12,
+                                                "column": 26,
+                                                "byte": 244
+                                            },
+                                            "end": {
+                                                "line": 12,
+                                                "column": 27,
+                                                "byte": 245
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        "literal": 2
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 30,
+                                        "byte": 248
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 30,
+                                        "byte": 248
+                                    }
+                                },
+                                "schema": {
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "emptyInput": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 32,
+                        "column": 5,
+                        "byte": 0
+                    },
+                    "end": {
+                        "line": 32,
+                        "column": 17,
+                        "byte": 0
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 32,
+                            "column": 5,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 32,
+                            "column": 15,
+                            "byte": 0
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 32,
+                                "column": 17,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 32,
+                                "column": 17,
+                                "byte": 0
+                            }
+                        },
+                        "schema": {
+                            "items": false,
+                            "type": "array"
+                        }
+                    }
+                }
+            },
+            "mixed": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 24,
+                        "column": 5,
+                        "byte": 417
+                    },
+                    "end": {
+                        "line": 24,
+                        "column": 62,
+                        "byte": 474
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 24,
+                            "column": 5,
+                            "byte": 417
+                        },
+                        "end": {
+                            "line": 24,
+                            "column": 15,
+                            "byte": 427
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 24,
+                                "column": 17,
+                                "byte": 429
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 62,
+                                "byte": 474
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "string"
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 42
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "boolean",
+                                            "const": true
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "properties": {
+                                                "key": {
+                                                    "type": "string",
+                                                    "const": "value"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "key"
+                                            ]
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 18,
+                                        "byte": 430
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 31,
+                                        "byte": 443
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "string"
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 42
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 24,
+                                                "column": 19,
+                                                "byte": 431
+                                            },
+                                            "end": {
+                                                "line": 24,
+                                                "column": 25,
+                                                "byte": 437
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "string"
+                                        },
+                                        "literal": "string"
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 24,
+                                                "column": 29,
+                                                "byte": 441
+                                            },
+                                            "end": {
+                                                "line": 24,
+                                                "column": 31,
+                                                "byte": 443
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 42
+                                        },
+                                        "literal": 42
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 34,
+                                        "byte": 446
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 45,
+                                        "byte": 457
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "boolean",
+                                            "const": true
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 24,
+                                                "column": 35,
+                                                "byte": 447
+                                            },
+                                            "end": {
+                                                "line": 24,
+                                                "column": 39,
+                                                "byte": 451
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "boolean",
+                                            "const": true
+                                        },
+                                        "literal": true
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 24,
+                                                "column": 41,
+                                                "byte": 453
+                                            },
+                                            "end": {
+                                                "line": 24,
+                                                "column": 45,
+                                                "byte": 457
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "null"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 48,
+                                        "byte": 460
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 62,
+                                        "byte": 474
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "properties": {
+                                                "key": {
+                                                    "type": "string",
+                                                    "const": "value"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "key"
+                                            ]
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 24,
+                                                "column": 49,
+                                                "byte": 461
+                                            },
+                                            "end": {
+                                                "line": 24,
+                                                "column": 62,
+                                                "byte": 474
+                                            }
+                                        },
+                                        "schema": {
+                                            "properties": {
+                                                "key": {
+                                                    "type": "string",
+                                                    "const": "value"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "key"
+                                            ]
+                                        },
+                                        "keyRanges": {
+                                            "key": {
+                                                "environment": "builtin-concat",
+                                                "begin": {
+                                                    "line": 24,
+                                                    "column": 50,
+                                                    "byte": 462
+                                                },
+                                                "end": {
+                                                    "line": 24,
+                                                    "column": 53,
+                                                    "byte": 465
+                                                }
+                                            }
+                                        },
+                                        "object": {
+                                            "key": {
+                                                "range": {
+                                                    "environment": "builtin-concat",
+                                                    "begin": {
+                                                        "line": 24,
+                                                        "column": 57,
+                                                        "byte": 469
+                                                    },
+                                                    "end": {
+                                                        "line": 24,
+                                                        "column": 62,
+                                                        "byte": 474
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "value"
+                                                },
+                                                "literal": "value"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "multiple": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 20,
+                        "column": 5,
+                        "byte": 349
+                    },
+                    "end": {
+                        "line": 20,
+                        "column": 38,
+                        "byte": 382
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 20,
+                            "column": 5,
+                            "byte": 349
+                        },
+                        "end": {
+                            "line": 20,
+                            "column": 15,
+                            "byte": 359
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 20,
+                                "column": 17,
+                                "byte": 361
+                            },
+                            "end": {
+                                "line": 20,
+                                "column": 38,
+                                "byte": 382
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 4
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 5
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 18,
+                                        "byte": 362
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 20,
+                                        "byte": 364
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 20,
+                                                "column": 19,
+                                                "byte": 363
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 20,
+                                                "byte": 364
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        "literal": 1
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 23,
+                                        "byte": 367
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 25,
+                                        "byte": 369
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 20,
+                                                "column": 24,
+                                                "byte": 368
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 25,
+                                                "byte": 369
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        "literal": 2
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 28,
+                                        "byte": 372
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 30,
+                                        "byte": 374
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 20,
+                                                "column": 29,
+                                                "byte": 373
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 30,
+                                                "byte": 374
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        "literal": 3
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 33,
+                                        "byte": 377
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 38,
+                                        "byte": 382
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 4
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 5
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 20,
+                                                "column": 34,
+                                                "byte": 378
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 35,
+                                                "byte": 379
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 4
+                                        },
+                                        "literal": 4
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 20,
+                                                "column": 37,
+                                                "byte": 381
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 38,
+                                                "byte": 382
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 5
+                                        },
+                                        "literal": 5
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "nested": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 28,
+                        "column": 5,
+                        "byte": 534
+                    },
+                    "end": {
+                        "line": 28,
+                        "column": 34,
+                        "byte": 563
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 28,
+                            "column": 5,
+                            "byte": 534
+                        },
+                        "end": {
+                            "line": 28,
+                            "column": 15,
+                            "byte": 544
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 28,
+                                "column": 17,
+                                "byte": 546
+                            },
+                            "end": {
+                                "line": 28,
+                                "column": 34,
+                                "byte": 563
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 1
+                                                },
+                                                {
+                                                    "type": "number",
+                                                    "const": 2
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 3
+                                                },
+                                                {
+                                                    "type": "number",
+                                                    "const": 4
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 28,
+                                        "column": 18,
+                                        "byte": 547
+                                    },
+                                    "end": {
+                                        "line": 28,
+                                        "column": 24,
+                                        "byte": 553
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 1
+                                                },
+                                                {
+                                                    "type": "number",
+                                                    "const": 2
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 28,
+                                                "column": 19,
+                                                "byte": 548
+                                            },
+                                            "end": {
+                                                "line": 28,
+                                                "column": 24,
+                                                "byte": 553
+                                            }
+                                        },
+                                        "schema": {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 1
+                                                },
+                                                {
+                                                    "type": "number",
+                                                    "const": 2
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        },
+                                        "list": [
+                                            {
+                                                "range": {
+                                                    "environment": "builtin-concat",
+                                                    "begin": {
+                                                        "line": 28,
+                                                        "column": 20,
+                                                        "byte": 549
+                                                    },
+                                                    "end": {
+                                                        "line": 28,
+                                                        "column": 21,
+                                                        "byte": 550
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "number",
+                                                    "const": 1
+                                                },
+                                                "literal": 1
+                                            },
+                                            {
+                                                "range": {
+                                                    "environment": "builtin-concat",
+                                                    "begin": {
+                                                        "line": 28,
+                                                        "column": 23,
+                                                        "byte": 552
+                                                    },
+                                                    "end": {
+                                                        "line": 28,
+                                                        "column": 24,
+                                                        "byte": 553
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "number",
+                                                    "const": 2
+                                                },
+                                                "literal": 2
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 28,
+                                        "column": 28,
+                                        "byte": 557
+                                    },
+                                    "end": {
+                                        "line": 28,
+                                        "column": 34,
+                                        "byte": 563
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 3
+                                                },
+                                                {
+                                                    "type": "number",
+                                                    "const": 4
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 28,
+                                                "column": 29,
+                                                "byte": 558
+                                            },
+                                            "end": {
+                                                "line": 28,
+                                                "column": 34,
+                                                "byte": 563
+                                            }
+                                        },
+                                        "schema": {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 3
+                                                },
+                                                {
+                                                    "type": "number",
+                                                    "const": 4
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        },
+                                        "list": [
+                                            {
+                                                "range": {
+                                                    "environment": "builtin-concat",
+                                                    "begin": {
+                                                        "line": 28,
+                                                        "column": 30,
+                                                        "byte": 559
+                                                    },
+                                                    "end": {
+                                                        "line": 28,
+                                                        "column": 31,
+                                                        "byte": 560
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "number",
+                                                    "const": 3
+                                                },
+                                                "literal": 3
+                                            },
+                                            {
+                                                "range": {
+                                                    "environment": "builtin-concat",
+                                                    "begin": {
+                                                        "line": 28,
+                                                        "column": 33,
+                                                        "byte": 562
+                                                    },
+                                                    "end": {
+                                                        "line": 28,
+                                                        "column": 34,
+                                                        "byte": 563
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "number",
+                                                    "const": 4
+                                                },
+                                                "literal": 4
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "single": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 16,
+                        "column": 5,
+                        "byte": 286
+                    },
+                    "end": {
+                        "line": 16,
+                        "column": 26,
+                        "byte": 307
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 16,
+                            "column": 5,
+                            "byte": 286
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 15,
+                            "byte": 296
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 16,
+                                "column": 17,
+                                "byte": 298
+                            },
+                            "end": {
+                                "line": 16,
+                                "column": 26,
+                                "byte": 307
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 16,
+                                        "column": 18,
+                                        "byte": 299
+                                    },
+                                    "end": {
+                                        "line": 16,
+                                        "column": 26,
+                                        "byte": 307
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 16,
+                                                "column": 19,
+                                                "byte": 300
+                                            },
+                                            "end": {
+                                                "line": 16,
+                                                "column": 20,
+                                                "byte": 301
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        "literal": 1
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 16,
+                                                "column": 22,
+                                                "byte": 303
+                                            },
+                                            "end": {
+                                                "line": 16,
+                                                "column": 23,
+                                                "byte": 304
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        "literal": 2
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 16,
+                                                "column": 25,
+                                                "byte": 306
+                                            },
+                                            "end": {
+                                                "line": 16,
+                                                "column": 26,
+                                                "byte": 307
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        "literal": 3
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "strings": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 8,
+                        "column": 5,
+                        "byte": 141
+                    },
+                    "end": {
+                        "line": 8,
+                        "column": 49,
+                        "byte": 185
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 8,
+                            "column": 5,
+                            "byte": 141
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 15,
+                            "byte": 151
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 8,
+                                "column": 17,
+                                "byte": 153
+                            },
+                            "end": {
+                                "line": 8,
+                                "column": 49,
+                                "byte": 185
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "const": "world"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "foo"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "const": "bar"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 18,
+                                        "byte": 154
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 33,
+                                        "byte": 169
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "const": "world"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 8,
+                                                "column": 19,
+                                                "byte": 155
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 24,
+                                                "byte": 160
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        "literal": "hello"
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 8,
+                                                "column": 28,
+                                                "byte": 164
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 33,
+                                                "byte": 169
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "world"
+                                        },
+                                        "literal": "world"
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 38,
+                                        "byte": 174
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 49,
+                                        "byte": 185
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "foo"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "const": "bar"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 8,
+                                                "column": 39,
+                                                "byte": 175
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 42,
+                                                "byte": 178
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "foo"
+                                        },
+                                        "literal": "foo"
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 8,
+                                                "column": 46,
+                                                "byte": 182
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 49,
+                                                "byte": 185
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "bar"
+                                        },
+                                        "literal": "bar"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "properties": {
+            "basic": {
+                "value": [
+                    {
+                        "value": 1,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 19,
+                                    "byte": 82
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 20,
+                                    "byte": 83
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 2,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 22,
+                                    "byte": 85
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 23,
+                                    "byte": 86
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 3,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 27,
+                                    "byte": 90
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 28,
+                                    "byte": 91
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 4,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 30,
+                                    "byte": 93
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 31,
+                                    "byte": 94
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 4,
+                            "column": 5,
+                            "byte": 68
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 31,
+                            "byte": 94
+                        }
+                    }
+                }
+            },
+            "empty": {
+                "value": [
+                    {
+                        "value": 1,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 12,
+                                    "column": 23,
+                                    "byte": 241
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 24,
+                                    "byte": 242
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 2,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 12,
+                                    "column": 26,
+                                    "byte": 244
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 27,
+                                    "byte": 245
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 12,
+                            "column": 5,
+                            "byte": 223
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 30,
+                            "byte": 248
+                        }
+                    }
+                }
+            },
+            "emptyInput": {
+                "value": [],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 32,
+                            "column": 5,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 32,
+                            "column": 17,
+                            "byte": 0
+                        }
+                    }
+                }
+            },
+            "mixed": {
+                "value": [
+                    {
+                        "value": "string",
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 24,
+                                    "column": 19,
+                                    "byte": 431
+                                },
+                                "end": {
+                                    "line": 24,
+                                    "column": 25,
+                                    "byte": 437
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 42,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 24,
+                                    "column": 29,
+                                    "byte": 441
+                                },
+                                "end": {
+                                    "line": 24,
+                                    "column": 31,
+                                    "byte": 443
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": true,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 24,
+                                    "column": 35,
+                                    "byte": 447
+                                },
+                                "end": {
+                                    "line": 24,
+                                    "column": 39,
+                                    "byte": 451
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 24,
+                                    "column": 41,
+                                    "byte": 453
+                                },
+                                "end": {
+                                    "line": 24,
+                                    "column": 45,
+                                    "byte": 457
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": {
+                            "key": {
+                                "value": "value",
+                                "trace": {
+                                    "def": {
+                                        "environment": "builtin-concat",
+                                        "begin": {
+                                            "line": 24,
+                                            "column": 57,
+                                            "byte": 469
+                                        },
+                                        "end": {
+                                            "line": 24,
+                                            "column": 62,
+                                            "byte": 474
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 24,
+                                    "column": 49,
+                                    "byte": 461
+                                },
+                                "end": {
+                                    "line": 24,
+                                    "column": 62,
+                                    "byte": 474
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 24,
+                            "column": 5,
+                            "byte": 417
+                        },
+                        "end": {
+                            "line": 24,
+                            "column": 62,
+                            "byte": 474
+                        }
+                    }
+                }
+            },
+            "multiple": {
+                "value": [
+                    {
+                        "value": 1,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 19,
+                                    "byte": 363
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 20,
+                                    "byte": 364
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 2,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 24,
+                                    "byte": 368
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 25,
+                                    "byte": 369
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 3,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 29,
+                                    "byte": 373
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 30,
+                                    "byte": 374
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 4,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 34,
+                                    "byte": 378
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 35,
+                                    "byte": 379
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 5,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 37,
+                                    "byte": 381
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 38,
+                                    "byte": 382
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 20,
+                            "column": 5,
+                            "byte": 349
+                        },
+                        "end": {
+                            "line": 20,
+                            "column": 38,
+                            "byte": 382
+                        }
+                    }
+                }
+            },
+            "nested": {
+                "value": [
+                    {
+                        "value": [
+                            {
+                                "value": 1,
+                                "trace": {
+                                    "def": {
+                                        "environment": "builtin-concat",
+                                        "begin": {
+                                            "line": 28,
+                                            "column": 20,
+                                            "byte": 549
+                                        },
+                                        "end": {
+                                            "line": 28,
+                                            "column": 21,
+                                            "byte": 550
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "value": 2,
+                                "trace": {
+                                    "def": {
+                                        "environment": "builtin-concat",
+                                        "begin": {
+                                            "line": 28,
+                                            "column": 23,
+                                            "byte": 552
+                                        },
+                                        "end": {
+                                            "line": 28,
+                                            "column": 24,
+                                            "byte": 553
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 28,
+                                    "column": 19,
+                                    "byte": 548
+                                },
+                                "end": {
+                                    "line": 28,
+                                    "column": 24,
+                                    "byte": 553
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": [
+                            {
+                                "value": 3,
+                                "trace": {
+                                    "def": {
+                                        "environment": "builtin-concat",
+                                        "begin": {
+                                            "line": 28,
+                                            "column": 30,
+                                            "byte": 559
+                                        },
+                                        "end": {
+                                            "line": 28,
+                                            "column": 31,
+                                            "byte": 560
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "value": 4,
+                                "trace": {
+                                    "def": {
+                                        "environment": "builtin-concat",
+                                        "begin": {
+                                            "line": 28,
+                                            "column": 33,
+                                            "byte": 562
+                                        },
+                                        "end": {
+                                            "line": 28,
+                                            "column": 34,
+                                            "byte": 563
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 28,
+                                    "column": 29,
+                                    "byte": 558
+                                },
+                                "end": {
+                                    "line": 28,
+                                    "column": 34,
+                                    "byte": 563
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 28,
+                            "column": 5,
+                            "byte": 534
+                        },
+                        "end": {
+                            "line": 28,
+                            "column": 34,
+                            "byte": 563
+                        }
+                    }
+                }
+            },
+            "single": {
+                "value": [
+                    {
+                        "value": 1,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 16,
+                                    "column": 19,
+                                    "byte": 300
+                                },
+                                "end": {
+                                    "line": 16,
+                                    "column": 20,
+                                    "byte": 301
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 2,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 16,
+                                    "column": 22,
+                                    "byte": 303
+                                },
+                                "end": {
+                                    "line": 16,
+                                    "column": 23,
+                                    "byte": 304
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 3,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 16,
+                                    "column": 25,
+                                    "byte": 306
+                                },
+                                "end": {
+                                    "line": 16,
+                                    "column": 26,
+                                    "byte": 307
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 16,
+                            "column": 5,
+                            "byte": 286
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 26,
+                            "byte": 307
+                        }
+                    }
+                }
+            },
+            "strings": {
+                "value": [
+                    {
+                        "value": "hello",
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 19,
+                                    "byte": 155
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 24,
+                                    "byte": 160
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "world",
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 28,
+                                    "byte": 164
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 33,
+                                    "byte": 169
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "foo",
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 39,
+                                    "byte": 175
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 42,
+                                    "byte": 178
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "bar",
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 46,
+                                    "byte": 182
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 49,
+                                    "byte": 185
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 8,
+                            "column": 5,
+                            "byte": 141
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 49,
+                            "byte": 185
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "basic": {
+                    "items": true,
+                    "type": "array"
+                },
+                "empty": {
+                    "items": true,
+                    "type": "array"
+                },
+                "emptyInput": {
+                    "items": true,
+                    "type": "array"
+                },
+                "mixed": {
+                    "items": true,
+                    "type": "array"
+                },
+                "multiple": {
+                    "items": true,
+                    "type": "array"
+                },
+                "nested": {
+                    "items": true,
+                    "type": "array"
+                },
+                "single": {
+                    "items": true,
+                    "type": "array"
+                },
+                "strings": {
+                    "items": true,
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "required": [
+                "basic",
+                "empty",
+                "emptyInput",
+                "mixed",
+                "multiple",
+                "nested",
+                "single",
+                "strings"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "builtin-concat",
+                            "trace": {
+                                "def": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "builtin-concat",
+                            "trace": {
+                                "def": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "builtin-concat"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "builtin-concat"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "checkJson": {
+        "basic": [
+            1,
+            2,
+            3,
+            4
+        ],
+        "empty": [
+            1,
+            2
+        ],
+        "emptyInput": [],
+        "mixed": [
+            "string",
+            42,
+            true,
+            null,
+            {
+                "key": "value"
+            }
+        ],
+        "multiple": [
+            1,
+            2,
+            3,
+            4,
+            5
+        ],
+        "nested": [
+            [
+                1,
+                2
+            ],
+            [
+                3,
+                4
+            ]
+        ],
+        "single": [
+            1,
+            2,
+            3
+        ],
+        "strings": [
+            "hello",
+            "world",
+            "foo",
+            "bar"
+        ]
+    },
+    "eval": {
+        "exprs": {
+            "basic": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 4,
+                        "column": 5,
+                        "byte": 68
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 31,
+                        "byte": 94
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 4,
+                            "column": 5,
+                            "byte": 68
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 15,
+                            "byte": 78
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 4,
+                                "column": 17,
+                                "byte": 80
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 31,
+                                "byte": 94
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 4
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 18,
+                                        "byte": 81
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 23,
+                                        "byte": 86
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 4,
+                                                "column": 19,
+                                                "byte": 82
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 20,
+                                                "byte": 83
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        "literal": 1
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 4,
+                                                "column": 22,
+                                                "byte": 85
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 23,
+                                                "byte": 86
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        "literal": 2
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 26,
+                                        "byte": 89
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 31,
+                                        "byte": 94
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 4
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 4,
+                                                "column": 27,
+                                                "byte": 90
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 28,
+                                                "byte": 91
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        "literal": 3
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 4,
+                                                "column": 30,
+                                                "byte": 93
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 31,
+                                                "byte": 94
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 4
+                                        },
+                                        "literal": 4
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "empty": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 12,
+                        "column": 5,
+                        "byte": 223
+                    },
+                    "end": {
+                        "line": 12,
+                        "column": 30,
+                        "byte": 248
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 12,
+                            "column": 5,
+                            "byte": 223
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 15,
+                            "byte": 233
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 12,
+                                "column": 17,
+                                "byte": 235
+                            },
+                            "end": {
+                                "line": 12,
+                                "column": 30,
+                                "byte": 248
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 18,
+                                        "byte": 236
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 18,
+                                        "byte": 236
+                                    }
+                                },
+                                "schema": {
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 22,
+                                        "byte": 240
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 27,
+                                        "byte": 245
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 12,
+                                                "column": 23,
+                                                "byte": 241
+                                            },
+                                            "end": {
+                                                "line": 12,
+                                                "column": 24,
+                                                "byte": 242
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        "literal": 1
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 12,
+                                                "column": 26,
+                                                "byte": 244
+                                            },
+                                            "end": {
+                                                "line": 12,
+                                                "column": 27,
+                                                "byte": 245
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        "literal": 2
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 30,
+                                        "byte": 248
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 30,
+                                        "byte": 248
+                                    }
+                                },
+                                "schema": {
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "emptyInput": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 32,
+                        "column": 5,
+                        "byte": 0
+                    },
+                    "end": {
+                        "line": 32,
+                        "column": 17,
+                        "byte": 0
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 32,
+                            "column": 5,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 32,
+                            "column": 15,
+                            "byte": 0
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 32,
+                                "column": 17,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 32,
+                                "column": 17,
+                                "byte": 0
+                            }
+                        },
+                        "schema": {
+                            "items": false,
+                            "type": "array"
+                        }
+                    }
+                }
+            },
+            "mixed": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 24,
+                        "column": 5,
+                        "byte": 417
+                    },
+                    "end": {
+                        "line": 24,
+                        "column": 62,
+                        "byte": 474
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 24,
+                            "column": 5,
+                            "byte": 417
+                        },
+                        "end": {
+                            "line": 24,
+                            "column": 15,
+                            "byte": 427
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 24,
+                                "column": 17,
+                                "byte": 429
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 62,
+                                "byte": 474
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "string"
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 42
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "boolean",
+                                            "const": true
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "properties": {
+                                                "key": {
+                                                    "type": "string",
+                                                    "const": "value"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "key"
+                                            ]
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 18,
+                                        "byte": 430
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 31,
+                                        "byte": 443
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "string"
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 42
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 24,
+                                                "column": 19,
+                                                "byte": 431
+                                            },
+                                            "end": {
+                                                "line": 24,
+                                                "column": 25,
+                                                "byte": 437
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "string"
+                                        },
+                                        "literal": "string"
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 24,
+                                                "column": 29,
+                                                "byte": 441
+                                            },
+                                            "end": {
+                                                "line": 24,
+                                                "column": 31,
+                                                "byte": 443
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 42
+                                        },
+                                        "literal": 42
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 34,
+                                        "byte": 446
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 45,
+                                        "byte": 457
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "boolean",
+                                            "const": true
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 24,
+                                                "column": 35,
+                                                "byte": 447
+                                            },
+                                            "end": {
+                                                "line": 24,
+                                                "column": 39,
+                                                "byte": 451
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "boolean",
+                                            "const": true
+                                        },
+                                        "literal": true
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 24,
+                                                "column": 41,
+                                                "byte": 453
+                                            },
+                                            "end": {
+                                                "line": 24,
+                                                "column": 45,
+                                                "byte": 457
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "null"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 24,
+                                        "column": 48,
+                                        "byte": 460
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 62,
+                                        "byte": 474
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "properties": {
+                                                "key": {
+                                                    "type": "string",
+                                                    "const": "value"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "key"
+                                            ]
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 24,
+                                                "column": 49,
+                                                "byte": 461
+                                            },
+                                            "end": {
+                                                "line": 24,
+                                                "column": 62,
+                                                "byte": 474
+                                            }
+                                        },
+                                        "schema": {
+                                            "properties": {
+                                                "key": {
+                                                    "type": "string",
+                                                    "const": "value"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "key"
+                                            ]
+                                        },
+                                        "keyRanges": {
+                                            "key": {
+                                                "environment": "builtin-concat",
+                                                "begin": {
+                                                    "line": 24,
+                                                    "column": 50,
+                                                    "byte": 462
+                                                },
+                                                "end": {
+                                                    "line": 24,
+                                                    "column": 53,
+                                                    "byte": 465
+                                                }
+                                            }
+                                        },
+                                        "object": {
+                                            "key": {
+                                                "range": {
+                                                    "environment": "builtin-concat",
+                                                    "begin": {
+                                                        "line": 24,
+                                                        "column": 57,
+                                                        "byte": 469
+                                                    },
+                                                    "end": {
+                                                        "line": 24,
+                                                        "column": 62,
+                                                        "byte": 474
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "value"
+                                                },
+                                                "literal": "value"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "multiple": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 20,
+                        "column": 5,
+                        "byte": 349
+                    },
+                    "end": {
+                        "line": 20,
+                        "column": 38,
+                        "byte": 382
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 20,
+                            "column": 5,
+                            "byte": 349
+                        },
+                        "end": {
+                            "line": 20,
+                            "column": 15,
+                            "byte": 359
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 20,
+                                "column": 17,
+                                "byte": 361
+                            },
+                            "end": {
+                                "line": 20,
+                                "column": 38,
+                                "byte": 382
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 4
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 5
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 18,
+                                        "byte": 362
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 20,
+                                        "byte": 364
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 20,
+                                                "column": 19,
+                                                "byte": 363
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 20,
+                                                "byte": 364
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        "literal": 1
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 23,
+                                        "byte": 367
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 25,
+                                        "byte": 369
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 20,
+                                                "column": 24,
+                                                "byte": 368
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 25,
+                                                "byte": 369
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        "literal": 2
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 28,
+                                        "byte": 372
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 30,
+                                        "byte": 374
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 20,
+                                                "column": 29,
+                                                "byte": 373
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 30,
+                                                "byte": 374
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        "literal": 3
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 20,
+                                        "column": 33,
+                                        "byte": 377
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 38,
+                                        "byte": 382
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 4
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 5
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 20,
+                                                "column": 34,
+                                                "byte": 378
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 35,
+                                                "byte": 379
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 4
+                                        },
+                                        "literal": 4
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 20,
+                                                "column": 37,
+                                                "byte": 381
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 38,
+                                                "byte": 382
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 5
+                                        },
+                                        "literal": 5
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "nested": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 28,
+                        "column": 5,
+                        "byte": 534
+                    },
+                    "end": {
+                        "line": 28,
+                        "column": 34,
+                        "byte": 563
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 28,
+                            "column": 5,
+                            "byte": 534
+                        },
+                        "end": {
+                            "line": 28,
+                            "column": 15,
+                            "byte": 544
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 28,
+                                "column": 17,
+                                "byte": 546
+                            },
+                            "end": {
+                                "line": 28,
+                                "column": 34,
+                                "byte": 563
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 1
+                                                },
+                                                {
+                                                    "type": "number",
+                                                    "const": 2
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 3
+                                                },
+                                                {
+                                                    "type": "number",
+                                                    "const": 4
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 28,
+                                        "column": 18,
+                                        "byte": 547
+                                    },
+                                    "end": {
+                                        "line": 28,
+                                        "column": 24,
+                                        "byte": 553
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 1
+                                                },
+                                                {
+                                                    "type": "number",
+                                                    "const": 2
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 28,
+                                                "column": 19,
+                                                "byte": 548
+                                            },
+                                            "end": {
+                                                "line": 28,
+                                                "column": 24,
+                                                "byte": 553
+                                            }
+                                        },
+                                        "schema": {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 1
+                                                },
+                                                {
+                                                    "type": "number",
+                                                    "const": 2
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        },
+                                        "list": [
+                                            {
+                                                "range": {
+                                                    "environment": "builtin-concat",
+                                                    "begin": {
+                                                        "line": 28,
+                                                        "column": 20,
+                                                        "byte": 549
+                                                    },
+                                                    "end": {
+                                                        "line": 28,
+                                                        "column": 21,
+                                                        "byte": 550
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "number",
+                                                    "const": 1
+                                                },
+                                                "literal": 1
+                                            },
+                                            {
+                                                "range": {
+                                                    "environment": "builtin-concat",
+                                                    "begin": {
+                                                        "line": 28,
+                                                        "column": 23,
+                                                        "byte": 552
+                                                    },
+                                                    "end": {
+                                                        "line": 28,
+                                                        "column": 24,
+                                                        "byte": 553
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "number",
+                                                    "const": 2
+                                                },
+                                                "literal": 2
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 28,
+                                        "column": 28,
+                                        "byte": 557
+                                    },
+                                    "end": {
+                                        "line": 28,
+                                        "column": 34,
+                                        "byte": 563
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 3
+                                                },
+                                                {
+                                                    "type": "number",
+                                                    "const": 4
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 28,
+                                                "column": 29,
+                                                "byte": 558
+                                            },
+                                            "end": {
+                                                "line": 28,
+                                                "column": 34,
+                                                "byte": 563
+                                            }
+                                        },
+                                        "schema": {
+                                            "prefixItems": [
+                                                {
+                                                    "type": "number",
+                                                    "const": 3
+                                                },
+                                                {
+                                                    "type": "number",
+                                                    "const": 4
+                                                }
+                                            ],
+                                            "items": false,
+                                            "type": "array"
+                                        },
+                                        "list": [
+                                            {
+                                                "range": {
+                                                    "environment": "builtin-concat",
+                                                    "begin": {
+                                                        "line": 28,
+                                                        "column": 30,
+                                                        "byte": 559
+                                                    },
+                                                    "end": {
+                                                        "line": 28,
+                                                        "column": 31,
+                                                        "byte": 560
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "number",
+                                                    "const": 3
+                                                },
+                                                "literal": 3
+                                            },
+                                            {
+                                                "range": {
+                                                    "environment": "builtin-concat",
+                                                    "begin": {
+                                                        "line": 28,
+                                                        "column": 33,
+                                                        "byte": 562
+                                                    },
+                                                    "end": {
+                                                        "line": 28,
+                                                        "column": 34,
+                                                        "byte": 563
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "number",
+                                                    "const": 4
+                                                },
+                                                "literal": 4
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "single": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 16,
+                        "column": 5,
+                        "byte": 286
+                    },
+                    "end": {
+                        "line": 16,
+                        "column": 26,
+                        "byte": 307
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 16,
+                            "column": 5,
+                            "byte": 286
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 15,
+                            "byte": 296
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 16,
+                                "column": 17,
+                                "byte": 298
+                            },
+                            "end": {
+                                "line": 16,
+                                "column": 26,
+                                "byte": 307
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 16,
+                                        "column": 18,
+                                        "byte": 299
+                                    },
+                                    "end": {
+                                        "line": 16,
+                                        "column": 26,
+                                        "byte": 307
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 16,
+                                                "column": 19,
+                                                "byte": 300
+                                            },
+                                            "end": {
+                                                "line": 16,
+                                                "column": 20,
+                                                "byte": 301
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        "literal": 1
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 16,
+                                                "column": 22,
+                                                "byte": 303
+                                            },
+                                            "end": {
+                                                "line": 16,
+                                                "column": 23,
+                                                "byte": 304
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        "literal": 2
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 16,
+                                                "column": 25,
+                                                "byte": 306
+                                            },
+                                            "end": {
+                                                "line": 16,
+                                                "column": 26,
+                                                "byte": 307
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        "literal": 3
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "strings": {
+                "range": {
+                    "environment": "builtin-concat",
+                    "begin": {
+                        "line": 8,
+                        "column": 5,
+                        "byte": 141
+                    },
+                    "end": {
+                        "line": 8,
+                        "column": 49,
+                        "byte": 185
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 8,
+                            "column": 5,
+                            "byte": 141
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 15,
+                            "byte": 151
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 8,
+                                "column": 17,
+                                "byte": 153
+                            },
+                            "end": {
+                                "line": 8,
+                                "column": 49,
+                                "byte": 185
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "const": "world"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "foo"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "const": "bar"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 18,
+                                        "byte": 154
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 33,
+                                        "byte": 169
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "const": "world"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 8,
+                                                "column": 19,
+                                                "byte": 155
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 24,
+                                                "byte": 160
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "hello"
+                                        },
+                                        "literal": "hello"
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 8,
+                                                "column": 28,
+                                                "byte": 164
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 33,
+                                                "byte": 169
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "world"
+                                        },
+                                        "literal": "world"
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 38,
+                                        "byte": 174
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 49,
+                                        "byte": 185
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "string",
+                                            "const": "foo"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "const": "bar"
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 8,
+                                                "column": 39,
+                                                "byte": 175
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 42,
+                                                "byte": 178
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "foo"
+                                        },
+                                        "literal": "foo"
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 8,
+                                                "column": 46,
+                                                "byte": 182
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 49,
+                                                "byte": 185
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "bar"
+                                        },
+                                        "literal": "bar"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "properties": {
+            "basic": {
+                "value": [
+                    {
+                        "value": 1,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 19,
+                                    "byte": 82
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 20,
+                                    "byte": 83
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 2,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 22,
+                                    "byte": 85
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 23,
+                                    "byte": 86
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 3,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 27,
+                                    "byte": 90
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 28,
+                                    "byte": 91
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 4,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 30,
+                                    "byte": 93
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 31,
+                                    "byte": 94
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 4,
+                            "column": 5,
+                            "byte": 68
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 31,
+                            "byte": 94
+                        }
+                    }
+                }
+            },
+            "empty": {
+                "value": [
+                    {
+                        "value": 1,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 12,
+                                    "column": 23,
+                                    "byte": 241
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 24,
+                                    "byte": 242
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 2,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 12,
+                                    "column": 26,
+                                    "byte": 244
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 27,
+                                    "byte": 245
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 12,
+                            "column": 5,
+                            "byte": 223
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 30,
+                            "byte": 248
+                        }
+                    }
+                }
+            },
+            "emptyInput": {
+                "value": [],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 32,
+                            "column": 5,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 32,
+                            "column": 17,
+                            "byte": 0
+                        }
+                    }
+                }
+            },
+            "mixed": {
+                "value": [
+                    {
+                        "value": "string",
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 24,
+                                    "column": 19,
+                                    "byte": 431
+                                },
+                                "end": {
+                                    "line": 24,
+                                    "column": 25,
+                                    "byte": 437
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 42,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 24,
+                                    "column": 29,
+                                    "byte": 441
+                                },
+                                "end": {
+                                    "line": 24,
+                                    "column": 31,
+                                    "byte": 443
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": true,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 24,
+                                    "column": 35,
+                                    "byte": 447
+                                },
+                                "end": {
+                                    "line": 24,
+                                    "column": 39,
+                                    "byte": 451
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 24,
+                                    "column": 41,
+                                    "byte": 453
+                                },
+                                "end": {
+                                    "line": 24,
+                                    "column": 45,
+                                    "byte": 457
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": {
+                            "key": {
+                                "value": "value",
+                                "trace": {
+                                    "def": {
+                                        "environment": "builtin-concat",
+                                        "begin": {
+                                            "line": 24,
+                                            "column": 57,
+                                            "byte": 469
+                                        },
+                                        "end": {
+                                            "line": 24,
+                                            "column": 62,
+                                            "byte": 474
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 24,
+                                    "column": 49,
+                                    "byte": 461
+                                },
+                                "end": {
+                                    "line": 24,
+                                    "column": 62,
+                                    "byte": 474
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 24,
+                            "column": 5,
+                            "byte": 417
+                        },
+                        "end": {
+                            "line": 24,
+                            "column": 62,
+                            "byte": 474
+                        }
+                    }
+                }
+            },
+            "multiple": {
+                "value": [
+                    {
+                        "value": 1,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 19,
+                                    "byte": 363
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 20,
+                                    "byte": 364
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 2,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 24,
+                                    "byte": 368
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 25,
+                                    "byte": 369
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 3,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 29,
+                                    "byte": 373
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 30,
+                                    "byte": 374
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 4,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 34,
+                                    "byte": 378
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 35,
+                                    "byte": 379
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 5,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 20,
+                                    "column": 37,
+                                    "byte": 381
+                                },
+                                "end": {
+                                    "line": 20,
+                                    "column": 38,
+                                    "byte": 382
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 20,
+                            "column": 5,
+                            "byte": 349
+                        },
+                        "end": {
+                            "line": 20,
+                            "column": 38,
+                            "byte": 382
+                        }
+                    }
+                }
+            },
+            "nested": {
+                "value": [
+                    {
+                        "value": [
+                            {
+                                "value": 1,
+                                "trace": {
+                                    "def": {
+                                        "environment": "builtin-concat",
+                                        "begin": {
+                                            "line": 28,
+                                            "column": 20,
+                                            "byte": 549
+                                        },
+                                        "end": {
+                                            "line": 28,
+                                            "column": 21,
+                                            "byte": 550
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "value": 2,
+                                "trace": {
+                                    "def": {
+                                        "environment": "builtin-concat",
+                                        "begin": {
+                                            "line": 28,
+                                            "column": 23,
+                                            "byte": 552
+                                        },
+                                        "end": {
+                                            "line": 28,
+                                            "column": 24,
+                                            "byte": 553
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 28,
+                                    "column": 19,
+                                    "byte": 548
+                                },
+                                "end": {
+                                    "line": 28,
+                                    "column": 24,
+                                    "byte": 553
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": [
+                            {
+                                "value": 3,
+                                "trace": {
+                                    "def": {
+                                        "environment": "builtin-concat",
+                                        "begin": {
+                                            "line": 28,
+                                            "column": 30,
+                                            "byte": 559
+                                        },
+                                        "end": {
+                                            "line": 28,
+                                            "column": 31,
+                                            "byte": 560
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "value": 4,
+                                "trace": {
+                                    "def": {
+                                        "environment": "builtin-concat",
+                                        "begin": {
+                                            "line": 28,
+                                            "column": 33,
+                                            "byte": 562
+                                        },
+                                        "end": {
+                                            "line": 28,
+                                            "column": 34,
+                                            "byte": 563
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 28,
+                                    "column": 29,
+                                    "byte": 558
+                                },
+                                "end": {
+                                    "line": 28,
+                                    "column": 34,
+                                    "byte": 563
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 28,
+                            "column": 5,
+                            "byte": 534
+                        },
+                        "end": {
+                            "line": 28,
+                            "column": 34,
+                            "byte": 563
+                        }
+                    }
+                }
+            },
+            "single": {
+                "value": [
+                    {
+                        "value": 1,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 16,
+                                    "column": 19,
+                                    "byte": 300
+                                },
+                                "end": {
+                                    "line": 16,
+                                    "column": 20,
+                                    "byte": 301
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 2,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 16,
+                                    "column": 22,
+                                    "byte": 303
+                                },
+                                "end": {
+                                    "line": 16,
+                                    "column": 23,
+                                    "byte": 304
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": 3,
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 16,
+                                    "column": 25,
+                                    "byte": 306
+                                },
+                                "end": {
+                                    "line": 16,
+                                    "column": 26,
+                                    "byte": 307
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 16,
+                            "column": 5,
+                            "byte": 286
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 26,
+                            "byte": 307
+                        }
+                    }
+                }
+            },
+            "strings": {
+                "value": [
+                    {
+                        "value": "hello",
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 19,
+                                    "byte": 155
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 24,
+                                    "byte": 160
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "world",
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 28,
+                                    "byte": 164
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 33,
+                                    "byte": 169
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "foo",
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 39,
+                                    "byte": 175
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 42,
+                                    "byte": 178
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "value": "bar",
+                        "trace": {
+                            "def": {
+                                "environment": "builtin-concat",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 46,
+                                    "byte": 182
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 49,
+                                    "byte": 185
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat",
+                        "begin": {
+                            "line": 8,
+                            "column": 5,
+                            "byte": 141
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 49,
+                            "byte": 185
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "basic": {
+                    "items": true,
+                    "type": "array"
+                },
+                "empty": {
+                    "items": true,
+                    "type": "array"
+                },
+                "emptyInput": {
+                    "items": true,
+                    "type": "array"
+                },
+                "mixed": {
+                    "items": true,
+                    "type": "array"
+                },
+                "multiple": {
+                    "items": true,
+                    "type": "array"
+                },
+                "nested": {
+                    "items": true,
+                    "type": "array"
+                },
+                "single": {
+                    "items": true,
+                    "type": "array"
+                },
+                "strings": {
+                    "items": true,
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "required": [
+                "basic",
+                "empty",
+                "emptyInput",
+                "mixed",
+                "multiple",
+                "nested",
+                "single",
+                "strings"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "builtin-concat",
+                            "trace": {
+                                "def": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "builtin-concat",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "builtin-concat",
+                            "trace": {
+                                "def": {
+                                    "environment": "builtin-concat",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "builtin-concat",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "builtin-concat"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "builtin-concat"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "evalJsonRedacted": {
+        "basic": [
+            1,
+            2,
+            3,
+            4
+        ],
+        "empty": [
+            1,
+            2
+        ],
+        "emptyInput": [],
+        "mixed": [
+            "string",
+            42,
+            true,
+            null,
+            {
+                "key": "value"
+            }
+        ],
+        "multiple": [
+            1,
+            2,
+            3,
+            4,
+            5
+        ],
+        "nested": [
+            [
+                1,
+                2
+            ],
+            [
+                3,
+                4
+            ]
+        ],
+        "single": [
+            1,
+            2,
+            3
+        ],
+        "strings": [
+            "hello",
+            "world",
+            "foo",
+            "bar"
+        ]
+    },
+    "evalJSONRevealed": {
+        "basic": [
+            1,
+            2,
+            3,
+            4
+        ],
+        "empty": [
+            1,
+            2
+        ],
+        "emptyInput": [],
+        "mixed": [
+            "string",
+            42,
+            true,
+            null,
+            {
+                "key": "value"
+            }
+        ],
+        "multiple": [
+            1,
+            2,
+            3,
+            4,
+            5
+        ],
+        "nested": [
+            [
+                1,
+                2
+            ],
+            [
+                3,
+                4
+            ]
+        ],
+        "single": [
+            1,
+            2,
+            3
+        ],
+        "strings": [
+            "hello",
+            "world",
+            "foo",
+            "bar"
+        ]
+    }
+}


### PR DESCRIPTION
This PR adds support for a new built-in function `fn::concat` which can be used to concatenate arrays.

```yaml
values:
  foo:
    - 1
    - 2
  bar:
    - 3
    - 4
  baz:
    fn::concat:
        - ${foo}
        - ${bar}
```

results in:

```json
{
  "bar": [
    3,
    4
  ],
  "baz": [
    1,
    2,
    3,
    4
  ],
  "foo": [
    1,
    2
  ]
}
```
Solves #287 