### PR TITLE
eval: tolerate syntax errors

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,4 +9,6 @@
 
 ### Bug Fixes
 
+- Environment declarations are now returned even in the face of syntax errors.
+
 ### Breaking changes

--- a/ast/expr.go
+++ b/ast/expr.go
@@ -892,7 +892,7 @@ func parseFromBase64(node *syntax.ObjectNode, name *StringExpr, args Expr) (Expr
 func parseSecret(node *syntax.ObjectNode, name *StringExpr, value Expr) (Expr, syntax.Diagnostics) {
 	if arg, ok := value.(*ObjectExpr); ok && len(arg.Entries) == 1 {
 		kvp := arg.Entries[0]
-		if kvp.Key.Value == "ciphertext" {
+		if kvp.Key.GetValue() == "ciphertext" {
 			if str, ok := kvp.Value.(*StringExpr); ok {
 				return CiphertextSyntax(node, name, arg, str), nil
 			}

--- a/eval/expr.go
+++ b/eval/expr.go
@@ -300,7 +300,9 @@ func (x *expr) export(environment string) esc.Expr {
 	case *objectExpr:
 		ex.KeyRanges = make(map[string]esc.Range, len(repr.node.Entries))
 		for _, kvp := range repr.node.Entries {
-			ex.KeyRanges[kvp.Key.Value] = convertRange(kvp.Key.Syntax().Syntax().Range(), environment)
+			if kvp.Key != nil {
+				ex.KeyRanges[kvp.Key.Value] = convertRange(kvp.Key.Syntax().Syntax().Range(), environment)
+			}
 		}
 
 		ex.Object = make(map[string]esc.Expr, len(repr.properties))

--- a/eval/testdata/eval/builtin-concat-errors/expected.json
+++ b/eval/testdata/eval/builtin-concat-errors/expected.json
@@ -23,5 +23,1710 @@
             "Extra": null,
             "Path": "values.invalidInput[\"fn::concat\"]"
         }
-    ]
+    ],
+    "checkDiags": [
+        {
+            "Severity": 1,
+            "Summary": "expected array, got string",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-concat-errors",
+                "Start": {
+                    "Line": 3,
+                    "Column": 17,
+                    "Byte": 40
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 29,
+                    "Byte": 52
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.invalidInput[\"fn::concat\"]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected array, got number",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-concat-errors",
+                "Start": {
+                    "Line": 5,
+                    "Column": 18,
+                    "Byte": 89
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 19,
+                    "Byte": 90
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.invalidNested[\"fn::concat\"][0]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected array, got number",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-concat-errors",
+                "Start": {
+                    "Line": 5,
+                    "Column": 21,
+                    "Byte": 92
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 22,
+                    "Byte": 93
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.invalidNested[\"fn::concat\"][1]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected array, got number",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-concat-errors",
+                "Start": {
+                    "Line": 5,
+                    "Column": 24,
+                    "Byte": 95
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 25,
+                    "Byte": 96
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.invalidNested[\"fn::concat\"][2]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected array, got string",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-concat-errors",
+                "Start": {
+                    "Line": 7,
+                    "Column": 26,
+                    "Byte": 0
+                },
+                "End": {
+                    "Line": 7,
+                    "Column": 33,
+                    "Byte": 0
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.mixedInvalid[\"fn::concat\"][1]"
+        }
+    ],
+    "check": {
+        "exprs": {
+            "invalidInput": {
+                "range": {
+                    "environment": "builtin-concat-errors",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 28
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 29,
+                        "byte": 52
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat-errors",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 28
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 38
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat-errors",
+                            "begin": {
+                                "line": 3,
+                                "column": 17,
+                                "byte": 40
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 29,
+                                "byte": 52
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "not an array"
+                        },
+                        "literal": "not an array"
+                    }
+                }
+            },
+            "invalidNested": {
+                "range": {
+                    "environment": "builtin-concat-errors",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 76
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 25,
+                        "byte": 96
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat-errors",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 76
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 15,
+                            "byte": 86
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat-errors",
+                            "begin": {
+                                "line": 5,
+                                "column": 17,
+                                "byte": 88
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 25,
+                                "byte": 96
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "type": "number",
+                                    "const": 1
+                                },
+                                {
+                                    "type": "number",
+                                    "const": 2
+                                },
+                                {
+                                    "type": "number",
+                                    "const": 3
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 18,
+                                        "byte": 89
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 19,
+                                        "byte": 90
+                                    }
+                                },
+                                "schema": {
+                                    "type": "number",
+                                    "const": 1
+                                },
+                                "literal": 1
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 21,
+                                        "byte": 92
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 22,
+                                        "byte": 93
+                                    }
+                                },
+                                "schema": {
+                                    "type": "number",
+                                    "const": 2
+                                },
+                                "literal": 2
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 24,
+                                        "byte": 95
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 25,
+                                        "byte": 96
+                                    }
+                                },
+                                "schema": {
+                                    "type": "number",
+                                    "const": 3
+                                },
+                                "literal": 3
+                            }
+                        ]
+                    }
+                }
+            },
+            "mixedInvalid": {
+                "range": {
+                    "environment": "builtin-concat-errors",
+                    "begin": {
+                        "line": 7,
+                        "column": 5,
+                        "byte": 0
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 42,
+                        "byte": 0
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat-errors",
+                        "begin": {
+                            "line": 7,
+                            "column": 5,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 15,
+                            "byte": 0
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat-errors",
+                            "begin": {
+                                "line": 7,
+                                "column": 17,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 42,
+                                "byte": 0
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "string",
+                                    "const": "invalid"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 4
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 18,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 23,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat-errors",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 19,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 20,
+                                                "byte": 0
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        "literal": 1
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat-errors",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 22,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 23,
+                                                "byte": 0
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        "literal": 2
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 26,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 33,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "invalid"
+                                },
+                                "literal": "invalid"
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 37,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 42,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 4
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat-errors",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 38,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 39,
+                                                "byte": 0
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        "literal": 3
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat-errors",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 41,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 42,
+                                                "byte": 0
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 4
+                                        },
+                                        "literal": 4
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "properties": {
+            "invalidInput": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat-errors",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 28
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 29,
+                            "byte": 52
+                        }
+                    }
+                }
+            },
+            "invalidNested": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat-errors",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 76
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 25,
+                            "byte": 96
+                        }
+                    }
+                }
+            },
+            "mixedInvalid": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat-errors",
+                        "begin": {
+                            "line": 7,
+                            "column": 5,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 42,
+                            "byte": 0
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "invalidInput": {
+                    "items": true,
+                    "type": "array"
+                },
+                "invalidNested": {
+                    "items": true,
+                    "type": "array"
+                },
+                "mixedInvalid": {
+                    "items": true,
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "required": [
+                "invalidInput",
+                "invalidNested",
+                "mixedInvalid"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "builtin-concat-errors",
+                            "trace": {
+                                "def": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "builtin-concat-errors",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "builtin-concat-errors",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "builtin-concat-errors",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "builtin-concat-errors",
+                            "trace": {
+                                "def": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "builtin-concat-errors",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "builtin-concat-errors"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "builtin-concat-errors"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "checkJson": {
+        "invalidInput": "[unknown]",
+        "invalidNested": "[unknown]",
+        "mixedInvalid": "[unknown]"
+    },
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "expected array, got string",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-concat-errors",
+                "Start": {
+                    "Line": 3,
+                    "Column": 17,
+                    "Byte": 40
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 29,
+                    "Byte": 52
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.invalidInput[\"fn::concat\"]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected array, got number",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-concat-errors",
+                "Start": {
+                    "Line": 5,
+                    "Column": 18,
+                    "Byte": 89
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 19,
+                    "Byte": 90
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.invalidNested[\"fn::concat\"][0]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected array, got number",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-concat-errors",
+                "Start": {
+                    "Line": 5,
+                    "Column": 21,
+                    "Byte": 92
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 22,
+                    "Byte": 93
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.invalidNested[\"fn::concat\"][1]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected array, got number",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-concat-errors",
+                "Start": {
+                    "Line": 5,
+                    "Column": 24,
+                    "Byte": 95
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 25,
+                    "Byte": 96
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.invalidNested[\"fn::concat\"][2]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "expected array, got string",
+            "Detail": "",
+            "Subject": {
+                "Filename": "builtin-concat-errors",
+                "Start": {
+                    "Line": 7,
+                    "Column": 26,
+                    "Byte": 0
+                },
+                "End": {
+                    "Line": 7,
+                    "Column": 33,
+                    "Byte": 0
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.mixedInvalid[\"fn::concat\"][1]"
+        }
+    ],
+    "eval": {
+        "exprs": {
+            "invalidInput": {
+                "range": {
+                    "environment": "builtin-concat-errors",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 28
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 29,
+                        "byte": 52
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat-errors",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 28
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 38
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat-errors",
+                            "begin": {
+                                "line": 3,
+                                "column": 17,
+                                "byte": 40
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 29,
+                                "byte": 52
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "not an array"
+                        },
+                        "literal": "not an array"
+                    }
+                }
+            },
+            "invalidNested": {
+                "range": {
+                    "environment": "builtin-concat-errors",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 76
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 25,
+                        "byte": 96
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat-errors",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 76
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 15,
+                            "byte": 86
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat-errors",
+                            "begin": {
+                                "line": 5,
+                                "column": 17,
+                                "byte": 88
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 25,
+                                "byte": 96
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "type": "number",
+                                    "const": 1
+                                },
+                                {
+                                    "type": "number",
+                                    "const": 2
+                                },
+                                {
+                                    "type": "number",
+                                    "const": 3
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 18,
+                                        "byte": 89
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 19,
+                                        "byte": 90
+                                    }
+                                },
+                                "schema": {
+                                    "type": "number",
+                                    "const": 1
+                                },
+                                "literal": 1
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 21,
+                                        "byte": 92
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 22,
+                                        "byte": 93
+                                    }
+                                },
+                                "schema": {
+                                    "type": "number",
+                                    "const": 2
+                                },
+                                "literal": 2
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 24,
+                                        "byte": 95
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 25,
+                                        "byte": 96
+                                    }
+                                },
+                                "schema": {
+                                    "type": "number",
+                                    "const": 3
+                                },
+                                "literal": 3
+                            }
+                        ]
+                    }
+                }
+            },
+            "mixedInvalid": {
+                "range": {
+                    "environment": "builtin-concat-errors",
+                    "begin": {
+                        "line": 7,
+                        "column": 5,
+                        "byte": 0
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 42,
+                        "byte": 0
+                    }
+                },
+                "schema": {
+                    "items": true,
+                    "type": "array"
+                },
+                "builtin": {
+                    "name": "fn::concat",
+                    "nameRange": {
+                        "environment": "builtin-concat-errors",
+                        "begin": {
+                            "line": 7,
+                            "column": 5,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 15,
+                            "byte": 0
+                        }
+                    },
+                    "argSchema": {
+                        "items": {
+                            "items": true,
+                            "type": "array"
+                        },
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "builtin-concat-errors",
+                            "begin": {
+                                "line": 7,
+                                "column": 17,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 42,
+                                "byte": 0
+                            }
+                        },
+                        "schema": {
+                            "prefixItems": [
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                {
+                                    "type": "string",
+                                    "const": "invalid"
+                                },
+                                {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 4
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                }
+                            ],
+                            "items": false,
+                            "type": "array"
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 18,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 23,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 2
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat-errors",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 19,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 20,
+                                                "byte": 0
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 1
+                                        },
+                                        "literal": 1
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat-errors",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 22,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 23,
+                                                "byte": 0
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 2
+                                        },
+                                        "literal": 2
+                                    }
+                                ]
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 26,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 33,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "invalid"
+                                },
+                                "literal": "invalid"
+                            },
+                            {
+                                "range": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 37,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 42,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": {
+                                    "prefixItems": [
+                                        {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        {
+                                            "type": "number",
+                                            "const": 4
+                                        }
+                                    ],
+                                    "items": false,
+                                    "type": "array"
+                                },
+                                "list": [
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat-errors",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 38,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 39,
+                                                "byte": 0
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 3
+                                        },
+                                        "literal": 3
+                                    },
+                                    {
+                                        "range": {
+                                            "environment": "builtin-concat-errors",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 41,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 42,
+                                                "byte": 0
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "number",
+                                            "const": 4
+                                        },
+                                        "literal": 4
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "properties": {
+            "invalidInput": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat-errors",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 28
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 29,
+                            "byte": 52
+                        }
+                    }
+                }
+            },
+            "invalidNested": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat-errors",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 76
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 25,
+                            "byte": 96
+                        }
+                    }
+                }
+            },
+            "mixedInvalid": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "builtin-concat-errors",
+                        "begin": {
+                            "line": 7,
+                            "column": 5,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 42,
+                            "byte": 0
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "invalidInput": {
+                    "items": true,
+                    "type": "array"
+                },
+                "invalidNested": {
+                    "items": true,
+                    "type": "array"
+                },
+                "mixedInvalid": {
+                    "items": true,
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "required": [
+                "invalidInput",
+                "invalidNested",
+                "mixedInvalid"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "builtin-concat-errors",
+                            "trace": {
+                                "def": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "builtin-concat-errors",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "builtin-concat-errors",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "builtin-concat-errors",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "builtin-concat-errors",
+                            "trace": {
+                                "def": {
+                                    "environment": "builtin-concat-errors",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "builtin-concat-errors",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "builtin-concat-errors"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "builtin-concat-errors"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "evalJsonRedacted": {
+        "invalidInput": "[unknown]",
+        "invalidNested": "[unknown]",
+        "mixedInvalid": "[unknown]"
+    },
+    "evalJSONRevealed": {
+        "invalidInput": "[unknown]",
+        "invalidNested": "[unknown]",
+        "mixedInvalid": "[unknown]"
+    }
 }

--- a/eval/testdata/eval/invalid-access-load/expected.json
+++ b/eval/testdata/eval/invalid-access-load/expected.json
@@ -230,5 +230,2998 @@
             "Extra": null,
             "Path": "values.propertyAccessTest[8]"
         }
-    ]
+    ],
+    "checkDiags": [
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 3,
+                    "Column": 9,
+                    "Byte": 38
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 9,
+                    "Byte": 38
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[0]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"open\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 4,
+                    "Column": 9,
+                    "Byte": 47
+                },
+                "End": {
+                    "Line": 4,
+                    "Column": 13,
+                    "Byte": 51
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[1]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"open\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 5,
+                    "Column": 9,
+                    "Byte": 67
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 13,
+                    "Byte": 71
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[2]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"open\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 6,
+                    "Column": 9,
+                    "Byte": 87
+                },
+                "End": {
+                    "Line": 6,
+                    "Column": 13,
+                    "Byte": 91
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[3]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"array\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 7,
+                    "Column": 9,
+                    "Byte": 107
+                },
+                "End": {
+                    "Line": 7,
+                    "Column": 14,
+                    "Byte": 112
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[4]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"array\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 8,
+                    "Column": 9,
+                    "Byte": 124
+                },
+                "End": {
+                    "Line": 8,
+                    "Column": 14,
+                    "Byte": 129
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[5]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 9,
+                    "Column": 9,
+                    "Byte": 151
+                },
+                "End": {
+                    "Line": 9,
+                    "Column": 10,
+                    "Byte": 152
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[6]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "cannot access an object property using an integer index",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 10,
+                    "Column": 9,
+                    "Byte": 161
+                },
+                "End": {
+                    "Line": 10,
+                    "Column": 12,
+                    "Byte": 164
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[7]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"2\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 11,
+                    "Column": 9,
+                    "Byte": 174
+                },
+                "End": {
+                    "Line": 11,
+                    "Column": 10,
+                    "Byte": 175
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[8]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"34\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 12,
+                    "Column": 9,
+                    "Byte": 193
+                },
+                "End": {
+                    "Line": 12,
+                    "Column": 11,
+                    "Byte": 195
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[9]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"bad\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 13,
+                    "Column": 9,
+                    "Byte": 209
+                },
+                "End": {
+                    "Line": 13,
+                    "Column": 13,
+                    "Byte": 213
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[10]"
+        }
+    ],
+    "check": {
+        "exprs": {
+            "propertyAccessTest": {
+                "range": {
+                    "environment": "invalid-access-load",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 34
+                    },
+                    "end": {
+                        "line": 13,
+                        "column": 14,
+                        "byte": 214
+                    }
+                },
+                "schema": {
+                    "prefixItems": [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    "items": false,
+                    "type": "array"
+                },
+                "list": [
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 3,
+                                "column": 7,
+                                "byte": 36
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 9,
+                                "byte": 38
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 9,
+                                        "byte": 38
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 9,
+                                        "byte": 38
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 7,
+                                        "byte": 36
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 9,
+                                        "byte": 38
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 4,
+                                "column": 7,
+                                "byte": 45
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 20,
+                                "byte": 58
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "open",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 9,
+                                        "byte": 47
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 13,
+                                        "byte": 51
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 7,
+                                        "byte": 45
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 20,
+                                        "byte": 58
+                                    }
+                                }
+                            },
+                            {
+                                "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 13,
+                                        "byte": 51
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 19,
+                                        "byte": 57
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 7,
+                                        "byte": 45
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 20,
+                                        "byte": 58
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 5,
+                                "column": 7,
+                                "byte": 65
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 20,
+                                "byte": 78
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "open",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 9,
+                                        "byte": 67
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 13,
+                                        "byte": 71
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 7,
+                                        "byte": 65
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 20,
+                                        "byte": 78
+                                    }
+                                }
+                            },
+                            {
+                                "key": "foo]}",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 13,
+                                        "byte": 71
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 20,
+                                        "byte": 78
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 7,
+                                        "byte": 65
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 20,
+                                        "byte": 78
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 6,
+                                "column": 7,
+                                "byte": 85
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 20,
+                                "byte": 98
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "open",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 9,
+                                        "byte": 87
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 13,
+                                        "byte": 91
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 7,
+                                        "byte": 85
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 20,
+                                        "byte": 98
+                                    }
+                                }
+                            },
+                            {
+                                "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 13,
+                                        "byte": 91
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 20,
+                                        "byte": 98
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 7,
+                                        "byte": 85
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 20,
+                                        "byte": 98
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 7,
+                                "column": 7,
+                                "byte": 105
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 17,
+                                "byte": 115
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "array",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 9,
+                                        "byte": 107
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 14,
+                                        "byte": 112
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 7,
+                                        "byte": 105
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 17,
+                                        "byte": 115
+                                    }
+                                }
+                            },
+                            {
+                                "index": 1,
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 14,
+                                        "byte": 112
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 16,
+                                        "byte": 114
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 7,
+                                        "byte": 105
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 17,
+                                        "byte": 115
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 8,
+                                "column": 7,
+                                "byte": 122
+                            },
+                            "end": {
+                                "line": 8,
+                                "column": 27,
+                                "byte": 142
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "array",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 9,
+                                        "byte": 124
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 14,
+                                        "byte": 129
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 7,
+                                        "byte": 122
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 27,
+                                        "byte": 142
+                                    }
+                                }
+                            },
+                            {
+                                "key": "notAnIndex",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 14,
+                                        "byte": 129
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 26,
+                                        "byte": 141
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 7,
+                                        "byte": 122
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 27,
+                                        "byte": 142
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 9,
+                                "column": 7,
+                                "byte": 149
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 10,
+                                "byte": 152
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 9,
+                                        "column": 9,
+                                        "byte": 151
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 10,
+                                        "byte": 152
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 9,
+                                        "column": 7,
+                                        "byte": 149
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 10,
+                                        "byte": 152
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 10,
+                                "column": 7,
+                                "byte": 159
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 13,
+                                "byte": 165
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "index": 2,
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 9,
+                                        "byte": 161
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 12,
+                                        "byte": 164
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 7,
+                                        "byte": 159
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 13,
+                                        "byte": 165
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 11,
+                                "column": 7,
+                                "byte": 172
+                            },
+                            "end": {
+                                "line": 11,
+                                "column": 19,
+                                "byte": 184
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "2",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 9,
+                                        "byte": 174
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 10,
+                                        "byte": 175
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 7,
+                                        "byte": 172
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 19,
+                                        "byte": 184
+                                    }
+                                }
+                            },
+                            {
+                                "key": "",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 10,
+                                        "byte": 175
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 11,
+                                        "byte": 176
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 7,
+                                        "byte": 172
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 19,
+                                        "byte": 184
+                                    }
+                                }
+                            },
+                            {
+                                "key": "bad",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 11,
+                                        "byte": 176
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 18,
+                                        "byte": 183
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 7,
+                                        "byte": 172
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 19,
+                                        "byte": 184
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 12,
+                                "column": 7,
+                                "byte": 191
+                            },
+                            "end": {
+                                "line": 12,
+                                "column": 16,
+                                "byte": 200
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "34",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 9,
+                                        "byte": 193
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 11,
+                                        "byte": 195
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 7,
+                                        "byte": 191
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 16,
+                                        "byte": 200
+                                    }
+                                }
+                            },
+                            {
+                                "key": "bad",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 11,
+                                        "byte": 195
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 15,
+                                        "byte": 199
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 7,
+                                        "byte": 191
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 16,
+                                        "byte": 200
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 13,
+                                "column": 7,
+                                "byte": 207
+                            },
+                            "end": {
+                                "line": 13,
+                                "column": 14,
+                                "byte": 214
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "bad",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 13,
+                                        "column": 9,
+                                        "byte": 209
+                                    },
+                                    "end": {
+                                        "line": 13,
+                                        "column": 13,
+                                        "byte": 213
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 13,
+                                        "column": 7,
+                                        "byte": 207
+                                    },
+                                    "end": {
+                                        "line": 13,
+                                        "column": 14,
+                                        "byte": 214
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "properties": {
+            "propertyAccessTest": {
+                "value": [
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 7,
+                                    "byte": 36
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 9,
+                                    "byte": 38
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 7,
+                                    "byte": 45
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 20,
+                                    "byte": 58
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 7,
+                                    "byte": 65
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 20,
+                                    "byte": 78
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 7,
+                                    "byte": 85
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 20,
+                                    "byte": 98
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 7,
+                                    "byte": 105
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 17,
+                                    "byte": 115
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 7,
+                                    "byte": 122
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 27,
+                                    "byte": 142
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 7,
+                                    "byte": 149
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 10,
+                                    "byte": 152
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 7,
+                                    "byte": 159
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 13,
+                                    "byte": 165
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 11,
+                                    "column": 7,
+                                    "byte": 172
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 19,
+                                    "byte": 184
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 12,
+                                    "column": 7,
+                                    "byte": 191
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 16,
+                                    "byte": 200
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 13,
+                                    "column": 7,
+                                    "byte": 207
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 14,
+                                    "byte": 214
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "invalid-access-load",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 34
+                        },
+                        "end": {
+                            "line": 13,
+                            "column": 14,
+                            "byte": 214
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "propertyAccessTest": {
+                    "prefixItems": [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    "items": false,
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "required": [
+                "propertyAccessTest"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-access-load",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "invalid-access-load",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-access-load",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-access-load"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-access-load"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "checkJson": {
+        "propertyAccessTest": [
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]"
+        ]
+    },
+    "evalDiags": [
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 3,
+                    "Column": 9,
+                    "Byte": 38
+                },
+                "End": {
+                    "Line": 3,
+                    "Column": 9,
+                    "Byte": 38
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[0]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"open\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 4,
+                    "Column": 9,
+                    "Byte": 47
+                },
+                "End": {
+                    "Line": 4,
+                    "Column": 13,
+                    "Byte": 51
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[1]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"open\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 5,
+                    "Column": 9,
+                    "Byte": 67
+                },
+                "End": {
+                    "Line": 5,
+                    "Column": 13,
+                    "Byte": 71
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[2]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"open\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 6,
+                    "Column": 9,
+                    "Byte": 87
+                },
+                "End": {
+                    "Line": 6,
+                    "Column": 13,
+                    "Byte": 91
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[3]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"array\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 7,
+                    "Column": 9,
+                    "Byte": 107
+                },
+                "End": {
+                    "Line": 7,
+                    "Column": 14,
+                    "Byte": 112
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[4]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"array\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 8,
+                    "Column": 9,
+                    "Byte": 124
+                },
+                "End": {
+                    "Line": 8,
+                    "Column": 14,
+                    "Byte": 129
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[5]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 9,
+                    "Column": 9,
+                    "Byte": 151
+                },
+                "End": {
+                    "Line": 9,
+                    "Column": 10,
+                    "Byte": 152
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[6]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "cannot access an object property using an integer index",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 10,
+                    "Column": 9,
+                    "Byte": 161
+                },
+                "End": {
+                    "Line": 10,
+                    "Column": 12,
+                    "Byte": 164
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[7]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"2\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 11,
+                    "Column": 9,
+                    "Byte": 174
+                },
+                "End": {
+                    "Line": 11,
+                    "Column": 10,
+                    "Byte": 175
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[8]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"34\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 12,
+                    "Column": 9,
+                    "Byte": 193
+                },
+                "End": {
+                    "Line": 12,
+                    "Column": 11,
+                    "Byte": 195
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[9]"
+        },
+        {
+            "Severity": 1,
+            "Summary": "unknown property \"bad\"",
+            "Detail": "",
+            "Subject": {
+                "Filename": "invalid-access-load",
+                "Start": {
+                    "Line": 13,
+                    "Column": 9,
+                    "Byte": 209
+                },
+                "End": {
+                    "Line": 13,
+                    "Column": 13,
+                    "Byte": 213
+                }
+            },
+            "Context": null,
+            "Expression": null,
+            "EvalContext": null,
+            "Extra": null,
+            "Path": "values.propertyAccessTest[10]"
+        }
+    ],
+    "eval": {
+        "exprs": {
+            "propertyAccessTest": {
+                "range": {
+                    "environment": "invalid-access-load",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 34
+                    },
+                    "end": {
+                        "line": 13,
+                        "column": 14,
+                        "byte": 214
+                    }
+                },
+                "schema": {
+                    "prefixItems": [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    "items": false,
+                    "type": "array"
+                },
+                "list": [
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 3,
+                                "column": 7,
+                                "byte": 36
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 9,
+                                "byte": 38
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 9,
+                                        "byte": 38
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 9,
+                                        "byte": 38
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 3,
+                                        "column": 7,
+                                        "byte": 36
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 9,
+                                        "byte": 38
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 4,
+                                "column": 7,
+                                "byte": 45
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 20,
+                                "byte": 58
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "open",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 9,
+                                        "byte": 47
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 13,
+                                        "byte": 51
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 7,
+                                        "byte": 45
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 20,
+                                        "byte": 58
+                                    }
+                                }
+                            },
+                            {
+                                "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 13,
+                                        "byte": 51
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 19,
+                                        "byte": 57
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 7,
+                                        "byte": 45
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 20,
+                                        "byte": 58
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 5,
+                                "column": 7,
+                                "byte": 65
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 20,
+                                "byte": 78
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "open",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 9,
+                                        "byte": 67
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 13,
+                                        "byte": 71
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 7,
+                                        "byte": 65
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 20,
+                                        "byte": 78
+                                    }
+                                }
+                            },
+                            {
+                                "key": "foo]}",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 13,
+                                        "byte": 71
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 20,
+                                        "byte": 78
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 7,
+                                        "byte": 65
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 20,
+                                        "byte": 78
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 6,
+                                "column": 7,
+                                "byte": 85
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 20,
+                                "byte": 98
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "open",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 9,
+                                        "byte": 87
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 13,
+                                        "byte": 91
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 7,
+                                        "byte": 85
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 20,
+                                        "byte": 98
+                                    }
+                                }
+                            },
+                            {
+                                "key": "foo",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 13,
+                                        "byte": 91
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 20,
+                                        "byte": 98
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 6,
+                                        "column": 7,
+                                        "byte": 85
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 20,
+                                        "byte": 98
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 7,
+                                "column": 7,
+                                "byte": 105
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 17,
+                                "byte": 115
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "array",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 9,
+                                        "byte": 107
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 14,
+                                        "byte": 112
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 7,
+                                        "byte": 105
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 17,
+                                        "byte": 115
+                                    }
+                                }
+                            },
+                            {
+                                "index": 1,
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 14,
+                                        "byte": 112
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 16,
+                                        "byte": 114
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 7,
+                                        "byte": 105
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 17,
+                                        "byte": 115
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 8,
+                                "column": 7,
+                                "byte": 122
+                            },
+                            "end": {
+                                "line": 8,
+                                "column": 27,
+                                "byte": 142
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "array",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 9,
+                                        "byte": 124
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 14,
+                                        "byte": 129
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 7,
+                                        "byte": 122
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 27,
+                                        "byte": 142
+                                    }
+                                }
+                            },
+                            {
+                                "key": "notAnIndex",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 14,
+                                        "byte": 129
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 26,
+                                        "byte": 141
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 8,
+                                        "column": 7,
+                                        "byte": 122
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 27,
+                                        "byte": 142
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 9,
+                                "column": 7,
+                                "byte": 149
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 10,
+                                "byte": 152
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 9,
+                                        "column": 9,
+                                        "byte": 151
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 10,
+                                        "byte": 152
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 9,
+                                        "column": 7,
+                                        "byte": 149
+                                    },
+                                    "end": {
+                                        "line": 9,
+                                        "column": 10,
+                                        "byte": 152
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 10,
+                                "column": 7,
+                                "byte": 159
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 13,
+                                "byte": 165
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "index": 2,
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 9,
+                                        "byte": 161
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 12,
+                                        "byte": 164
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 10,
+                                        "column": 7,
+                                        "byte": 159
+                                    },
+                                    "end": {
+                                        "line": 10,
+                                        "column": 13,
+                                        "byte": 165
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 11,
+                                "column": 7,
+                                "byte": 172
+                            },
+                            "end": {
+                                "line": 11,
+                                "column": 19,
+                                "byte": 184
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "2",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 9,
+                                        "byte": 174
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 10,
+                                        "byte": 175
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 7,
+                                        "byte": 172
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 19,
+                                        "byte": 184
+                                    }
+                                }
+                            },
+                            {
+                                "key": "",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 10,
+                                        "byte": 175
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 11,
+                                        "byte": 176
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 7,
+                                        "byte": 172
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 19,
+                                        "byte": 184
+                                    }
+                                }
+                            },
+                            {
+                                "key": "bad",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 11,
+                                        "byte": 176
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 18,
+                                        "byte": 183
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 7,
+                                        "byte": 172
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 19,
+                                        "byte": 184
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 12,
+                                "column": 7,
+                                "byte": 191
+                            },
+                            "end": {
+                                "line": 12,
+                                "column": 16,
+                                "byte": 200
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "34",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 9,
+                                        "byte": 193
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 11,
+                                        "byte": 195
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 7,
+                                        "byte": 191
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 16,
+                                        "byte": 200
+                                    }
+                                }
+                            },
+                            {
+                                "key": "bad",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 11,
+                                        "byte": 195
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 15,
+                                        "byte": 199
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 12,
+                                        "column": 7,
+                                        "byte": 191
+                                    },
+                                    "end": {
+                                        "line": 12,
+                                        "column": 16,
+                                        "byte": 200
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "range": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 13,
+                                "column": 7,
+                                "byte": 207
+                            },
+                            "end": {
+                                "line": 13,
+                                "column": 14,
+                                "byte": 214
+                            }
+                        },
+                        "schema": true,
+                        "symbol": [
+                            {
+                                "key": "bad",
+                                "range": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 13,
+                                        "column": 9,
+                                        "byte": 209
+                                    },
+                                    "end": {
+                                        "line": 13,
+                                        "column": 13,
+                                        "byte": 213
+                                    }
+                                },
+                                "value": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 13,
+                                        "column": 7,
+                                        "byte": 207
+                                    },
+                                    "end": {
+                                        "line": 13,
+                                        "column": 14,
+                                        "byte": 214
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "properties": {
+            "propertyAccessTest": {
+                "value": [
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 7,
+                                    "byte": 36
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 9,
+                                    "byte": 38
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 4,
+                                    "column": 7,
+                                    "byte": 45
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 20,
+                                    "byte": 58
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 7,
+                                    "byte": 65
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 20,
+                                    "byte": 78
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 7,
+                                    "byte": 85
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 20,
+                                    "byte": 98
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 7,
+                                    "byte": 105
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 17,
+                                    "byte": 115
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 7,
+                                    "byte": 122
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 27,
+                                    "byte": 142
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 9,
+                                    "column": 7,
+                                    "byte": 149
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 10,
+                                    "byte": 152
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 7,
+                                    "byte": 159
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 13,
+                                    "byte": 165
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 11,
+                                    "column": 7,
+                                    "byte": 172
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 19,
+                                    "byte": 184
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 12,
+                                    "column": 7,
+                                    "byte": 191
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 16,
+                                    "byte": 200
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-access-load",
+                                "begin": {
+                                    "line": 13,
+                                    "column": 7,
+                                    "byte": 207
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 14,
+                                    "byte": 214
+                                }
+                            }
+                        }
+                    }
+                ],
+                "trace": {
+                    "def": {
+                        "environment": "invalid-access-load",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 34
+                        },
+                        "end": {
+                            "line": 13,
+                            "column": 14,
+                            "byte": 214
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "propertyAccessTest": {
+                    "prefixItems": [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    "items": false,
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "required": [
+                "propertyAccessTest"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-access-load",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "invalid-access-load",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-access-load",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-access-load",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-access-load",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-access-load"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-access-load"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "evalJsonRedacted": {
+        "propertyAccessTest": [
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]"
+        ]
+    },
+    "evalJSONRevealed": {
+        "propertyAccessTest": [
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]",
+            "[unknown]"
+        ]
+    }
 }

--- a/eval/testdata/eval/invalid-import/expected.json
+++ b/eval/testdata/eval/invalid-import/expected.json
@@ -23,5 +23,502 @@
             "Extra": null,
             "Path": "imports[0]"
         }
-    ]
+    ],
+    "check": {
+        "exprs": {
+            "foo": {
+                "range": {
+                    "environment": "invalid-import",
+                    "begin": {
+                        "line": 4,
+                        "column": 8,
+                        "byte": 29
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 11,
+                        "byte": 32
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "bar"
+                },
+                "literal": "bar"
+            }
+        },
+        "properties": {
+            "foo": {
+                "value": "bar",
+                "trace": {
+                    "def": {
+                        "environment": "invalid-import",
+                        "begin": {
+                            "line": 4,
+                            "column": 8,
+                            "byte": 29
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 11,
+                            "byte": 32
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "foo": {
+                    "type": "string",
+                    "const": "bar"
+                }
+            },
+            "type": "object",
+            "required": [
+                "foo"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-import",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-import",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-import",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "invalid-import",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-import",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-import",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-import",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-import",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-import",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-import"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-import"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "checkJson": {
+        "foo": "bar"
+    },
+    "eval": {
+        "exprs": {
+            "foo": {
+                "range": {
+                    "environment": "invalid-import",
+                    "begin": {
+                        "line": 4,
+                        "column": 8,
+                        "byte": 29
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 11,
+                        "byte": 32
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "bar"
+                },
+                "literal": "bar"
+            }
+        },
+        "properties": {
+            "foo": {
+                "value": "bar",
+                "trace": {
+                    "def": {
+                        "environment": "invalid-import",
+                        "begin": {
+                            "line": 4,
+                            "column": 8,
+                            "byte": 29
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 11,
+                            "byte": 32
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "foo": {
+                    "type": "string",
+                    "const": "bar"
+                }
+            },
+            "type": "object",
+            "required": [
+                "foo"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-import",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-import",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-import",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "invalid-import",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-import",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-import",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-import",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-import",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-import",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-import"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-import"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "evalJsonRedacted": {
+        "foo": "bar"
+    },
+    "evalJSONRevealed": {
+        "foo": "bar"
+    }
 }

--- a/eval/testdata/eval/invalid-join/expected.json
+++ b/eval/testdata/eval/invalid-join/expected.json
@@ -23,5 +23,745 @@
             "Extra": null,
             "Path": "values.join[\"fn::join\"]"
         }
-    ]
+    ],
+    "check": {
+        "exprs": {
+            "join": {
+                "range": {
+                    "environment": "invalid-join",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 20
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 19,
+                        "byte": 34
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "fn::join",
+                    "nameRange": {
+                        "environment": "invalid-join",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 13,
+                            "byte": 28
+                        }
+                    },
+                    "argSchema": {
+                        "prefixItems": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        ],
+                        "items": false,
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "invalid-join",
+                            "begin": {
+                                "line": 3,
+                                "column": 15,
+                                "byte": 30
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 19,
+                                "byte": 34
+                            }
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "invalid-join",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            },
+                            {
+                                "range": {
+                                    "environment": "invalid-join",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            }
+                        ]
+                    }
+                }
+            },
+            "other": {
+                "range": {
+                    "environment": "invalid-join",
+                    "begin": {
+                        "line": 4,
+                        "column": 10,
+                        "byte": 44
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 15,
+                        "byte": 49
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "value"
+                },
+                "literal": "value"
+            }
+        },
+        "properties": {
+            "join": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-join",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 19,
+                            "byte": 34
+                        }
+                    }
+                }
+            },
+            "other": {
+                "value": "value",
+                "trace": {
+                    "def": {
+                        "environment": "invalid-join",
+                        "begin": {
+                            "line": 4,
+                            "column": 10,
+                            "byte": 44
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 15,
+                            "byte": 49
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "join": {
+                    "type": "string"
+                },
+                "other": {
+                    "type": "string",
+                    "const": "value"
+                }
+            },
+            "type": "object",
+            "required": [
+                "join",
+                "other"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-join",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-join",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-join",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "invalid-join",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-join",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-join",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-join",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-join",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-join",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-join"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-join"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "checkJson": {
+        "join": "[unknown]",
+        "other": "value"
+    },
+    "eval": {
+        "exprs": {
+            "join": {
+                "range": {
+                    "environment": "invalid-join",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 20
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 19,
+                        "byte": 34
+                    }
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "builtin": {
+                    "name": "fn::join",
+                    "nameRange": {
+                        "environment": "invalid-join",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 13,
+                            "byte": 28
+                        }
+                    },
+                    "argSchema": {
+                        "prefixItems": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        ],
+                        "items": false,
+                        "type": "array"
+                    },
+                    "arg": {
+                        "range": {
+                            "environment": "invalid-join",
+                            "begin": {
+                                "line": 3,
+                                "column": 15,
+                                "byte": 30
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 19,
+                                "byte": 34
+                            }
+                        },
+                        "list": [
+                            {
+                                "range": {
+                                    "environment": "invalid-join",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            },
+                            {
+                                "range": {
+                                    "environment": "invalid-join",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            }
+                        ]
+                    }
+                }
+            },
+            "other": {
+                "range": {
+                    "environment": "invalid-join",
+                    "begin": {
+                        "line": 4,
+                        "column": 10,
+                        "byte": 44
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 15,
+                        "byte": 49
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "value"
+                },
+                "literal": "value"
+            }
+        },
+        "properties": {
+            "join": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-join",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 19,
+                            "byte": 34
+                        }
+                    }
+                }
+            },
+            "other": {
+                "value": "value",
+                "trace": {
+                    "def": {
+                        "environment": "invalid-join",
+                        "begin": {
+                            "line": 4,
+                            "column": 10,
+                            "byte": 44
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 15,
+                            "byte": 49
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "join": {
+                    "type": "string"
+                },
+                "other": {
+                    "type": "string",
+                    "const": "value"
+                }
+            },
+            "type": "object",
+            "required": [
+                "join",
+                "other"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-join",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-join",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-join",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "invalid-join",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-join",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-join",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-join",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-join",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-join",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-join"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-join"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "evalJsonRedacted": {
+        "join": "[unknown]",
+        "other": "value"
+    },
+    "evalJSONRevealed": {
+        "join": "[unknown]",
+        "other": "value"
+    }
 }

--- a/eval/testdata/eval/invalid-object-key/expected.json
+++ b/eval/testdata/eval/invalid-object-key/expected.json
@@ -23,5 +23,585 @@
             "Extra": null,
             "Path": "values.b[\"${a}\"]"
         }
-    ]
+    ],
+    "check": {
+        "exprs": {
+            "a": {
+                "range": {
+                    "environment": "invalid-object-key",
+                    "begin": {
+                        "line": 2,
+                        "column": 6,
+                        "byte": 13
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 11,
+                        "byte": 18
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "value"
+                },
+                "literal": "value"
+            },
+            "b": {
+                "range": {
+                    "environment": "invalid-object-key",
+                    "begin": {
+                        "line": 3,
+                        "column": 6,
+                        "byte": 24
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 21,
+                        "byte": 39
+                    }
+                },
+                "schema": {
+                    "type": "object"
+                }
+            }
+        },
+        "properties": {
+            "a": {
+                "value": "value",
+                "trace": {
+                    "def": {
+                        "environment": "invalid-object-key",
+                        "begin": {
+                            "line": 2,
+                            "column": 6,
+                            "byte": 13
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 11,
+                            "byte": 18
+                        }
+                    }
+                }
+            },
+            "b": {
+                "value": {},
+                "trace": {
+                    "def": {
+                        "environment": "invalid-object-key",
+                        "begin": {
+                            "line": 3,
+                            "column": 6,
+                            "byte": 24
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 21,
+                            "byte": 39
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "a": {
+                    "type": "string",
+                    "const": "value"
+                },
+                "b": {
+                    "type": "object"
+                }
+            },
+            "type": "object",
+            "required": [
+                "a",
+                "b"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-object-key",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-object-key",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-object-key",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "invalid-object-key",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-object-key",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-object-key",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-object-key",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-object-key",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-object-key",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-object-key"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-object-key"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "checkJson": {
+        "a": "value",
+        "b": {}
+    },
+    "eval": {
+        "exprs": {
+            "a": {
+                "range": {
+                    "environment": "invalid-object-key",
+                    "begin": {
+                        "line": 2,
+                        "column": 6,
+                        "byte": 13
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 11,
+                        "byte": 18
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": "value"
+                },
+                "literal": "value"
+            },
+            "b": {
+                "range": {
+                    "environment": "invalid-object-key",
+                    "begin": {
+                        "line": 3,
+                        "column": 6,
+                        "byte": 24
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 21,
+                        "byte": 39
+                    }
+                },
+                "schema": {
+                    "type": "object"
+                }
+            }
+        },
+        "properties": {
+            "a": {
+                "value": "value",
+                "trace": {
+                    "def": {
+                        "environment": "invalid-object-key",
+                        "begin": {
+                            "line": 2,
+                            "column": 6,
+                            "byte": 13
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 11,
+                            "byte": 18
+                        }
+                    }
+                }
+            },
+            "b": {
+                "value": {},
+                "trace": {
+                    "def": {
+                        "environment": "invalid-object-key",
+                        "begin": {
+                            "line": 3,
+                            "column": 6,
+                            "byte": 24
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 21,
+                            "byte": 39
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "a": {
+                    "type": "string",
+                    "const": "value"
+                },
+                "b": {
+                    "type": "object"
+                }
+            },
+            "type": "object",
+            "required": [
+                "a",
+                "b"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-object-key",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-object-key",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-object-key",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "invalid-object-key",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-object-key",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-object-key",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-object-key",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-object-key",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-object-key",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-object-key"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-object-key"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "evalJsonRedacted": {
+        "a": "value",
+        "b": {}
+    },
+    "evalJSONRevealed": {
+        "a": "value",
+        "b": {}
+    }
 }

--- a/eval/testdata/eval/invalid-open/expected.json
+++ b/eval/testdata/eval/invalid-open/expected.json
@@ -69,5 +69,1124 @@
             "Extra": null,
             "Path": "values[\"invalid-provider\"][\"fn::open\"].provider"
         }
-    ]
+    ],
+    "check": {
+        "exprs": {
+            "invalid-provider": {
+                "range": {
+                    "environment": "invalid-open",
+                    "begin": {
+                        "line": 9,
+                        "column": 5,
+                        "byte": 140
+                    },
+                    "end": {
+                        "line": 11,
+                        "column": 21,
+                        "byte": 195
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::open",
+                    "nameRange": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 9,
+                            "column": 5,
+                            "byte": 140
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 13,
+                            "byte": 148
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 15,
+                                        "byte": 189
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 21,
+                                        "byte": 195
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "inputs"
+                                },
+                                "literal": "inputs"
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            }
+                        }
+                    }
+                }
+            },
+            "missing-inputs": {
+                "range": {
+                    "environment": "invalid-open",
+                    "begin": {
+                        "line": 6,
+                        "column": 5,
+                        "byte": 85
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 21,
+                        "byte": 115
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::open",
+                    "nameRange": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 85
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 13,
+                            "byte": 93
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 17,
+                                        "byte": 111
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 21,
+                                        "byte": 115
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "test"
+                                },
+                                "literal": "test"
+                            }
+                        }
+                    }
+                }
+            },
+            "missing-provider": {
+                "range": {
+                    "environment": "invalid-open",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 32
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 21,
+                        "byte": 62
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::open",
+                    "nameRange": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 32
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 13,
+                            "byte": 40
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 15,
+                                        "byte": 56
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 21,
+                                        "byte": 62
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "inputs"
+                                },
+                                "literal": "inputs"
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "invalid-provider": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 9,
+                            "column": 5,
+                            "byte": 140
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 21,
+                            "byte": 195
+                        }
+                    }
+                }
+            },
+            "missing-inputs": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 85
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 21,
+                            "byte": 115
+                        }
+                    }
+                }
+            },
+            "missing-provider": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 32
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 21,
+                            "byte": 62
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "invalid-provider": true,
+                "missing-inputs": true,
+                "missing-provider": true
+            },
+            "type": "object",
+            "required": [
+                "invalid-provider",
+                "missing-inputs",
+                "missing-provider"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-open",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-open",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "invalid-open",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-open",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-open",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-open",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-open"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-open"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "checkJson": {
+        "invalid-provider": "[unknown]",
+        "missing-inputs": "[unknown]",
+        "missing-provider": "[unknown]"
+    },
+    "eval": {
+        "exprs": {
+            "invalid-provider": {
+                "range": {
+                    "environment": "invalid-open",
+                    "begin": {
+                        "line": 9,
+                        "column": 5,
+                        "byte": 140
+                    },
+                    "end": {
+                        "line": 11,
+                        "column": 21,
+                        "byte": 195
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::open",
+                    "nameRange": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 9,
+                            "column": 5,
+                            "byte": 140
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 13,
+                            "byte": 148
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 15,
+                                        "byte": 189
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 21,
+                                        "byte": 195
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "inputs"
+                                },
+                                "literal": "inputs"
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            }
+                        }
+                    }
+                }
+            },
+            "missing-inputs": {
+                "range": {
+                    "environment": "invalid-open",
+                    "begin": {
+                        "line": 6,
+                        "column": 5,
+                        "byte": 85
+                    },
+                    "end": {
+                        "line": 7,
+                        "column": 21,
+                        "byte": 115
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::open",
+                    "nameRange": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 85
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 13,
+                            "byte": 93
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 17,
+                                        "byte": 111
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 21,
+                                        "byte": 115
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "test"
+                                },
+                                "literal": "test"
+                            }
+                        }
+                    }
+                }
+            },
+            "missing-provider": {
+                "range": {
+                    "environment": "invalid-open",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 32
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 21,
+                        "byte": 62
+                    }
+                },
+                "schema": true,
+                "builtin": {
+                    "name": "fn::open",
+                    "nameRange": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 32
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 13,
+                            "byte": 40
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 15,
+                                        "byte": 56
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 21,
+                                        "byte": 62
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "inputs"
+                                },
+                                "literal": "inputs"
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "schema": true
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "invalid-provider": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 9,
+                            "column": 5,
+                            "byte": 140
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 21,
+                            "byte": 195
+                        }
+                    }
+                }
+            },
+            "missing-inputs": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 85
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 21,
+                            "byte": 115
+                        }
+                    }
+                }
+            },
+            "missing-provider": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-open",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 32
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 21,
+                            "byte": 62
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "invalid-provider": true,
+                "missing-inputs": true,
+                "missing-provider": true
+            },
+            "type": "object",
+            "required": [
+                "invalid-provider",
+                "missing-inputs",
+                "missing-provider"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-open",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-open",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "invalid-open",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-open",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-open",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-open",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-open",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-open"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-open"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "evalJsonRedacted": {
+        "invalid-provider": "[unknown]",
+        "missing-inputs": "[unknown]",
+        "missing-provider": "[unknown]"
+    },
+    "evalJSONRevealed": {
+        "invalid-provider": "[unknown]",
+        "missing-inputs": "[unknown]",
+        "missing-provider": "[unknown]"
+    }
 }

