### PR TITLE
ast/eval: improve missing field diags

### DIFF
--- a/ast/environment.go
+++ b/ast/environment.go
@@ -240,7 +240,7 @@ func Environment(description *StringExpr, imports ImportListDecl, values Propert
 func ParseEnvironment(source []byte, node syntax.Node) (*EnvironmentDecl, syntax.Diagnostics) {
 	environment := EnvironmentDecl{source: source}
 
-	diags := parseRecord("environment", &environment, node, false)
+	diags := parseRecord("environment", &environment, node, true)
 	return &environment, diags
 }
 

--- a/ast/environment_test.go
+++ b/ast/environment_test.go
@@ -39,7 +39,7 @@ func TestExample(t *testing.T) {
 imports:
   - green-channel
   - us-west-2
-config:
+values:
   aws:
     fn::open:
       provider: aws-oidc
@@ -68,7 +68,7 @@ func TestExample2(t *testing.T) {
 imports:
   - green-channel
   - us-west-2
-config:
+values:
   aws:
     fn::open::aws-oidc:
       sessionName: site-prod-session

--- a/diags/diags.go
+++ b/diags/diags.go
@@ -39,10 +39,11 @@ func (e NonExistentFieldFormatter) messageHeader(fieldLabel string) string {
 }
 
 func (e NonExistentFieldFormatter) messageBody(field string) string {
-	existing := sortByEditDistance(e.Fields, field)
-	if len(existing) == 0 {
+	if len(e.Fields) == 0 {
 		return fmt.Sprintf("%s has no %s", e.ParentLabel, e.fieldsName())
 	}
+
+	existing := sortByEditDistance(field, e.Fields)
 	list := strings.Join(existing, ", ")
 	if len(existing) > e.MaxElements && e.MaxElements != 0 {
 		extraLength := len(existing) - e.MaxElements

--- a/diags/diags_test.go
+++ b/diags/diags_test.go
@@ -57,7 +57,7 @@ func TestNonExistentFieldFormatterMessageBody(t *testing.T) {
 	}{
 		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{}}, "field", "parent has no fields"},
 		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{"a", "b"}}, "field", "Existing fields are: a, b"},
-		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{"field3", "field2", "field1"}}, "field", "Existing fields are: field1, field2, field3"},
+		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{"field3", "field2", "field1"}}, "field", "Existing fields are: field3, field2, field1"},
 		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{"field1", "field2", "field3"}, MaxElements: 4}, "field", "Existing fields are: field1, field2, field3"},
 		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{"field1", "field2", "field3"}, MaxElements: 3}, "field", "Existing fields are: field1, field2, field3"},
 		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{"field1", "field2", "field3"}, MaxElements: 2}, "field", "Existing fields are: field1, field2 and 1 other"},
@@ -78,7 +78,7 @@ func TestNonExistentFieldFormatterMessage(t *testing.T) {
 	}{
 		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{}}, "field", "label", "label does not exist on parent. parent has no fields"},
 		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{"a", "b"}}, "field", "label", "label does not exist on parent. Existing fields are: a, b"},
-		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{"field3", "field2", "field1"}}, "field", "label", "label does not exist on parent. Existing fields are: field1, field2, field3"},
+		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{"field3", "field2", "field1"}}, "field", "label", "label does not exist on parent. Existing fields are: field3, field2, field1"},
 		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{"field1", "field2", "field3"}, MaxElements: 2}, "field", "label", "label does not exist on parent. Existing fields are: field1, field2 and 1 other"},
 	}
 	for _, tt := range tests {
@@ -97,7 +97,7 @@ func TestNonExistentFieldFormatterMessageWithDetail(t *testing.T) {
 	}{
 		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{}}, "field", "label", "label does not exist on parent", "parent has no fields"},
 		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{"a", "b"}}, "field", "label", "label does not exist on parent", "Existing fields are: a, b"},
