### PR TITLE
schema: fix rotateonly propagation

### DIFF
--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -177,3 +177,23 @@ func TestCompile(t *testing.T) {
 		})
 	}
 }
+
+func TestRotateOnly(t *testing.T) {
+	root := &Schema{
+		Type: "object",
+		Defs: map[string]*Schema{
+			"foo": String().Schema(),
+		},
+		Properties: map[string]*Schema{
+			"rotateOnly": Array().Items(Ref("#/$defs/foo")).Schema(),
+			"standard":   Ref("#/$defs/foo"),
+		},
+		RotateOnly: []string{"rotateOnly"},
+	}
+	err := root.Compile()
+	require.NoError(t, err)
+
+	assert.True(t, root.Property("rotateOnly").IsRotateOnly())
+	assert.True(t, root.Property("rotateOnly").Item(0).IsRotateOnly())
+	assert.False(t, root.Property("standard").IsRotateOnly())
+}


### PR DESCRIPTION
Propagate rotateonly deeply rather than shallowly. This should improve
the reliability of determining whether or not a particular schema has
rotate only semantics. Without these changes, the rotateonly semantics
of a property's schema would be lost when accessing the property's own
referenced schemas.

These changes also fix potential sharing issues that could occur when
marking property schemas as rotateonly by copying the property schema
instead of mutating it in place.