--- a/eval/testdata/eval/invalid-plaintext/expected.json
+++ b/eval/testdata/eval/invalid-plaintext/expected.json
@@ -23,5 +23,938 @@
             "Extra": null,
             "Path": "values.foo[\"fn::secret\"]"
         }
-    ]
+    ],
+    "check": {
+        "exprs": {
+            "bar": {
+                "range": {
+                    "environment": "invalid-plaintext",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 57
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 17,
+                        "byte": 82
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "valid"
+                        },
+                        "object": {
+                            "type": "string",
+                            "const": "here"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "object"
+                    ]
+                },
+                "keyRanges": {
+                    "a": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 57
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 6,
+                            "byte": 58
+                        }
+                    },
+                    "object": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 70
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 11,
+                            "byte": 76
+                        }
+                    }
+                },
+                "object": {
+                    "a": {
+                        "range": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 5,
+                                "column": 8,
+                                "byte": 60
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 13,
+                                "byte": 65
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "valid"
+                        },
+                        "literal": "valid"
+                    },
+                    "object": {
+                        "range": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 6,
+                                "column": 13,
+                                "byte": 78
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 17,
+                                "byte": 82
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "here"
+                        },
+                        "literal": "here"
+                    }
+                }
+            },
+            "foo": {
+                "range": {
+                    "environment": "invalid-plaintext",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 19
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 29,
+                        "byte": 43
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": ""
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 19
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 29
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": ""
+                        },
+                        "literal": ""
+                    }
+                }
+            }
+        },
+        "properties": {
+            "bar": {
+                "value": {
+                    "a": {
+                        "value": "valid",
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-plaintext",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 8,
+                                    "byte": 60
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 13,
+                                    "byte": 65
+                                }
+                            }
+                        }
+                    },
+                    "object": {
+                        "value": "here",
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-plaintext",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 13,
+                                    "byte": 78
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 17,
+                                    "byte": 82
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 57
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 17,
+                            "byte": 82
+                        }
+                    }
+                }
+            },
+            "foo": {
+                "value": "",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 0,
+                            "column": 0,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 0,
+                            "column": 0,
+                            "byte": 0
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "bar": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "valid"
+                        },
+                        "object": {
+                            "type": "string",
+                            "const": "here"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "object"
+                    ]
+                },
+                "foo": {
+                    "type": "string",
+                    "const": ""
+                }
+            },
+            "type": "object",
+            "required": [
+                "bar",
+                "foo"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-plaintext",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-plaintext",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "invalid-plaintext",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-plaintext",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-plaintext",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-plaintext",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-plaintext"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-plaintext"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "checkJson": {
+        "bar": {
+            "a": "valid",
+            "object": "here"
+        },
+        "foo": "[secret]"
+    },
+    "eval": {
+        "exprs": {
+            "bar": {
+                "range": {
+                    "environment": "invalid-plaintext",
+                    "begin": {
+                        "line": 5,
+                        "column": 5,
+                        "byte": 57
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 17,
+                        "byte": 82
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "valid"
+                        },
+                        "object": {
+                            "type": "string",
+                            "const": "here"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "object"
+                    ]
+                },
+                "keyRanges": {
+                    "a": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 57
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 6,
+                            "byte": 58
+                        }
+                    },
+                    "object": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 6,
+                            "column": 5,
+                            "byte": 70
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 11,
+                            "byte": 76
+                        }
+                    }
+                },
+                "object": {
+                    "a": {
+                        "range": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 5,
+                                "column": 8,
+                                "byte": 60
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 13,
+                                "byte": 65
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "valid"
+                        },
+                        "literal": "valid"
+                    },
+                    "object": {
+                        "range": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 6,
+                                "column": 13,
+                                "byte": 78
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 17,
+                                "byte": 82
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": "here"
+                        },
+                        "literal": "here"
+                    }
+                }
+            },
+            "foo": {
+                "range": {
+                    "environment": "invalid-plaintext",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 19
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 29,
+                        "byte": 43
+                    }
+                },
+                "schema": {
+                    "type": "string",
+                    "const": ""
+                },
+                "builtin": {
+                    "name": "fn::secret",
+                    "nameRange": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 19
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 29
+                        }
+                    },
+                    "argSchema": true,
+                    "arg": {
+                        "range": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "schema": {
+                            "type": "string",
+                            "const": ""
+                        },
+                        "literal": ""
+                    }
+                }
+            }
+        },
+        "properties": {
+            "bar": {
+                "value": {
+                    "a": {
+                        "value": "valid",
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-plaintext",
+                                "begin": {
+                                    "line": 5,
+                                    "column": 8,
+                                    "byte": 60
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 13,
+                                    "byte": 65
+                                }
+                            }
+                        }
+                    },
+                    "object": {
+                        "value": "here",
+                        "trace": {
+                            "def": {
+                                "environment": "invalid-plaintext",
+                                "begin": {
+                                    "line": 6,
+                                    "column": 13,
+                                    "byte": 78
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 17,
+                                    "byte": 82
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 5,
+                            "column": 5,
+                            "byte": 57
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 17,
+                            "byte": 82
+                        }
+                    }
+                }
+            },
+            "foo": {
+                "value": "",
+                "secret": true,
+                "trace": {
+                    "def": {
+                        "environment": "invalid-plaintext",
+                        "begin": {
+                            "line": 0,
+                            "column": 0,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 0,
+                            "column": 0,
+                            "byte": 0
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "bar": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "valid"
+                        },
+                        "object": {
+                            "type": "string",
+                            "const": "here"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "object"
+                    ]
+                },
+                "foo": {
+                    "type": "string",
+                    "const": ""
+                }
+            },
+            "type": "object",
+            "required": [
+                "bar",
+                "foo"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-plaintext",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-plaintext",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "invalid-plaintext",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-plaintext",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "invalid-plaintext",
+                            "trace": {
+                                "def": {
+                                    "environment": "invalid-plaintext",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "invalid-plaintext",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-plaintext"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "invalid-plaintext"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "evalJsonRedacted": {
+        "bar": {
+            "a": "valid",
+            "object": "here"
+        },
+        "foo": "[secret]"
+    },
+    "evalJSONRevealed": {
+        "bar": {
+            "a": "valid",
+            "object": "here"
+        },
+        "foo": ""
+    }
 }

--- a/eval/testdata/eval/rotate/expected.json
+++ b/eval/testdata/eval/rotate/expected.json
@@ -46,5 +46,5115 @@
             "Extra": null,
             "Path": "values.invalid.short[\"fn::rotate::swap\"]"
         }
+    ],
+    "check": {
+        "exprs": {
+            "full": {
+                "range": {
+                    "environment": "rotate",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 20
+                    },
+                    "end": {
+                        "line": 8,
+                        "column": 16,
+                        "byte": 114
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "a": {
+                            "type": "string"
+                        },
+                        "b": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "b"
+                    ]
+                },
+                "builtin": {
+                    "name": "fn::rotate",
+                    "nameRange": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 30
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            },
+                            "state": {
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "a": {
+                                                "type": "string"
+                                            },
+                                            "b": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "required": [
+                                            "a",
+                                            "b"
+                                        ]
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "type": ""
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider",
+                            "state"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 15,
+                                        "byte": 67
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 15,
+                                        "byte": 67
+                                    }
+                                },
+                                "schema": {
+                                    "type": "object"
+                                }
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 17,
+                                        "byte": 48
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 21,
+                                        "byte": 52
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "swap"
+                                },
+                                "literal": "swap"
+                            },
+                            "state": {
+                                "range": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 9,
+                                        "byte": 91
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 16,
+                                        "byte": 114
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "a": {
+                                            "type": "string",
+                                            "const": "bar1"
+                                        },
+                                        "b": {
+                                            "type": "string",
+                                            "const": "bar2"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "a",
+                                        "b"
+                                    ]
+                                },
+                                "keyRanges": {
+                                    "a": {
+                                        "environment": "rotate",
+                                        "begin": {
+                                            "line": 7,
+                                            "column": 9,
+                                            "byte": 91
+                                        },
+                                        "end": {
+                                            "line": 7,
+                                            "column": 10,
+                                            "byte": 92
+                                        }
+                                    },
+                                    "b": {
+                                        "environment": "rotate",
+                                        "begin": {
+                                            "line": 8,
+                                            "column": 9,
+                                            "byte": 107
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 10,
+                                            "byte": 108
+                                        }
+                                    }
+                                },
+                                "object": {
+                                    "a": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 12,
+                                                "byte": 94
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 16,
+                                                "byte": 98
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "bar1"
+                                        },
+                                        "literal": "bar1"
+                                    },
+                                    "b": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 8,
+                                                "column": 12,
+                                                "byte": 110
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 16,
+                                                "byte": 114
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "bar2"
+                                        },
+                                        "literal": "bar2"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "invalid": {
+                "range": {
+                    "environment": "rotate",
+                    "begin": {
+                        "line": 20,
+                        "column": 5,
+                        "byte": 269
+                    },
+                    "end": {
+                        "line": 33,
+                        "column": 18,
+                        "byte": 511
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "full": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        },
+                        "short": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "full",
+                        "short"
+                    ]
+                },
+                "keyRanges": {
+                    "full": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 20,
+                            "column": 5,
+                            "byte": 269
+                        },
+                        "end": {
+                            "line": 20,
+                            "column": 9,
+                            "byte": 273
+                        }
+                    },
+                    "short": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 28,
+                            "column": 5,
+                            "byte": 401
+                        },
+                        "end": {
+                            "line": 28,
+                            "column": 10,
+                            "byte": 406
+                        }
+                    }
+                },
+                "object": {
+                    "full": {
+                        "range": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 21,
+                                "column": 7,
+                                "byte": 281
+                            },
+                            "end": {
+                                "line": 26,
+                                "column": 18,
+                                "byte": 395
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        },
+                        "builtin": {
+                            "name": "fn::rotate",
+                            "nameRange": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 21,
+                                    "column": 7,
+                                    "byte": 281
+                                },
+                                "end": {
+                                    "line": 21,
+                                    "column": 17,
+                                    "byte": 291
+                                }
+                            },
+                            "argSchema": {
+                                "properties": {
+                                    "inputs": true,
+                                    "provider": {
+                                        "type": "string"
+                                    },
+                                    "state": {
+                                        "oneOf": [
+                                            {
+                                                "properties": {
+                                                    "a": {
+                                                        "type": "string"
+                                                    },
+                                                    "b": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "required": [
+                                                    "a",
+                                                    "b"
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "type": ""
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "inputs",
+                                    "provider",
+                                    "state"
+                                ]
+                            },
+                            "arg": {
+                                "range": {
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "object": {
+                                    "inputs": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
+                                        "schema": true
+                                    },
+                                    "provider": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 22,
+                                                "column": 19,
+                                                "byte": 311
+                                            },
+                                            "end": {
+                                                "line": 22,
+                                                "column": 23,
+                                                "byte": 315
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "swap"
+                                        },
+                                        "literal": "swap"
+                                    },
+                                    "state": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 25,
+                                                "column": 11,
+                                                "byte": 370
+                                            },
+                                            "end": {
+                                                "line": 26,
+                                                "column": 18,
+                                                "byte": 395
+                                            }
+                                        },
+                                        "schema": {
+                                            "properties": {
+                                                "a": {
+                                                    "type": "string",
+                                                    "const": "bar1"
+                                                },
+                                                "b": {
+                                                    "type": "string",
+                                                    "const": "bar2"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "a",
+                                                "b"
+                                            ]
+                                        },
+                                        "keyRanges": {
+                                            "a": {
+                                                "environment": "rotate",
+                                                "begin": {
+                                                    "line": 25,
+                                                    "column": 11,
+                                                    "byte": 370
+                                                },
+                                                "end": {
+                                                    "line": 25,
+                                                    "column": 12,
+                                                    "byte": 371
+                                                }
+                                            },
+                                            "b": {
+                                                "environment": "rotate",
+                                                "begin": {
+                                                    "line": 26,
+                                                    "column": 11,
+                                                    "byte": 388
+                                                },
+                                                "end": {
+                                                    "line": 26,
+                                                    "column": 12,
+                                                    "byte": 389
+                                                }
+                                            }
+                                        },
+                                        "object": {
+                                            "a": {
+                                                "range": {
+                                                    "environment": "rotate",
+                                                    "begin": {
+                                                        "line": 25,
+                                                        "column": 14,
+                                                        "byte": 373
+                                                    },
+                                                    "end": {
+                                                        "line": 25,
+                                                        "column": 18,
+                                                        "byte": 377
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "bar1"
+                                                },
+                                                "literal": "bar1"
+                                            },
+                                            "b": {
+                                                "range": {
+                                                    "environment": "rotate",
+                                                    "begin": {
+                                                        "line": 26,
+                                                        "column": 14,
+                                                        "byte": 391
+                                                    },
+                                                    "end": {
+                                                        "line": 26,
+                                                        "column": 18,
+                                                        "byte": 395
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "bar2"
+                                                },
+                                                "literal": "bar2"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "short": {
+                        "range": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 29,
+                                "column": 7,
+                                "byte": 414
+                            },
+                            "end": {
+                                "line": 33,
+                                "column": 18,
+                                "byte": 511
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        },
+                        "builtin": {
+                            "name": "fn::rotate::swap",
+                            "nameRange": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 29,
+                                    "column": 7,
+                                    "byte": 414
+                                },
+                                "end": {
+                                    "line": 29,
+                                    "column": 23,
+                                    "byte": 430
+                                }
+                            },
+                            "argSchema": {
+                                "properties": {
+                                    "inputs": true,
+                                    "state": {
+                                        "oneOf": [
+                                            {
+                                                "properties": {
+                                                    "a": {
+                                                        "type": "string"
+                                                    },
+                                                    "b": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "required": [
+                                                    "a",
+                                                    "b"
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "type": ""
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "inputs",
+                                    "state"
+                                ]
+                            },
+                            "arg": {
+                                "range": {
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "object": {
+                                    "inputs": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
+                                        "schema": true
+                                    },
+                                    "state": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 32,
+                                                "column": 11,
+                                                "byte": 486
+                                            },
+                                            "end": {
+                                                "line": 33,
+                                                "column": 18,
+                                                "byte": 511
+                                            }
+                                        },
+                                        "schema": {
+                                            "properties": {
+                                                "a": {
+                                                    "type": "string",
+                                                    "const": "bar1"
+                                                },
+                                                "b": {
+                                                    "type": "string",
+                                                    "const": "bar2"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "a",
+                                                "b"
+                                            ]
+                                        },
+                                        "keyRanges": {
+                                            "a": {
+                                                "environment": "rotate",
+                                                "begin": {
+                                                    "line": 32,
+                                                    "column": 11,
+                                                    "byte": 486
+                                                },
+                                                "end": {
+                                                    "line": 32,
+                                                    "column": 12,
+                                                    "byte": 487
+                                                }
+                                            },
+                                            "b": {
+                                                "environment": "rotate",
+                                                "begin": {
+                                                    "line": 33,
+                                                    "column": 11,
+                                                    "byte": 504
+                                                },
+                                                "end": {
+                                                    "line": 33,
+                                                    "column": 12,
+                                                    "byte": 505
+                                                }
+                                            }
+                                        },
+                                        "object": {
+                                            "a": {
+                                                "range": {
+                                                    "environment": "rotate",
+                                                    "begin": {
+                                                        "line": 32,
+                                                        "column": 14,
+                                                        "byte": 489
+                                                    },
+                                                    "end": {
+                                                        "line": 32,
+                                                        "column": 18,
+                                                        "byte": 493
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "bar1"
+                                                },
+                                                "literal": "bar1"
+                                            },
+                                            "b": {
+                                                "range": {
+                                                    "environment": "rotate",
+                                                    "begin": {
+                                                        "line": 33,
+                                                        "column": 14,
+                                                        "byte": 507
+                                                    },
+                                                    "end": {
+                                                        "line": 33,
+                                                        "column": 18,
+                                                        "byte": 511
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "bar2"
+                                                },
+                                                "literal": "bar2"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "reference": {
+                "range": {
+                    "environment": "rotate",
+                    "begin": {
+                        "line": 17,
+                        "column": 5,
+                        "byte": 226
+                    },
+                    "end": {
+                        "line": 17,
+                        "column": 31,
+                        "byte": 252
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "test": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "test"
+                    ]
+                },
+                "keyRanges": {
+                    "test": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 17,
+                            "column": 5,
+                            "byte": 226
+                        },
+                        "end": {
+                            "line": 17,
+                            "column": 9,
+                            "byte": 230
+                        }
+                    }
+                },
+                "object": {
+                    "test": {
+                        "range": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 17,
+                                "column": 11,
+                                "byte": 232
+                            },
+                            "end": {
+                                "line": 17,
+                                "column": 31,
+                                "byte": 252
+                            }
+                        },
+                        "schema": {
+                            "type": "string"
+                        },
+                        "interpolate": [
+                            {
+                                "value": [
+                                    {
+                                        "key": "full",
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 13,
+                                                "byte": 234
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 17,
+                                                "byte": 238
+                                            }
+                                        },
+                                        "value": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 3,
+                                                "column": 5,
+                                                "byte": 20
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 16,
+                                                "byte": 114
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "key": "a",
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 17,
+                                                "byte": 238
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 19,
+                                                "byte": 240
+                                            }
+                                        },
+                                        "value": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 11,
+                                                "byte": 232
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 31,
+                                                "byte": 252
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "text": " ",
+                                "value": [
+                                    {
+                                        "key": "short",
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 23,
+                                                "byte": 244
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 28,
+                                                "byte": 249
+                                            }
+                                        },
+                                        "value": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 10,
+                                                "column": 5,
+                                                "byte": 128
+                                            },
+                                            "end": {
+                                                "line": 14,
+                                                "column": 16,
+                                                "byte": 207
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "key": "b",
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 28,
+                                                "byte": 249
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 30,
+                                                "byte": 251
+                                            }
+                                        },
+                                        "value": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 11,
+                                                "byte": 232
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 31,
+                                                "byte": 252
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "short": {
+                "range": {
+                    "environment": "rotate",
+                    "begin": {
+                        "line": 10,
+                        "column": 5,
+                        "byte": 128
+                    },
+                    "end": {
+                        "line": 14,
+                        "column": 16,
+                        "byte": 207
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "a": {
+                            "type": "string"
+                        },
+                        "b": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "b"
+                    ]
+                },
+                "builtin": {
+                    "name": "fn::rotate::swap",
+                    "nameRange": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 10,
+                            "column": 5,
+                            "byte": 128
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 21,
+                            "byte": 144
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "state": {
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "a": {
+                                                "type": "string"
+                                            },
+                                            "b": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "required": [
+                                            "a",
+                                            "b"
+                                        ]
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "type": ""
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "state"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 15,
+                                        "byte": 160
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 15,
+                                        "byte": 160
+                                    }
+                                },
+                                "schema": {
+                                    "type": "object"
+                                }
+                            },
+                            "state": {
+                                "range": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 13,
+                                        "column": 9,
+                                        "byte": 184
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 16,
+                                        "byte": 207
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "a": {
+                                            "type": "string",
+                                            "const": "bar1"
+                                        },
+                                        "b": {
+                                            "type": "string",
+                                            "const": "bar2"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "a",
+                                        "b"
+                                    ]
+                                },
+                                "keyRanges": {
+                                    "a": {
+                                        "environment": "rotate",
+                                        "begin": {
+                                            "line": 13,
+                                            "column": 9,
+                                            "byte": 184
+                                        },
+                                        "end": {
+                                            "line": 13,
+                                            "column": 10,
+                                            "byte": 185
+                                        }
+                                    },
+                                    "b": {
+                                        "environment": "rotate",
+                                        "begin": {
+                                            "line": 14,
+                                            "column": 9,
+                                            "byte": 200
+                                        },
+                                        "end": {
+                                            "line": 14,
+                                            "column": 10,
+                                            "byte": 201
+                                        }
+                                    }
+                                },
+                                "object": {
+                                    "a": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 13,
+                                                "column": 12,
+                                                "byte": 187
+                                            },
+                                            "end": {
+                                                "line": 13,
+                                                "column": 16,
+                                                "byte": 191
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "bar1"
+                                        },
+                                        "literal": "bar1"
+                                    },
+                                    "b": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 14,
+                                                "column": 12,
+                                                "byte": 203
+                                            },
+                                            "end": {
+                                                "line": 14,
+                                                "column": 16,
+                                                "byte": 207
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "bar2"
+                                        },
+                                        "literal": "bar2"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "full": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 16,
+                            "byte": 114
+                        }
+                    }
+                }
+            },
+            "invalid": {
+                "value": {
+                    "full": {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 21,
+                                    "column": 7,
+                                    "byte": 281
+                                },
+                                "end": {
+                                    "line": 26,
+                                    "column": 18,
+                                    "byte": 395
+                                }
+                            }
+                        }
+                    },
+                    "short": {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 29,
+                                    "column": 7,
+                                    "byte": 414
+                                },
+                                "end": {
+                                    "line": 33,
+                                    "column": 18,
+                                    "byte": 511
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 20,
+                            "column": 5,
+                            "byte": 269
+                        },
+                        "end": {
+                            "line": 33,
+                            "column": 18,
+                            "byte": 511
+                        }
+                    }
+                }
+            },
+            "reference": {
+                "value": {
+                    "test": {
+                        "value": "[unknown]",
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 17,
+                                    "column": 11,
+                                    "byte": 232
+                                },
+                                "end": {
+                                    "line": 17,
+                                    "column": 31,
+                                    "byte": 252
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 17,
+                            "column": 5,
+                            "byte": 226
+                        },
+                        "end": {
+                            "line": 17,
+                            "column": 31,
+                            "byte": 252
+                        }
+                    }
+                }
+            },
+            "short": {
+                "unknown": true,
+                "trace": {
+                    "def": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 10,
+                            "column": 5,
+                            "byte": 128
+                        },
+                        "end": {
+                            "line": 14,
+                            "column": 16,
+                            "byte": 207
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "full": {
+                    "properties": {
+                        "a": {
+                            "type": "string"
+                        },
+                        "b": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "b"
+                    ]
+                },
+                "invalid": {
+                    "properties": {
+                        "full": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        },
+                        "short": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "full",
+                        "short"
+                    ]
+                },
+                "reference": {
+                    "properties": {
+                        "test": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "test"
+                    ]
+                },
+                "short": {
+                    "properties": {
+                        "a": {
+                            "type": "string"
+                        },
+                        "b": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "b"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "full",
+                "invalid",
+                "reference",
+                "short"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "rotate",
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "rotate",
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "rotate"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "rotate"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "checkJson": {
+        "full": "[unknown]",
+        "invalid": {
+            "full": "[unknown]",
+            "short": "[unknown]"
+        },
+        "reference": {
+            "test": "[unknown]"
+        },
+        "short": "[unknown]"
+    },
+    "eval": {
+        "exprs": {
+            "full": {
+                "range": {
+                    "environment": "rotate",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 20
+                    },
+                    "end": {
+                        "line": 8,
+                        "column": 16,
+                        "byte": 114
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "bar1"
+                        },
+                        "b": {
+                            "type": "string",
+                            "const": "bar2"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "b"
+                    ]
+                },
+                "builtin": {
+                    "name": "fn::rotate",
+                    "nameRange": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 30
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            },
+                            "state": {
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "a": {
+                                                "type": "string"
+                                            },
+                                            "b": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "required": [
+                                            "a",
+                                            "b"
+                                        ]
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "type": ""
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider",
+                            "state"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 15,
+                                        "byte": 67
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 15,
+                                        "byte": 67
+                                    }
+                                },
+                                "schema": {
+                                    "type": "object"
+                                }
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 17,
+                                        "byte": 48
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 21,
+                                        "byte": 52
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "swap"
+                                },
+                                "literal": "swap"
+                            },
+                            "state": {
+                                "range": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 9,
+                                        "byte": 91
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 16,
+                                        "byte": 114
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "a": {
+                                            "type": "string",
+                                            "const": "bar1"
+                                        },
+                                        "b": {
+                                            "type": "string",
+                                            "const": "bar2"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "a",
+                                        "b"
+                                    ]
+                                },
+                                "keyRanges": {
+                                    "a": {
+                                        "environment": "rotate",
+                                        "begin": {
+                                            "line": 7,
+                                            "column": 9,
+                                            "byte": 91
+                                        },
+                                        "end": {
+                                            "line": 7,
+                                            "column": 10,
+                                            "byte": 92
+                                        }
+                                    },
+                                    "b": {
+                                        "environment": "rotate",
+                                        "begin": {
+                                            "line": 8,
+                                            "column": 9,
+                                            "byte": 107
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 10,
+                                            "byte": 108
+                                        }
+                                    }
+                                },
+                                "object": {
+                                    "a": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 12,
+                                                "byte": 94
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 16,
+                                                "byte": 98
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "bar1"
+                                        },
+                                        "literal": "bar1"
+                                    },
+                                    "b": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 8,
+                                                "column": 12,
+                                                "byte": 110
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 16,
+                                                "byte": 114
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "bar2"
+                                        },
+                                        "literal": "bar2"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "invalid": {
+                "range": {
+                    "environment": "rotate",
+                    "begin": {
+                        "line": 20,
+                        "column": 5,
+                        "byte": 269
+                    },
+                    "end": {
+                        "line": 33,
+                        "column": 18,
+                        "byte": 511
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "full": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        },
+                        "short": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "full",
+                        "short"
+                    ]
+                },
+                "keyRanges": {
+                    "full": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 20,
+                            "column": 5,
+                            "byte": 269
+                        },
+                        "end": {
+                            "line": 20,
+                            "column": 9,
+                            "byte": 273
+                        }
+                    },
+                    "short": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 28,
+                            "column": 5,
+                            "byte": 401
+                        },
+                        "end": {
+                            "line": 28,
+                            "column": 10,
+                            "byte": 406
+                        }
+                    }
+                },
+                "object": {
+                    "full": {
+                        "range": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 21,
+                                "column": 7,
+                                "byte": 281
+                            },
+                            "end": {
+                                "line": 26,
+                                "column": 18,
+                                "byte": 395
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        },
+                        "builtin": {
+                            "name": "fn::rotate",
+                            "nameRange": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 21,
+                                    "column": 7,
+                                    "byte": 281
+                                },
+                                "end": {
+                                    "line": 21,
+                                    "column": 17,
+                                    "byte": 291
+                                }
+                            },
+                            "argSchema": {
+                                "properties": {
+                                    "inputs": true,
+                                    "provider": {
+                                        "type": "string"
+                                    },
+                                    "state": {
+                                        "oneOf": [
+                                            {
+                                                "properties": {
+                                                    "a": {
+                                                        "type": "string"
+                                                    },
+                                                    "b": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "required": [
+                                                    "a",
+                                                    "b"
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "type": ""
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "inputs",
+                                    "provider",
+                                    "state"
+                                ]
+                            },
+                            "arg": {
+                                "range": {
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "object": {
+                                    "inputs": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
+                                        "schema": true
+                                    },
+                                    "provider": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 22,
+                                                "column": 19,
+                                                "byte": 311
+                                            },
+                                            "end": {
+                                                "line": 22,
+                                                "column": 23,
+                                                "byte": 315
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "swap"
+                                        },
+                                        "literal": "swap"
+                                    },
+                                    "state": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 25,
+                                                "column": 11,
+                                                "byte": 370
+                                            },
+                                            "end": {
+                                                "line": 26,
+                                                "column": 18,
+                                                "byte": 395
+                                            }
+                                        },
+                                        "schema": {
+                                            "properties": {
+                                                "a": {
+                                                    "type": "string",
+                                                    "const": "bar1"
+                                                },
+                                                "b": {
+                                                    "type": "string",
+                                                    "const": "bar2"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "a",
+                                                "b"
+                                            ]
+                                        },
+                                        "keyRanges": {
+                                            "a": {
+                                                "environment": "rotate",
+                                                "begin": {
+                                                    "line": 25,
+                                                    "column": 11,
+                                                    "byte": 370
+                                                },
+                                                "end": {
+                                                    "line": 25,
+                                                    "column": 12,
+                                                    "byte": 371
+                                                }
+                                            },
+                                            "b": {
+                                                "environment": "rotate",
+                                                "begin": {
+                                                    "line": 26,
+                                                    "column": 11,
+                                                    "byte": 388
+                                                },
+                                                "end": {
+                                                    "line": 26,
+                                                    "column": 12,
+                                                    "byte": 389
+                                                }
+                                            }
+                                        },
+                                        "object": {
+                                            "a": {
+                                                "range": {
+                                                    "environment": "rotate",
+                                                    "begin": {
+                                                        "line": 25,
+                                                        "column": 14,
+                                                        "byte": 373
+                                                    },
+                                                    "end": {
+                                                        "line": 25,
+                                                        "column": 18,
+                                                        "byte": 377
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "bar1"
+                                                },
+                                                "literal": "bar1"
+                                            },
+                                            "b": {
+                                                "range": {
+                                                    "environment": "rotate",
+                                                    "begin": {
+                                                        "line": 26,
+                                                        "column": 14,
+                                                        "byte": 391
+                                                    },
+                                                    "end": {
+                                                        "line": 26,
+                                                        "column": 18,
+                                                        "byte": 395
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "bar2"
+                                                },
+                                                "literal": "bar2"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "short": {
+                        "range": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 29,
+                                "column": 7,
+                                "byte": 414
+                            },
+                            "end": {
+                                "line": 33,
+                                "column": 18,
+                                "byte": 511
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        },
+                        "builtin": {
+                            "name": "fn::rotate::swap",
+                            "nameRange": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 29,
+                                    "column": 7,
+                                    "byte": 414
+                                },
+                                "end": {
+                                    "line": 29,
+                                    "column": 23,
+                                    "byte": 430
+                                }
+                            },
+                            "argSchema": {
+                                "properties": {
+                                    "inputs": true,
+                                    "state": {
+                                        "oneOf": [
+                                            {
+                                                "properties": {
+                                                    "a": {
+                                                        "type": "string"
+                                                    },
+                                                    "b": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "required": [
+                                                    "a",
+                                                    "b"
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "type": ""
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "inputs",
+                                    "state"
+                                ]
+                            },
+                            "arg": {
+                                "range": {
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "object": {
+                                    "inputs": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
+                                        "schema": true
+                                    },
+                                    "state": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 32,
+                                                "column": 11,
+                                                "byte": 486
+                                            },
+                                            "end": {
+                                                "line": 33,
+                                                "column": 18,
+                                                "byte": 511
+                                            }
+                                        },
+                                        "schema": {
+                                            "properties": {
+                                                "a": {
+                                                    "type": "string",
+                                                    "const": "bar1"
+                                                },
+                                                "b": {
+                                                    "type": "string",
+                                                    "const": "bar2"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "a",
+                                                "b"
+                                            ]
+                                        },
+                                        "keyRanges": {
+                                            "a": {
+                                                "environment": "rotate",
+                                                "begin": {
+                                                    "line": 32,
+                                                    "column": 11,
+                                                    "byte": 486
+                                                },
+                                                "end": {
+                                                    "line": 32,
+                                                    "column": 12,
+                                                    "byte": 487
+                                                }
+                                            },
+                                            "b": {
+                                                "environment": "rotate",
+                                                "begin": {
+                                                    "line": 33,
+                                                    "column": 11,
+                                                    "byte": 504
+                                                },
+                                                "end": {
+                                                    "line": 33,
+                                                    "column": 12,
+                                                    "byte": 505
+                                                }
+                                            }
+                                        },
+                                        "object": {
+                                            "a": {
+                                                "range": {
+                                                    "environment": "rotate",
+                                                    "begin": {
+                                                        "line": 32,
+                                                        "column": 14,
+                                                        "byte": 489
+                                                    },
+                                                    "end": {
+                                                        "line": 32,
+                                                        "column": 18,
+                                                        "byte": 493
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "bar1"
+                                                },
+                                                "literal": "bar1"
+                                            },
+                                            "b": {
+                                                "range": {
+                                                    "environment": "rotate",
+                                                    "begin": {
+                                                        "line": 33,
+                                                        "column": 14,
+                                                        "byte": 507
+                                                    },
+                                                    "end": {
+                                                        "line": 33,
+                                                        "column": 18,
+                                                        "byte": 511
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "bar2"
+                                                },
+                                                "literal": "bar2"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "reference": {
+                "range": {
+                    "environment": "rotate",
+                    "begin": {
+                        "line": 17,
+                        "column": 5,
+                        "byte": 226
+                    },
+                    "end": {
+                        "line": 17,
+                        "column": 31,
+                        "byte": 252
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "test": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "test"
+                    ]
+                },
+                "keyRanges": {
+                    "test": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 17,
+                            "column": 5,
+                            "byte": 226
+                        },
+                        "end": {
+                            "line": 17,
+                            "column": 9,
+                            "byte": 230
+                        }
+                    }
+                },
+                "object": {
+                    "test": {
+                        "range": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 17,
+                                "column": 11,
+                                "byte": 232
+                            },
+                            "end": {
+                                "line": 17,
+                                "column": 31,
+                                "byte": 252
+                            }
+                        },
+                        "schema": {
+                            "type": "string"
+                        },
+                        "interpolate": [
+                            {
+                                "value": [
+                                    {
+                                        "key": "full",
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 13,
+                                                "byte": 234
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 17,
+                                                "byte": 238
+                                            }
+                                        },
+                                        "value": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 3,
+                                                "column": 5,
+                                                "byte": 20
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 16,
+                                                "byte": 114
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "key": "a",
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 17,
+                                                "byte": 238
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 19,
+                                                "byte": 240
+                                            }
+                                        },
+                                        "value": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 3,
+                                                "column": 5,
+                                                "byte": 20
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 16,
+                                                "byte": 114
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "text": " ",
+                                "value": [
+                                    {
+                                        "key": "short",
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 23,
+                                                "byte": 244
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 28,
+                                                "byte": 249
+                                            }
+                                        },
+                                        "value": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 10,
+                                                "column": 5,
+                                                "byte": 128
+                                            },
+                                            "end": {
+                                                "line": 14,
+                                                "column": 16,
+                                                "byte": 207
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "key": "b",
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 28,
+                                                "byte": 249
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 30,
+                                                "byte": 251
+                                            }
+                                        },
+                                        "value": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 10,
+                                                "column": 5,
+                                                "byte": 128
+                                            },
+                                            "end": {
+                                                "line": 14,
+                                                "column": 16,
+                                                "byte": 207
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "short": {
+                "range": {
+                    "environment": "rotate",
+                    "begin": {
+                        "line": 10,
+                        "column": 5,
+                        "byte": 128
+                    },
+                    "end": {
+                        "line": 14,
+                        "column": 16,
+                        "byte": 207
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "bar1"
+                        },
+                        "b": {
+                            "type": "string",
+                            "const": "bar2"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "b"
+                    ]
+                },
+                "builtin": {
+                    "name": "fn::rotate::swap",
+                    "nameRange": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 10,
+                            "column": 5,
+                            "byte": 128
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 21,
+                            "byte": 144
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "state": {
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "a": {
+                                                "type": "string"
+                                            },
+                                            "b": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "required": [
+                                            "a",
+                                            "b"
+                                        ]
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "type": ""
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "state"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 15,
+                                        "byte": 160
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 15,
+                                        "byte": 160
+                                    }
+                                },
+                                "schema": {
+                                    "type": "object"
+                                }
+                            },
+                            "state": {
+                                "range": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 13,
+                                        "column": 9,
+                                        "byte": 184
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 16,
+                                        "byte": 207
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "a": {
+                                            "type": "string",
+                                            "const": "bar1"
+                                        },
+                                        "b": {
+                                            "type": "string",
+                                            "const": "bar2"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "a",
+                                        "b"
+                                    ]
+                                },
+                                "keyRanges": {
+                                    "a": {
+                                        "environment": "rotate",
+                                        "begin": {
+                                            "line": 13,
+                                            "column": 9,
+                                            "byte": 184
+                                        },
+                                        "end": {
+                                            "line": 13,
+                                            "column": 10,
+                                            "byte": 185
+                                        }
+                                    },
+                                    "b": {
+                                        "environment": "rotate",
+                                        "begin": {
+                                            "line": 14,
+                                            "column": 9,
+                                            "byte": 200
+                                        },
+                                        "end": {
+                                            "line": 14,
+                                            "column": 10,
+                                            "byte": 201
+                                        }
+                                    }
+                                },
+                                "object": {
+                                    "a": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 13,
+                                                "column": 12,
+                                                "byte": 187
+                                            },
+                                            "end": {
+                                                "line": 13,
+                                                "column": 16,
+                                                "byte": 191
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "bar1"
+                                        },
+                                        "literal": "bar1"
+                                    },
+                                    "b": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 14,
+                                                "column": 12,
+                                                "byte": 203
+                                            },
+                                            "end": {
+                                                "line": 14,
+                                                "column": 16,
+                                                "byte": 207
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "bar2"
+                                        },
+                                        "literal": "bar2"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "full": {
+                "value": {
+                    "a": {
+                        "value": "bar1",
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 20
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 16,
+                                    "byte": 114
+                                }
+                            }
+                        }
+                    },
+                    "b": {
+                        "value": "bar2",
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 20
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 16,
+                                    "byte": 114
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 16,
+                            "byte": 114
+                        }
+                    }
+                }
+            },
+            "invalid": {
+                "value": {
+                    "full": {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 21,
+                                    "column": 7,
+                                    "byte": 281
+                                },
+                                "end": {
+                                    "line": 26,
+                                    "column": 18,
+                                    "byte": 395
+                                }
+                            }
+                        }
+                    },
+                    "short": {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 29,
+                                    "column": 7,
+                                    "byte": 414
+                                },
+                                "end": {
+                                    "line": 33,
+                                    "column": 18,
+                                    "byte": 511
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 20,
+                            "column": 5,
+                            "byte": 269
+                        },
+                        "end": {
+                            "line": 33,
+                            "column": 18,
+                            "byte": 511
+                        }
+                    }
+                }
+            },
+            "reference": {
+                "value": {
+                    "test": {
+                        "value": "bar1 bar2",
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 17,
+                                    "column": 11,
+                                    "byte": 232
+                                },
+                                "end": {
+                                    "line": 17,
+                                    "column": 31,
+                                    "byte": 252
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 17,
+                            "column": 5,
+                            "byte": 226
+                        },
+                        "end": {
+                            "line": 17,
+                            "column": 31,
+                            "byte": 252
+                        }
+                    }
+                }
+            },
+            "short": {
+                "value": {
+                    "a": {
+                        "value": "bar1",
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 5,
+                                    "byte": 128
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "column": 16,
+                                    "byte": 207
+                                }
+                            }
+                        }
+                    },
+                    "b": {
+                        "value": "bar2",
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 5,
+                                    "byte": 128
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "column": 16,
+                                    "byte": 207
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 10,
+                            "column": 5,
+                            "byte": 128
+                        },
+                        "end": {
+                            "line": 14,
+                            "column": 16,
+                            "byte": 207
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "full": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "bar1"
+                        },
+                        "b": {
+                            "type": "string",
+                            "const": "bar2"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "b"
+                    ]
+                },
+                "invalid": {
+                    "properties": {
+                        "full": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        },
+                        "short": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "full",
+                        "short"
+                    ]
+                },
+                "reference": {
+                    "properties": {
+                        "test": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "test"
+                    ]
+                },
+                "short": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "bar1"
+                        },
+                        "b": {
+                            "type": "string",
+                            "const": "bar2"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "b"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "full",
+                "invalid",
+                "reference",
+                "short"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "rotate",
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "rotate",
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "rotate"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "rotate"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "evalJsonRedacted": {
+        "full": {
+            "a": "bar1",
+            "b": "bar2"
+        },
+        "invalid": {
+            "full": "[unknown]",
+            "short": "[unknown]"
+        },
+        "reference": {
+            "test": "bar1 bar2"
+        },
+        "short": {
+            "a": "bar1",
+            "b": "bar2"
+        }
+    },
+    "evalJSONRevealed": {
+        "full": {
+            "a": "bar1",
+            "b": "bar2"
+        },
+        "invalid": {
+            "full": "[unknown]",
+            "short": "[unknown]"
+        },
+        "reference": {
+            "test": "bar1 bar2"
+        },
+        "short": {
+            "a": "bar1",
+            "b": "bar2"
+        }
+    },
+    "rotate": {
+        "exprs": {
+            "full": {
+                "range": {
+                    "environment": "rotate",
+                    "begin": {
+                        "line": 3,
+                        "column": 5,
+                        "byte": 20
+                    },
+                    "end": {
+                        "line": 8,
+                        "column": 16,
+                        "byte": 114
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "bar2"
+                        },
+                        "b": {
+                            "type": "string",
+                            "const": "bar1"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "b"
+                    ]
+                },
+                "builtin": {
+                    "name": "fn::rotate",
+                    "nameRange": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 15,
+                            "byte": 30
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "provider": {
+                                "type": "string"
+                            },
+                            "state": {
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "a": {
+                                                "type": "string"
+                                            },
+                                            "b": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "required": [
+                                            "a",
+                                            "b"
+                                        ]
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "type": ""
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "provider",
+                            "state"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 5,
+                                        "column": 15,
+                                        "byte": 67
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 15,
+                                        "byte": 67
+                                    }
+                                },
+                                "schema": {
+                                    "type": "object"
+                                }
+                            },
+                            "provider": {
+                                "range": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 4,
+                                        "column": 17,
+                                        "byte": 48
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 21,
+                                        "byte": 52
+                                    }
+                                },
+                                "schema": {
+                                    "type": "string",
+                                    "const": "swap"
+                                },
+                                "literal": "swap"
+                            },
+                            "state": {
+                                "range": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 7,
+                                        "column": 9,
+                                        "byte": 91
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 16,
+                                        "byte": 114
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "a": {
+                                            "type": "string",
+                                            "const": "bar1"
+                                        },
+                                        "b": {
+                                            "type": "string",
+                                            "const": "bar2"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "a",
+                                        "b"
+                                    ]
+                                },
+                                "keyRanges": {
+                                    "a": {
+                                        "environment": "rotate",
+                                        "begin": {
+                                            "line": 7,
+                                            "column": 9,
+                                            "byte": 91
+                                        },
+                                        "end": {
+                                            "line": 7,
+                                            "column": 10,
+                                            "byte": 92
+                                        }
+                                    },
+                                    "b": {
+                                        "environment": "rotate",
+                                        "begin": {
+                                            "line": 8,
+                                            "column": 9,
+                                            "byte": 107
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 10,
+                                            "byte": 108
+                                        }
+                                    }
+                                },
+                                "object": {
+                                    "a": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 7,
+                                                "column": 12,
+                                                "byte": 94
+                                            },
+                                            "end": {
+                                                "line": 7,
+                                                "column": 16,
+                                                "byte": 98
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "bar1"
+                                        },
+                                        "literal": "bar1"
+                                    },
+                                    "b": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 8,
+                                                "column": 12,
+                                                "byte": 110
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 16,
+                                                "byte": 114
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "bar2"
+                                        },
+                                        "literal": "bar2"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "invalid": {
+                "range": {
+                    "environment": "rotate",
+                    "begin": {
+                        "line": 20,
+                        "column": 5,
+                        "byte": 269
+                    },
+                    "end": {
+                        "line": 33,
+                        "column": 18,
+                        "byte": 511
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "full": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        },
+                        "short": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "full",
+                        "short"
+                    ]
+                },
+                "keyRanges": {
+                    "full": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 20,
+                            "column": 5,
+                            "byte": 269
+                        },
+                        "end": {
+                            "line": 20,
+                            "column": 9,
+                            "byte": 273
+                        }
+                    },
+                    "short": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 28,
+                            "column": 5,
+                            "byte": 401
+                        },
+                        "end": {
+                            "line": 28,
+                            "column": 10,
+                            "byte": 406
+                        }
+                    }
+                },
+                "object": {
+                    "full": {
+                        "range": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 21,
+                                "column": 7,
+                                "byte": 281
+                            },
+                            "end": {
+                                "line": 26,
+                                "column": 18,
+                                "byte": 395
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        },
+                        "builtin": {
+                            "name": "fn::rotate",
+                            "nameRange": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 21,
+                                    "column": 7,
+                                    "byte": 281
+                                },
+                                "end": {
+                                    "line": 21,
+                                    "column": 17,
+                                    "byte": 291
+                                }
+                            },
+                            "argSchema": {
+                                "properties": {
+                                    "inputs": true,
+                                    "provider": {
+                                        "type": "string"
+                                    },
+                                    "state": {
+                                        "oneOf": [
+                                            {
+                                                "properties": {
+                                                    "a": {
+                                                        "type": "string"
+                                                    },
+                                                    "b": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "required": [
+                                                    "a",
+                                                    "b"
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "type": ""
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "inputs",
+                                    "provider",
+                                    "state"
+                                ]
+                            },
+                            "arg": {
+                                "range": {
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "object": {
+                                    "inputs": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
+                                        "schema": true
+                                    },
+                                    "provider": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 22,
+                                                "column": 19,
+                                                "byte": 311
+                                            },
+                                            "end": {
+                                                "line": 22,
+                                                "column": 23,
+                                                "byte": 315
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "swap"
+                                        },
+                                        "literal": "swap"
+                                    },
+                                    "state": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 25,
+                                                "column": 11,
+                                                "byte": 370
+                                            },
+                                            "end": {
+                                                "line": 26,
+                                                "column": 18,
+                                                "byte": 395
+                                            }
+                                        },
+                                        "schema": {
+                                            "properties": {
+                                                "a": {
+                                                    "type": "string",
+                                                    "const": "bar1"
+                                                },
+                                                "b": {
+                                                    "type": "string",
+                                                    "const": "bar2"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "a",
+                                                "b"
+                                            ]
+                                        },
+                                        "keyRanges": {
+                                            "a": {
+                                                "environment": "rotate",
+                                                "begin": {
+                                                    "line": 25,
+                                                    "column": 11,
+                                                    "byte": 370
+                                                },
+                                                "end": {
+                                                    "line": 25,
+                                                    "column": 12,
+                                                    "byte": 371
+                                                }
+                                            },
+                                            "b": {
+                                                "environment": "rotate",
+                                                "begin": {
+                                                    "line": 26,
+                                                    "column": 11,
+                                                    "byte": 388
+                                                },
+                                                "end": {
+                                                    "line": 26,
+                                                    "column": 12,
+                                                    "byte": 389
+                                                }
+                                            }
+                                        },
+                                        "object": {
+                                            "a": {
+                                                "range": {
+                                                    "environment": "rotate",
+                                                    "begin": {
+                                                        "line": 25,
+                                                        "column": 14,
+                                                        "byte": 373
+                                                    },
+                                                    "end": {
+                                                        "line": 25,
+                                                        "column": 18,
+                                                        "byte": 377
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "bar1"
+                                                },
+                                                "literal": "bar1"
+                                            },
+                                            "b": {
+                                                "range": {
+                                                    "environment": "rotate",
+                                                    "begin": {
+                                                        "line": 26,
+                                                        "column": 14,
+                                                        "byte": 391
+                                                    },
+                                                    "end": {
+                                                        "line": 26,
+                                                        "column": 18,
+                                                        "byte": 395
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "bar2"
+                                                },
+                                                "literal": "bar2"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "short": {
+                        "range": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 29,
+                                "column": 7,
+                                "byte": 414
+                            },
+                            "end": {
+                                "line": 33,
+                                "column": 18,
+                                "byte": 511
+                            }
+                        },
+                        "schema": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        },
+                        "builtin": {
+                            "name": "fn::rotate::swap",
+                            "nameRange": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 29,
+                                    "column": 7,
+                                    "byte": 414
+                                },
+                                "end": {
+                                    "line": 29,
+                                    "column": 23,
+                                    "byte": 430
+                                }
+                            },
+                            "argSchema": {
+                                "properties": {
+                                    "inputs": true,
+                                    "state": {
+                                        "oneOf": [
+                                            {
+                                                "properties": {
+                                                    "a": {
+                                                        "type": "string"
+                                                    },
+                                                    "b": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "required": [
+                                                    "a",
+                                                    "b"
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "type": ""
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "inputs",
+                                    "state"
+                                ]
+                            },
+                            "arg": {
+                                "range": {
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                },
+                                "object": {
+                                    "inputs": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        },
+                                        "schema": true
+                                    },
+                                    "state": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 32,
+                                                "column": 11,
+                                                "byte": 486
+                                            },
+                                            "end": {
+                                                "line": 33,
+                                                "column": 18,
+                                                "byte": 511
+                                            }
+                                        },
+                                        "schema": {
+                                            "properties": {
+                                                "a": {
+                                                    "type": "string",
+                                                    "const": "bar1"
+                                                },
+                                                "b": {
+                                                    "type": "string",
+                                                    "const": "bar2"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "required": [
+                                                "a",
+                                                "b"
+                                            ]
+                                        },
+                                        "keyRanges": {
+                                            "a": {
+                                                "environment": "rotate",
+                                                "begin": {
+                                                    "line": 32,
+                                                    "column": 11,
+                                                    "byte": 486
+                                                },
+                                                "end": {
+                                                    "line": 32,
+                                                    "column": 12,
+                                                    "byte": 487
+                                                }
+                                            },
+                                            "b": {
+                                                "environment": "rotate",
+                                                "begin": {
+                                                    "line": 33,
+                                                    "column": 11,
+                                                    "byte": 504
+                                                },
+                                                "end": {
+                                                    "line": 33,
+                                                    "column": 12,
+                                                    "byte": 505
+                                                }
+                                            }
+                                        },
+                                        "object": {
+                                            "a": {
+                                                "range": {
+                                                    "environment": "rotate",
+                                                    "begin": {
+                                                        "line": 32,
+                                                        "column": 14,
+                                                        "byte": 489
+                                                    },
+                                                    "end": {
+                                                        "line": 32,
+                                                        "column": 18,
+                                                        "byte": 493
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "bar1"
+                                                },
+                                                "literal": "bar1"
+                                            },
+                                            "b": {
+                                                "range": {
+                                                    "environment": "rotate",
+                                                    "begin": {
+                                                        "line": 33,
+                                                        "column": 14,
+                                                        "byte": 507
+                                                    },
+                                                    "end": {
+                                                        "line": 33,
+                                                        "column": 18,
+                                                        "byte": 511
+                                                    }
+                                                },
+                                                "schema": {
+                                                    "type": "string",
+                                                    "const": "bar2"
+                                                },
+                                                "literal": "bar2"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "reference": {
+                "range": {
+                    "environment": "rotate",
+                    "begin": {
+                        "line": 17,
+                        "column": 5,
+                        "byte": 226
+                    },
+                    "end": {
+                        "line": 17,
+                        "column": 31,
+                        "byte": 252
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "test": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "test"
+                    ]
+                },
+                "keyRanges": {
+                    "test": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 17,
+                            "column": 5,
+                            "byte": 226
+                        },
+                        "end": {
+                            "line": 17,
+                            "column": 9,
+                            "byte": 230
+                        }
+                    }
+                },
+                "object": {
+                    "test": {
+                        "range": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 17,
+                                "column": 11,
+                                "byte": 232
+                            },
+                            "end": {
+                                "line": 17,
+                                "column": 31,
+                                "byte": 252
+                            }
+                        },
+                        "schema": {
+                            "type": "string"
+                        },
+                        "interpolate": [
+                            {
+                                "value": [
+                                    {
+                                        "key": "full",
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 13,
+                                                "byte": 234
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 17,
+                                                "byte": 238
+                                            }
+                                        },
+                                        "value": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 3,
+                                                "column": 5,
+                                                "byte": 20
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 16,
+                                                "byte": 114
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "key": "a",
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 17,
+                                                "byte": 238
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 19,
+                                                "byte": 240
+                                            }
+                                        },
+                                        "value": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 3,
+                                                "column": 5,
+                                                "byte": 20
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 16,
+                                                "byte": 114
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "text": " ",
+                                "value": [
+                                    {
+                                        "key": "short",
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 23,
+                                                "byte": 244
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 28,
+                                                "byte": 249
+                                            }
+                                        },
+                                        "value": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 10,
+                                                "column": 5,
+                                                "byte": 128
+                                            },
+                                            "end": {
+                                                "line": 14,
+                                                "column": 16,
+                                                "byte": 207
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "key": "b",
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 17,
+                                                "column": 28,
+                                                "byte": 249
+                                            },
+                                            "end": {
+                                                "line": 17,
+                                                "column": 30,
+                                                "byte": 251
+                                            }
+                                        },
+                                        "value": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 10,
+                                                "column": 5,
+                                                "byte": 128
+                                            },
+                                            "end": {
+                                                "line": 14,
+                                                "column": 16,
+                                                "byte": 207
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "short": {
+                "range": {
+                    "environment": "rotate",
+                    "begin": {
+                        "line": 10,
+                        "column": 5,
+                        "byte": 128
+                    },
+                    "end": {
+                        "line": 14,
+                        "column": 16,
+                        "byte": 207
+                    }
+                },
+                "schema": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "bar2"
+                        },
+                        "b": {
+                            "type": "string",
+                            "const": "bar1"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "b"
+                    ]
+                },
+                "builtin": {
+                    "name": "fn::rotate::swap",
+                    "nameRange": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 10,
+                            "column": 5,
+                            "byte": 128
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 21,
+                            "byte": 144
+                        }
+                    },
+                    "argSchema": {
+                        "properties": {
+                            "inputs": true,
+                            "state": {
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "a": {
+                                                "type": "string"
+                                            },
+                                            "b": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "required": [
+                                            "a",
+                                            "b"
+                                        ]
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "type": ""
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "inputs",
+                            "state"
+                        ]
+                    },
+                    "arg": {
+                        "range": {
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        },
+                        "object": {
+                            "inputs": {
+                                "range": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 11,
+                                        "column": 15,
+                                        "byte": 160
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 15,
+                                        "byte": 160
+                                    }
+                                },
+                                "schema": {
+                                    "type": "object"
+                                }
+                            },
+                            "state": {
+                                "range": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 13,
+                                        "column": 9,
+                                        "byte": 184
+                                    },
+                                    "end": {
+                                        "line": 14,
+                                        "column": 16,
+                                        "byte": 207
+                                    }
+                                },
+                                "schema": {
+                                    "properties": {
+                                        "a": {
+                                            "type": "string",
+                                            "const": "bar1"
+                                        },
+                                        "b": {
+                                            "type": "string",
+                                            "const": "bar2"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "required": [
+                                        "a",
+                                        "b"
+                                    ]
+                                },
+                                "keyRanges": {
+                                    "a": {
+                                        "environment": "rotate",
+                                        "begin": {
+                                            "line": 13,
+                                            "column": 9,
+                                            "byte": 184
+                                        },
+                                        "end": {
+                                            "line": 13,
+                                            "column": 10,
+                                            "byte": 185
+                                        }
+                                    },
+                                    "b": {
+                                        "environment": "rotate",
+                                        "begin": {
+                                            "line": 14,
+                                            "column": 9,
+                                            "byte": 200
+                                        },
+                                        "end": {
+                                            "line": 14,
+                                            "column": 10,
+                                            "byte": 201
+                                        }
+                                    }
+                                },
+                                "object": {
+                                    "a": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 13,
+                                                "column": 12,
+                                                "byte": 187
+                                            },
+                                            "end": {
+                                                "line": 13,
+                                                "column": 16,
+                                                "byte": 191
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "bar1"
+                                        },
+                                        "literal": "bar1"
+                                    },
+                                    "b": {
+                                        "range": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 14,
+                                                "column": 12,
+                                                "byte": 203
+                                            },
+                                            "end": {
+                                                "line": 14,
+                                                "column": 16,
+                                                "byte": 207
+                                            }
+                                        },
+                                        "schema": {
+                                            "type": "string",
+                                            "const": "bar2"
+                                        },
+                                        "literal": "bar2"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "properties": {
+            "full": {
+                "value": {
+                    "a": {
+                        "value": "bar2",
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 20
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 16,
+                                    "byte": 114
+                                }
+                            }
+                        }
+                    },
+                    "b": {
+                        "value": "bar1",
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 3,
+                                    "column": 5,
+                                    "byte": 20
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 16,
+                                    "byte": 114
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 3,
+                            "column": 5,
+                            "byte": 20
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 16,
+                            "byte": 114
+                        }
+                    }
+                }
+            },
+            "invalid": {
+                "value": {
+                    "full": {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 21,
+                                    "column": 7,
+                                    "byte": 281
+                                },
+                                "end": {
+                                    "line": 26,
+                                    "column": 18,
+                                    "byte": 395
+                                }
+                            }
+                        }
+                    },
+                    "short": {
+                        "unknown": true,
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 29,
+                                    "column": 7,
+                                    "byte": 414
+                                },
+                                "end": {
+                                    "line": 33,
+                                    "column": 18,
+                                    "byte": 511
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 20,
+                            "column": 5,
+                            "byte": 269
+                        },
+                        "end": {
+                            "line": 33,
+                            "column": 18,
+                            "byte": 511
+                        }
+                    }
+                }
+            },
+            "reference": {
+                "value": {
+                    "test": {
+                        "value": "bar2 bar1",
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 17,
+                                    "column": 11,
+                                    "byte": 232
+                                },
+                                "end": {
+                                    "line": 17,
+                                    "column": 31,
+                                    "byte": 252
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 17,
+                            "column": 5,
+                            "byte": 226
+                        },
+                        "end": {
+                            "line": 17,
+                            "column": 31,
+                            "byte": 252
+                        }
+                    }
+                }
+            },
+            "short": {
+                "value": {
+                    "a": {
+                        "value": "bar2",
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 5,
+                                    "byte": 128
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "column": 16,
+                                    "byte": 207
+                                }
+                            }
+                        }
+                    },
+                    "b": {
+                        "value": "bar1",
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 10,
+                                    "column": 5,
+                                    "byte": 128
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "column": 16,
+                                    "byte": 207
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "environment": "rotate",
+                        "begin": {
+                            "line": 10,
+                            "column": 5,
+                            "byte": 128
+                        },
+                        "end": {
+                            "line": 14,
+                            "column": 16,
+                            "byte": 207
+                        }
+                    }
+                }
+            }
+        },
+        "schema": {
+            "properties": {
+                "full": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "bar2"
+                        },
+                        "b": {
+                            "type": "string",
+                            "const": "bar1"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "b"
+                    ]
+                },
+                "invalid": {
+                    "properties": {
+                        "full": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        },
+                        "short": {
+                            "properties": {
+                                "a": {
+                                    "type": "string"
+                                },
+                                "b": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "a",
+                                "b"
+                            ]
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "full",
+                        "short"
+                    ]
+                },
+                "reference": {
+                    "properties": {
+                        "test": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "test"
+                    ]
+                },
+                "short": {
+                    "properties": {
+                        "a": {
+                            "type": "string",
+                            "const": "bar2"
+                        },
+                        "b": {
+                            "type": "string",
+                            "const": "bar1"
+                        }
+                    },
+                    "type": "object",
+                    "required": [
+                        "a",
+                        "b"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "full",
+                "invalid",
+                "reference",
+                "short"
+            ]
+        },
+        "executionContext": {
+            "properties": {
+                "currentEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "rotate",
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "pulumi": {
+                    "value": {
+                        "user": {
+                            "value": {
+                                "id": {
+                                    "value": "USER_123",
+                                    "trace": {
+                                        "def": {
+                                            "environment": "rotate",
+                                            "begin": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            },
+                                            "end": {
+                                                "line": 0,
+                                                "column": 0,
+                                                "byte": 0
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                },
+                "rootEnvironment": {
+                    "value": {
+                        "name": {
+                            "value": "rotate",
+                            "trace": {
+                                "def": {
+                                    "environment": "rotate",
+                                    "begin": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    },
+                                    "end": {
+                                        "line": 0,
+                                        "column": 0,
+                                        "byte": 0
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "trace": {
+                        "def": {
+                            "environment": "rotate",
+                            "begin": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            },
+                            "end": {
+                                "line": 0,
+                                "column": 0,
+                                "byte": 0
+                            }
+                        }
+                    }
+                }
+            },
+            "schema": {
+                "properties": {
+                    "currentEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "rotate"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    },
+                    "pulumi": {
+                        "properties": {
+                            "user": {
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "const": "USER_123"
+                                    }
+                                },
+                                "type": "object",
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "user"
+                        ]
+                    },
+                    "rootEnvironment": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "const": "rotate"
+                            }
+                        },
+                        "type": "object",
+                        "required": [
+                            "name"
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "currentEnvironment",
+                    "pulumi",
+                    "rootEnvironment"
+                ]
+            }
+        }
+    },
+    "rotateJson": {
+        "full": {
+            "a": "bar2",
+            "b": "bar1"
+        },
+        "invalid": {
+            "full": "[unknown]",
+            "short": "[unknown]"
+        },
+        "reference": {
+            "test": "bar2 bar1"
+        },
+        "short": {
+            "a": "bar2",
+            "b": "bar1"
+        }
+    },
+    "rotatePatches": [
+        {
+            "DocPath": "values.full[\"fn::rotate\"].state",
+            "Replacement": {
+                "value": {
+                    "a": {
+                        "value": "bar2",
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 8,
+                                    "column": 12,
+                                    "byte": 110
+                                },
+                                "end": {
+                                    "line": 8,
+                                    "column": 16,
+                                    "byte": 114
+                                }
+                            }
+                        }
+                    },
+                    "b": {
+                        "value": "bar1",
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 7,
+                                    "column": 12,
+                                    "byte": 94
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 16,
+                                    "byte": 98
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "begin": {
+                            "line": 0,
+                            "column": 0,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 0,
+                            "column": 0,
+                            "byte": 0
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "DocPath": "values.short[\"fn::rotate::swap\"].state",
+            "Replacement": {
+                "value": {
+                    "a": {
+                        "value": "bar2",
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 14,
+                                    "column": 12,
+                                    "byte": 203
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "column": 16,
+                                    "byte": 207
+                                }
+                            }
+                        }
+                    },
+                    "b": {
+                        "value": "bar1",
+                        "trace": {
+                            "def": {
+                                "environment": "rotate",
+                                "begin": {
+                                    "line": 13,
+                                    "column": 12,
+                                    "byte": 187
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 16,
+                                    "byte": 191
+                                }
+                            }
+                        }
+                    }
+                },
+                "trace": {
+                    "def": {
+                        "begin": {
+                            "line": 0,
+                            "column": 0,
+                            "byte": 0
+                        },
+                        "end": {
+                            "line": 0,
+                            "column": 0,
+                            "byte": 0
+                        }
+                    }
+                }
+            }
+        }
     ]
 }


### PR DESCRIPTION
We must tolerate syntax errors when loading an environment. Returning a
nil `EnvironmentDecl` prevents us from being able to analyze the
portions of the environment that were successfully parsed. This
interferes with analysis of environments that are only partially
erroneous. One important scenario this covers is autocompletion in the
face of syntax errors, which is common while editing an environment.