-		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{"field3", "field2", "field1"}}, "field", "label", "label does not exist on parent", "Existing fields are: field1, field2, field3"},
+		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{"field3", "field2", "field1"}}, "field", "label", "label does not exist on parent", "Existing fields are: field3, field2, field1"},
 		{NonExistentFieldFormatter{ParentLabel: "parent", Fields: []string{"field1", "field2", "field3"}, MaxElements: 2}, "field", "label", "label does not exist on parent", "Existing fields are: field1, field2 and 1 other"},
 	}
 	for _, tt := range tests {

--- a/diags/utils.go
+++ b/diags/utils.go
@@ -16,60 +16,14 @@ package diags
 
 import (
 	"fmt"
-	"sort"
+
+	"github.com/pulumi/esc/internal/spell"
 )
 
-// editDistance calculates the Levenshtein distance between words a and b.
-func editDistance(a, b string) int {
-	// Algorithm taken from https://en.wikipedia.org/wiki/Levenshtein_distance
-	d := make([][]int, len(a)+1)
-	for i := range d {
-		d[i] = make([]int, len(b)+1)
-	}
-	for i := 0; i < len(a)+1; i++ {
-		d[i][0] = i
-	}
-	for j := 0; j < len(b)+1; j++ {
-		d[0][j] = j
-	}
-
-	min := func(i, j int) int {
-		if i < j {
-			return i
-		}
-		return j
-	}
-	for i := 1; i < len(a)+1; i++ {
-		for j := 1; j < len(b)+1; j++ {
-			var subCost int
-			if a[i-1] != b[j-1] {
-				subCost = 1
-			}
-			d[i][j] = min(d[i-1][j]+1, // deletion
-				min(d[i][j-1]+1, // insertion
-					d[i-1][j-1]+subCost), // substitution
-			)
-		}
-	}
-	return d[len(a)][len(b)]
-}
-
-func sortByEditDistance(words []string, comparedTo string) []string {
+func sortByEditDistance(comparedTo string, words []string) []string {
 	w := make([]string, len(words))
 	copy(w, words)
-	m := map[string]int{}
-	v := func(s string) int {
-		d, ok := m[s]
-		if !ok {
-			d = editDistance(s, comparedTo)
-			m[s] = d
-		}
-		return d
-	}
-	sort.Strings(w)
-	sort.SliceStable(w, func(i, j int) bool {
-		return v(w[i]) < v(w[j])
-	})
+	spell.SortByEditDistance(comparedTo, w)
 	return w
 }
 

--- a/diags/utils_test.go
+++ b/diags/utils_test.go
@@ -20,40 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEditDistance(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		a, b     string
-		expected int
-	}{
-		{"vpcId", "cpcId", 1},
-		{"vpcId", "foo", 5},
-	}
-
-	for _, c := range cases {
-		assert.Equal(t, c.expected, editDistance(c.a, c.b))
-	}
-}
-
-func TestSortByEditDistance(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		words      []string
-		comparedTo string
-		expected   []string
-	}{
-		{[]string{}, "test", []string{}},
-		{[]string{"", "", ""}, "test", []string{"", "", ""}},
-		{[]string{"test", "test2"}, "test", []string{"test", "test2"}},
-		{[]string{"test2", "test"}, "test", []string{"test", "test2"}},
-		{[]string{"test2", "test", "test2"}, "test", []string{"test", "test2", "test2"}},
-		{[]string{"c", "b", "a"}, "test", []string{"a", "b", "c"}},
-	}
-	for _, c := range cases {
-		assert.Equalf(t, c.expected, sortByEditDistance(c.words, c.comparedTo), "sortByEditDistance(%v, %v)", c.words, c.comparedTo)
-	}
-}
-
 func TestDisplayList(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -420,7 +420,7 @@ func TestEval(t *testing.T) {
 				var rotated *esc.Environment
 				var patches []*Patch
 				var rotateDiags syntax.Diagnostics
-				var rotationResult *RotationResult
+				var rotationResult RotationResult
 				if doRotate {
 					rotated, rotationResult, rotateDiags = RotateEnvironment(context.Background(), environmentName, env, rot128{}, testProviders{},
 						&testEnvironments{basePath}, execContext, rotatePaths)

--- a/eval/rotation.go
+++ b/eval/rotation.go
@@ -35,9 +35,9 @@ type Rotation struct {
 	Patch  *Patch             // updated rotation state generated during evaluation, to be written back to the environment definition
 }
 
-func (r *RotationResult) Patches() []*Patch {
+func (r RotationResult) Patches() []*Patch {
 	var patches []*Patch
-	for _, rotation := range *r {
+	for _, rotation := range r {
 		if rotation.Patch != nil {
 			patches = append(patches, rotation.Patch)
 		}

--- a/eval/testdata/eval/invalid-access/expected.json
+++ b/eval/testdata/eval/invalid-access/expected.json
@@ -140,7 +140,7 @@
         },
         {
             "Severity": 1,
-            "Summary": "unknown property \"bar\"",
+            "Summary": "unknown property \"bar\"; did you mean \"baz\"?",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-access",
@@ -4630,7 +4630,7 @@
         },
         {
             "Severity": 1,
-            "Summary": "unknown property \"bar\"",
+            "Summary": "unknown property \"bar\"; did you mean \"baz\"?",
             "Detail": "",
             "Subject": {
                 "Filename": "invalid-access",

--- a/internal/spell/spell.go
+++ b/internal/spell/spell.go
@@ -1,0 +1,127 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spell
+
+import (
+	"cmp"
+	"iter"
+	"slices"
+	"strings"
+	"unicode"
+)
+
+// Nearest returns the element of candidates nearest to x using the Levenshtein metric, or "" if none were promising.
+func Nearest[S ~string](x S, candidates iter.Seq[S]) S {
+	// Ignore underscores and case when matching.
+	x = fold(x)
+
+	var best S
+	bestD := (len(x) + 1) / 2 // allow up to 50% typos
+	for c := range candidates {
+		d := levenshtein(x, fold(c), &bestD)
+		if d < bestD {
+			bestD = d
+			best = c
+		}
+	}
+	return best
+}
+
+// SortByEditDistance sorts the list of candidates by edit distance from x.
+func SortByEditDistance[S ~string](x S, candidates []S) {
+	// Ignore underscores and case when matching.
+	x = fold(x)
+
+	slices.SortStableFunc(candidates, func(ca, cb S) int {
+		return cmp.Compare(levenshtein(x, fold(ca), nil), levenshtein(x, fold(cb), nil))
+	})
+}
+
+// levenshtein returns the non-negative Levenshtein edit distance between the byte strings x and y.
+//
+// If the computed distance exceeds max, the function may return early with an approximate value > max.
+func levenshtein[S ~string](x, y S, max *int) int {
+	// This implementation is derived from one by Laurent Le Brun in Bazel that uses the single-row space efficiency
+	// trick described at bitbucket.org/clearer/iosifovich.
+
+	// Let x be the shorter string.
+	if len(x) > len(y) {
+		x, y = y, x
+	}
+
+	// Remove common prefix.
+	for i := 0; i < len(x); i++ {
+		if x[i] != y[i] {
+			x = x[i:]
+			y = y[i:]
+			break
+		}
+	}
+	if x == "" {
+		return len(y)
+	}
+
+	if max != nil {
+		if d := abs(len(x) - len(y)); d > *max {
+			return d // excessive length divergence
+		}
+	}
+
+	row := make([]int, len(y)+1)
+	for i := range row {
+		row[i] = i
+	}
+
+	for i := 1; i <= len(x); i++ {
+		row[0] = i
+		best := i
+		prev := i - 1
+		for j := 1; j <= len(y); j++ {
+			a := prev + b2i(x[i-1] != y[j-1]) // substitution
+			b := 1 + row[j-1]                 // deletion
+			c := 1 + row[j]                   // insertion
+			k := min(a, min(b, c))
+			prev, row[j] = row[j], k
+			best = min(best, k)
+		}
+		if max != nil && best > *max {
+			return best
+		}
+	}
+	return row[len(y)]
+}
+
+func b2i(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func abs(x int) int {
+	if x >= 0 {
+		return x
+	}
+	return -x
+}
+
+func fold[S ~string](s S) S {
+	return S(strings.Map(func(r rune) rune {
+		if r == '_' {
+			return -1
+		}
+		return unicode.ToLower(r)
+	}, string(s)))
+}

--- a/internal/spell/spell_test.go
+++ b/internal/spell/spell_test.go
@@ -1,0 +1,79 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spell
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEditDistance(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		a, b     string
+		expected int
+	}{
+		{"vpcId", "cpcId", 1},
+		{"vpcId", "foo", 5},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.expected, levenshtein(c.a, c.b, nil))
+	}
+}
+
+func TestNearest(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		words      []string
+		comparedTo string
+		expected   string
+	}{
+		{[]string{}, "test", ""},
+		{[]string{"", "", ""}, "test", ""},
+		{[]string{"test", "test2"}, "test", "test"},
+		{[]string{"test2", "test"}, "test", "test"},
+		{[]string{"test2", "test", "test2"}, "test", "test"},
+		{[]string{"c", "b", "a"}, "test", ""},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.expected, Nearest(c.comparedTo, slices.Values(c.words)))
+	}
+}
+
+func TestSortByEditDistance(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		words      []string
+		comparedTo string
+		expected   []string
+	}{
+		{[]string{}, "test", []string{}},
+		{[]string{"", "", ""}, "test", []string{"", "", ""}},
+		{[]string{"test", "test2"}, "test", []string{"test", "test2"}},
+		{[]string{"test2", "test"}, "test", []string{"test", "test2"}},
+		{[]string{"test2", "test", "test2"}, "test", []string{"test", "test2", "test2"}},
+		{[]string{"c", "b", "a"}, "test", []string{"c", "b", "a"}},
+	}
+	for _, c := range cases {
+		words := make([]string, len(c.words))
+		copy(words, c.words)
+		SortByEditDistance(c.comparedTo, words)
+
+		assert.Equalf(t, c.expected, words, "SortByEditDistance(%v, %v)", c.words, c.comparedTo)
+	}
+}


### PR DESCRIPTION
- Enable the "no such field" diagnostic on the root environment
- When issuing a diagnostic for a missing property when evaluating a
  property access, include an optional "did you mean" message
- Additionally, replace the `*RotationResult` bits with just
  `RotationResult`, as it is already `nil`-able

With these changes, users will see warnings if they attempt to define
top-level keys in an environment that are neither `values` nor
`imports`.
