### PR TITLE
Add `esc setup aws` command for AWS OIDC integration

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,6 +4,9 @@
   [#281](https://github.com/pulumi/esc/issues/281)
 - Add native support for OIDC token exchange when logging into Pulumi Cloud. Run `esc login --help` for more
   information. [#607](https://github.com/pulumi/esc/pull/607)
+- Add `esc setup aws` command to configure AWS OIDC integration for Pulumi ESC. This command creates the
+  necessary AWS resources (OIDC provider, IAM role, policy attachment) and optionally creates an ESC
+  environment with the OIDC configuration.
 
 ### Bug Fixes
 

--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -110,10 +110,14 @@ func (r *environmentRef) String() string {
 }
 
 func (cmd *envCommand) parseRef(refStr string) environmentRef {
+	return parseEnvRef(refStr, cmd.esc.account.DefaultOrg)
+}
+
+func parseEnvRef(refStr, defaultOrg string) environmentRef {
 	var orgName, projectName, envNameAndVersion string
 
 	hasAmbiguousPath := false
-	orgName = cmd.esc.account.DefaultOrg
+	orgName = defaultOrg
 	projectName = client.DefaultProject
 	isUsingLegacyID := false
 

--- a/cmd/esc/cli/esc.go
+++ b/cmd/esc/cli/esc.go
@@ -140,6 +140,7 @@ func New(opts *Options) *cobra.Command {
 	cmd.AddCommand(newLogoutCmd(esc))
 	cmd.AddCommand(newVersionCmd(esc))
 	cmd.AddCommand(newGenDocsCmd(cmd))
+	cmd.AddCommand(newSetupCmd(esc))
 
 	return cmd
 }

--- a/cmd/esc/cli/setup.go
+++ b/cmd/esc/cli/setup.go
@@ -1,0 +1,33 @@
+// Copyright 2026, Pulumi Corporation.
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type setupCommand struct {
+	esc *escCommand
+}
+
+func newSetupCmd(esc *escCommand) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Setup cloud integrations for Pulumi ESC",
+		Long: "Setup cloud integrations for Pulumi ESC\n" +
+			"\n" +
+			"This command group provides utilities to configure cloud providers for use with " +
+			"Pulumi ESC OIDC authentication.\n" +
+			"\n" +
+			"Available cloud providers:\n" +
+			"  aws     Setup AWS OIDC integration\n",
+
+		Args: cobra.NoArgs,
+	}
+
+	setup := &setupCommand{esc: esc}
+
+	cmd.AddCommand(newSetupAWSCmd(setup))
+
+	return cmd
+}

--- a/cmd/esc/cli/setup_aws.go
+++ b/cmd/esc/cli/setup_aws.go
@@ -1,0 +1,373 @@
+// Copyright 2026, Pulumi Corporation.
+
+package cli
+
+import (
+	"context"
+	"crypto/sha1" //nolint:gosec // Required for AWS OIDC provider thumbprint calculation
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+const (
+	oidcIssuerURL  = "https://api.pulumi.com/oidc"
+	oidcIssuerHost = "api.pulumi.com/oidc"
+)
+
+// iamClient defines the IAM operations needed for AWS OIDC setup.
+type iamClient interface {
+	CreateOpenIDConnectProvider(ctx context.Context, params *iam.CreateOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error)
+	AddClientIDToOpenIDConnectProvider(ctx context.Context, params *iam.AddClientIDToOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.AddClientIDToOpenIDConnectProviderOutput, error)
+	CreateRole(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error)
+	AttachRolePolicy(ctx context.Context, params *iam.AttachRolePolicyInput, optFns ...func(*iam.Options)) (*iam.AttachRolePolicyOutput, error)
+}
+
+func newSetupAWSCmd(setup *setupCommand) *cobra.Command {
+	var roleName string
+	var policy string
+	var envName string
+	var orgName string
+
+	cmd := &cobra.Command{
+		Use:   "aws",
+		Short: "Setup AWS OIDC integration for Pulumi ESC",
+		Long: "Setup AWS OIDC integration for Pulumi ESC\n" +
+			"\n" +
+			"This command creates the necessary AWS resources for OIDC authentication:\n" +
+			"  - An OIDC identity provider for Pulumi Cloud\n" +
+			"  - An IAM role with a trust policy for your organization\n" +
+			"  - A policy attachment for the specified policy\n" +
+			"\n" +
+			"AWS credentials must be configured in your environment (via AWS_ACCESS_KEY_ID,\n" +
+			"AWS_SECRET_ACCESS_KEY, or other standard AWS credential methods).\n" +
+			"\n" +
+			"Example:\n" +
+			"  esc setup aws --role-name PulumiESCRole\n" +
+			"  esc setup aws --role-name PulumiESCRole --policy ReadOnlyAccess\n" +
+			"  esc setup aws --role-name PulumiESCRole --org myorg\n" +
+			"  esc setup aws --role-name PulumiESCRole --environment myorg/myproject/aws-dev\n",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			if err := setup.esc.getCachedClient(ctx); err != nil {
+				return err
+			}
+
+			if roleName == "" {
+				return fmt.Errorf("--role-name is required")
+			}
+
+			if orgName == "" {
+				orgName = setup.esc.account.DefaultOrg
+			}
+			if orgName == "" {
+				return fmt.Errorf("could not determine organization; please specify --org or set a default org with 'esc login --default-org <org>'")
+			}
+
+			result, err := setupAWSOIDC(ctx, setup.esc, orgName, roleName, policy)
+			if err != nil {
+				return err
+			}
+
+			if envName != "" {
+				return createOrUpdateEnvironment(ctx, setup.esc, orgName, envName, result.roleArn)
+			}
+
+			printEnvironmentYAML(setup.esc, result.roleArn)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&roleName, "role-name", "", "The name of the IAM role to create (required)")
+	cmd.Flags().StringVar(&policy, "policy", "AdministratorAccess", "The AWS managed policy name to attach to the role")
+	cmd.Flags().StringVar(&orgName, "org", "", "The Pulumi organization to configure OIDC for (defaults to current org)")
+	cmd.Flags().StringVar(&envName, "environment", "", "Create or update an ESC environment with the OIDC configuration")
+
+	return cmd
+}
+
+type awsSetupResult struct {
+	accountID        string
+	partition        string
+	roleArn          string
+	oidcProviderArn  string
+	oidcProviderNew  bool
+	roleNew          bool
+	policyAttachment string
+}
+
+func setupAWSOIDC(ctx context.Context, esc *escCommand, orgName, roleName, policyName string) (*awsSetupResult, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading AWS configuration: %w", err)
+	}
+
+	stsClient := sts.NewFromConfig(cfg)
+	iamClient := iam.NewFromConfig(cfg)
+
+	identity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return nil, fmt.Errorf("getting AWS caller identity: %w", err)
+	}
+
+	accountID := *identity.Account
+	partition := parsePartitionFromARN(*identity.Arn)
+
+	fmt.Fprintf(esc.stdout, "AWS Account: %s (partition: %s)\n", accountID, partition)
+	fmt.Fprintf(esc.stdout, "Organization: %s\n\n", orgName)
+
+	thumbprint, err := getOIDCThumbprint(oidcIssuerHost)
+	if err != nil {
+		return nil, fmt.Errorf("getting OIDC thumbprint: %w", err)
+	}
+
+	audience := fmt.Sprintf("aws:%s", orgName)
+	oidcProviderArn := fmt.Sprintf("arn:%s:iam::%s:oidc-provider/%s", partition, accountID, oidcIssuerHost)
+
+	oidcProviderNew, err := createOrUpdateOIDCProvider(ctx, esc, iamClient, oidcProviderArn, audience, thumbprint)
+	if err != nil {
+		return nil, err
+	}
+
+	roleArn := fmt.Sprintf("arn:%s:iam::%s:role/%s", partition, accountID, roleName)
+	roleNew, err := createRole(ctx, esc, iamClient, roleName, oidcProviderArn, audience)
+	if err != nil {
+		return nil, err
+	}
+
+	policyArn := fmt.Sprintf("arn:%s:iam::aws:policy/%s", partition, policyName)
+	if err := attachRolePolicy(ctx, esc, iamClient, roleName, policyArn); err != nil {
+		return nil, err
+	}
+
+	return &awsSetupResult{
+		accountID:        accountID,
+		partition:        partition,
+		roleArn:          roleArn,
+		oidcProviderArn:  oidcProviderArn,
+		oidcProviderNew:  oidcProviderNew,
+		roleNew:          roleNew,
+		policyAttachment: policyArn,
+	}, nil
+}
+
+func parsePartitionFromARN(arn string) string {
+	parts := strings.Split(arn, ":")
+	if len(parts) >= 2 {
+		return parts[1]
+	}
+	return "aws"
+}
+
+func getOIDCThumbprint(host string) (string, error) {
+	hostWithPort := host
+	if !strings.Contains(host, ":") {
+		hostParts := strings.Split(host, "/")
+		hostWithPort = hostParts[0] + ":443"
+	}
+
+	conn, err := tls.Dial("tcp", hostWithPort, &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	})
+	if err != nil {
+		return "", fmt.Errorf("connecting to %s: %w", hostWithPort, err)
+	}
+	defer conn.Close()
+
+	certs := conn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		return "", fmt.Errorf("no certificates returned from %s", host)
+	}
+
+	rootCert := certs[len(certs)-1]
+	thumbprint := sha1.Sum(rootCert.Raw) //nolint:gosec // Required for AWS OIDC provider thumbprint calculation
+
+	var thumbprintStr strings.Builder
+	for _, b := range thumbprint {
+		fmt.Fprintf(&thumbprintStr, "%02x", b)
+	}
+
+	return thumbprintStr.String(), nil
+}
+
+func createOrUpdateOIDCProvider(
+	ctx context.Context,
+	esc *escCommand,
+	iamCli iamClient,
+	oidcProviderArn, audience, thumbprint string,
+) (bool, error) {
+	_, err := iamCli.CreateOpenIDConnectProvider(ctx, &iam.CreateOpenIDConnectProviderInput{
+		Url:            aws.String(oidcIssuerURL),
+		ClientIDList:   []string{audience},
+		ThumbprintList: []string{thumbprint},
+	})
+
+	if err != nil {
+		var entityExists *iamtypes.EntityAlreadyExistsException
+		if errors.As(err, &entityExists) {
+			fmt.Fprintf(esc.stdout, "OIDC Provider: %s (existing)\n", oidcProviderArn)
+
+			_, err := iamCli.AddClientIDToOpenIDConnectProvider(ctx, &iam.AddClientIDToOpenIDConnectProviderInput{
+				OpenIDConnectProviderArn: aws.String(oidcProviderArn),
+				ClientID:                 aws.String(audience),
+			})
+			if err != nil {
+				var invalidInput *iamtypes.InvalidInputException
+				if errors.As(err, &invalidInput) && strings.Contains(err.Error(), "already registered") {
+					fmt.Fprintf(esc.stdout, "  Audience '%s' already configured\n", audience)
+					return false, nil
+				}
+				return false, fmt.Errorf("adding audience to OIDC provider: %w", err)
+			}
+
+			fmt.Fprintf(esc.stdout, "  Added audience: %s\n", audience)
+			return false, nil
+		}
+		return false, fmt.Errorf("creating OIDC provider: %w", err)
+	}
+
+	fmt.Fprintf(esc.stdout, "OIDC Provider: %s (created)\n", oidcProviderArn)
+	return true, nil
+}
+
+func createRole(
+	ctx context.Context,
+	esc *escCommand,
+	iamCli iamClient,
+	roleName, oidcProviderArn, audience string,
+) (bool, error) {
+	trustPolicy := map[string]interface{}{
+		"Version": "2012-10-17",
+		"Statement": []map[string]interface{}{
+			{
+				"Effect": "Allow",
+				"Principal": map[string]interface{}{
+					"Federated": oidcProviderArn,
+				},
+				"Action": "sts:AssumeRoleWithWebIdentity",
+				"Condition": map[string]interface{}{
+					"StringEquals": map[string]interface{}{
+						fmt.Sprintf("%s:aud", oidcIssuerHost): audience,
+					},
+				},
+			},
+		},
+	}
+
+	trustPolicyJSON, err := json.Marshal(trustPolicy)
+	if err != nil {
+		return false, fmt.Errorf("marshaling trust policy: %w", err)
+	}
+
+	_, err = iamCli.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String(roleName),
+		AssumeRolePolicyDocument: aws.String(string(trustPolicyJSON)),
+	})
+
+	if err != nil {
+		var entityExists *iamtypes.EntityAlreadyExistsException
+		if errors.As(err, &entityExists) {
+			fmt.Fprintf(esc.stdout, "IAM Role: %s (existing)\n", roleName)
+			return false, nil
+		}
+		return false, fmt.Errorf("creating IAM role: %w", err)
+	}
+
+	fmt.Fprintf(esc.stdout, "IAM Role: %s (created)\n", roleName)
+	return true, nil
+}
+
+func attachRolePolicy(
+	ctx context.Context,
+	esc *escCommand,
+	iamCli iamClient,
+	roleName, policyArn string,
+) error {
+	_, err := iamCli.AttachRolePolicy(ctx, &iam.AttachRolePolicyInput{
+		RoleName:  aws.String(roleName),
+		PolicyArn: aws.String(policyArn),
+	})
+	if err != nil {
+		return fmt.Errorf("attaching policy to role: %w", err)
+	}
+
+	fmt.Fprintf(esc.stdout, "Policy Attached: %s\n", policyArn)
+	return nil
+}
+
+func generateEnvironmentYAML(roleArn string) string {
+	return fmt.Sprintf(`values:
+  aws:
+    login:
+      fn::open::aws-login:
+        oidc:
+          duration: 1h
+          roleArn: %s
+          sessionName: pulumi-esc-session
+  environmentVariables:
+    AWS_ACCESS_KEY_ID: ${aws.login.accessKeyId}
+    AWS_SECRET_ACCESS_KEY: ${aws.login.secretAccessKey}
+    AWS_SESSION_TOKEN: ${aws.login.sessionToken}
+`, roleArn)
+}
+
+func printEnvironmentYAML(esc *escCommand, roleArn string) {
+	fmt.Fprintf(esc.stdout, "\nAdd the following to your ESC environment:\n\n")
+	fmt.Fprint(esc.stdout, generateEnvironmentYAML(roleArn))
+}
+
+func createOrUpdateEnvironment(ctx context.Context, esc *escCommand, defaultOrg, envName, roleArn string) error {
+	yaml := generateEnvironmentYAML(roleArn)
+
+	ref := parseEnvRef(envName, defaultOrg)
+
+	exists := true
+	_, err := esc.client.EnvironmentExists(ctx, ref.orgName, ref.projectName, ref.envName)
+	if err != nil {
+		var errResp *apitype.ErrorResponse
+		if errors.As(err, &errResp) && errResp.Code == http.StatusNotFound {
+			exists = false
+		} else {
+			return fmt.Errorf("checking environment existence: %w", err)
+		}
+	}
+
+	if !exists {
+		if err := esc.client.CreateEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName); err != nil {
+			return fmt.Errorf("creating environment: %w", err)
+		}
+		fmt.Fprintf(esc.stdout, "\nEnvironment created: %s\n", ref.String())
+	}
+
+	diags, err := esc.client.UpdateEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName, []byte(yaml), "")
+	if err != nil {
+		return fmt.Errorf("updating environment: %w", err)
+	}
+
+	if len(diags) != 0 {
+		fmt.Fprintf(esc.stderr, "Warning: environment has diagnostics:\n")
+		for _, d := range diags {
+			fmt.Fprintf(esc.stderr, "  - %s\n", d.Summary)
+		}
+	}
+
+	if exists {
+		fmt.Fprintf(esc.stdout, "\nEnvironment updated: %s\n", ref.String())
+	}
+
+	return nil
+}

--- a/cmd/esc/cli/setup_aws_test.go
+++ b/cmd/esc/cli/setup_aws_test.go
@@ -1,0 +1,382 @@
+// Copyright 2026, Pulumi Corporation.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/esc/cmd/esc/cli/client"
+	"github.com/pulumi/esc/cmd/esc/cli/workspace"
+	pulumi_workspace "github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func TestParsePartitionFromARN(t *testing.T) {
+	tests := []struct {
+		name     string
+		arn      string
+		expected string
+	}{
+		{
+			name:     "standard AWS partition",
+			arn:      "arn:aws:sts::123456789012:assumed-role/role-name/session",
+			expected: "aws",
+		},
+		{
+			name:     "GovCloud partition",
+			arn:      "arn:aws-us-gov:sts::123456789012:assumed-role/role-name/session",
+			expected: "aws-us-gov",
+		},
+		{
+			name:     "China partition",
+			arn:      "arn:aws-cn:sts::123456789012:assumed-role/role-name/session",
+			expected: "aws-cn",
+		},
+		{
+			name:     "invalid ARN defaults to aws",
+			arn:      "invalid",
+			expected: "aws",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parsePartitionFromARN(tt.arn)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseEnvRef(t *testing.T) {
+	tests := []struct {
+		name        string
+		defaultOrg  string
+		envName     string
+		expectedOrg string
+		expectedPrj string
+		expectedEnv string
+	}{
+		{
+			name:        "full path org/project/env",
+			defaultOrg:  "default-org",
+			envName:     "my-org/my-project/my-env",
+			expectedOrg: "my-org",
+			expectedPrj: "my-project",
+			expectedEnv: "my-env",
+		},
+		{
+			name:        "project/env uses default org",
+			defaultOrg:  "default-org",
+			envName:     "my-project/my-env",
+			expectedOrg: "default-org",
+			expectedPrj: "my-project",
+			expectedEnv: "my-env",
+		},
+		{
+			name:        "env only uses default org and default project",
+			defaultOrg:  "default-org",
+			envName:     "my-env",
+			expectedOrg: "default-org",
+			expectedPrj: "default",
+			expectedEnv: "my-env",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref := parseEnvRef(tt.envName, tt.defaultOrg)
+			assert.Equal(t, tt.expectedOrg, ref.orgName)
+			assert.Equal(t, tt.expectedPrj, ref.projectName)
+			assert.Equal(t, tt.expectedEnv, ref.envName)
+		})
+	}
+}
+
+func TestGenerateEnvironmentYAML(t *testing.T) {
+	roleArn := "arn:aws:iam::123456789012:role/TestRole"
+	yaml := generateEnvironmentYAML(roleArn)
+
+	assert.Contains(t, yaml, "fn::open::aws-login:")
+	assert.Contains(t, yaml, "oidc:")
+	assert.Contains(t, yaml, "duration: 1h")
+	assert.Contains(t, yaml, roleArn)
+	assert.Contains(t, yaml, "sessionName: pulumi-esc-session")
+	assert.Contains(t, yaml, "AWS_ACCESS_KEY_ID: ${aws.login.accessKeyId}")
+	assert.Contains(t, yaml, "AWS_SECRET_ACCESS_KEY: ${aws.login.secretAccessKey}")
+	assert.Contains(t, yaml, "AWS_SESSION_TOKEN: ${aws.login.sessionToken}")
+}
+
+func TestSetupAWSCmd_MissingRoleName(t *testing.T) {
+	backend := "https://api.pulumi.com"
+	creds := pulumi_workspace.Credentials{
+		Current: backend,
+		Accounts: map[string]pulumi_workspace.Account{
+			backend: {
+				Username:    "test-user",
+				AccessToken: "access-token",
+			},
+		},
+	}
+
+	fs := testFS{}
+	testWorkspace := workspace.New(fs, &testPulumiWorkspace{
+		credentials: creds,
+		config: pulumi_workspace.PulumiConfig{
+			BackendConfig: map[string]pulumi_workspace.BackendConfig{
+				backend: {DefaultOrg: "test-org"},
+			},
+		},
+	})
+
+	var stdout, stderr bytes.Buffer
+	esc := &escCommand{
+		command:   "esc",
+		login:     &testLoginManager{creds: creds},
+		workspace: testWorkspace,
+		environ:   testEnviron{},
+		stdout:    &stdout,
+		stderr:    &stderr,
+		newClient: func(userAgent, backendURL, accessToken string, insecure bool) client.Client {
+			return &testPulumiClient{user: "test-user", defaultOrg: "test-org"}
+		},
+	}
+
+	setup := &setupCommand{esc: esc}
+	cmd := newSetupAWSCmd(setup)
+
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--role-name is required")
+}
+
+func TestSetupAWSCmd_WithOrgFlag(t *testing.T) {
+	// This test verifies that the --org flag is properly parsed
+	// The actual AWS calls would fail without real credentials,
+	// but we can verify the command structure is correct
+	backend := "https://api.pulumi.com"
+	creds := pulumi_workspace.Credentials{
+		Current: backend,
+		Accounts: map[string]pulumi_workspace.Account{
+			backend: {
+				Username:    "test-user",
+				AccessToken: "access-token",
+			},
+		},
+	}
+
+	fs := testFS{}
+	testWorkspace := workspace.New(fs, &testPulumiWorkspace{
+		credentials: creds,
+		config: pulumi_workspace.PulumiConfig{
+			BackendConfig: map[string]pulumi_workspace.BackendConfig{
+				backend: {DefaultOrg: "default-org"},
+			},
+		},
+	})
+
+	var stdout, stderr bytes.Buffer
+	esc := &escCommand{
+		command:   "esc",
+		login:     &testLoginManager{creds: creds},
+		workspace: testWorkspace,
+		environ:   testEnviron{},
+		stdout:    &stdout,
+		stderr:    &stderr,
+		newClient: func(userAgent, backendURL, accessToken string, insecure bool) client.Client {
+			return &testPulumiClient{user: "test-user", defaultOrg: "default-org"}
+		},
+	}
+
+	setup := &setupCommand{esc: esc}
+	cmd := newSetupAWSCmd(setup)
+
+	// Verify the command has the expected flags
+	assert.NotNil(t, cmd.Flags().Lookup("role-name"))
+	assert.NotNil(t, cmd.Flags().Lookup("policy"))
+	assert.NotNil(t, cmd.Flags().Lookup("org"))
+	assert.NotNil(t, cmd.Flags().Lookup("environment"))
+
+	// Verify default policy value
+	policyFlag := cmd.Flags().Lookup("policy")
+	assert.Equal(t, "AdministratorAccess", policyFlag.DefValue)
+}
+
+// Mock IAM client for testing
+type mockIAMClient struct {
+	createOpenIDConnectProviderFunc    func(ctx context.Context, params *iam.CreateOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error)
+	addClientIDToOpenIDConnectProvider func(ctx context.Context, params *iam.AddClientIDToOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.AddClientIDToOpenIDConnectProviderOutput, error)
+	createRoleFunc                     func(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error)
+	attachRolePolicyFunc               func(ctx context.Context, params *iam.AttachRolePolicyInput, optFns ...func(*iam.Options)) (*iam.AttachRolePolicyOutput, error)
+}
+
+func (m *mockIAMClient) CreateOpenIDConnectProvider(ctx context.Context, params *iam.CreateOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error) {
+	return m.createOpenIDConnectProviderFunc(ctx, params, optFns...)
+}
+
+func (m *mockIAMClient) AddClientIDToOpenIDConnectProvider(ctx context.Context, params *iam.AddClientIDToOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.AddClientIDToOpenIDConnectProviderOutput, error) {
+	return m.addClientIDToOpenIDConnectProvider(ctx, params, optFns...)
+}
+
+func (m *mockIAMClient) CreateRole(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error) {
+	return m.createRoleFunc(ctx, params, optFns...)
+}
+
+func (m *mockIAMClient) AttachRolePolicy(ctx context.Context, params *iam.AttachRolePolicyInput, optFns ...func(*iam.Options)) (*iam.AttachRolePolicyOutput, error) {
+	return m.attachRolePolicyFunc(ctx, params, optFns...)
+}
+
+func TestCreateOrUpdateOIDCProvider(t *testing.T) {
+	t.Run("creates new OIDC provider", func(t *testing.T) {
+		var stdout bytes.Buffer
+		esc := &escCommand{stdout: &stdout}
+
+		iamClient := &mockIAMClient{
+			createOpenIDConnectProviderFunc: func(ctx context.Context, params *iam.CreateOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error) {
+				assert.Equal(t, oidcIssuerURL, *params.Url)
+				assert.Equal(t, []string{"aws:test-org"}, params.ClientIDList)
+				return &iam.CreateOpenIDConnectProviderOutput{}, nil
+			},
+		}
+
+		isNew, err := createOrUpdateOIDCProvider(context.Background(), esc, iamClient, "arn:aws:iam::123456789012:oidc-provider/api.pulumi.com/oidc", "aws:test-org", "thumbprint123")
+
+		require.NoError(t, err)
+		assert.True(t, isNew)
+		assert.Contains(t, stdout.String(), "(created)")
+	})
+
+	t.Run("adds audience to existing OIDC provider", func(t *testing.T) {
+		var stdout bytes.Buffer
+		esc := &escCommand{stdout: &stdout}
+
+		iamClient := &mockIAMClient{
+			createOpenIDConnectProviderFunc: func(ctx context.Context, params *iam.CreateOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error) {
+				return nil, &iamtypes.EntityAlreadyExistsException{Message: aws.String("provider already exists")}
+			},
+			addClientIDToOpenIDConnectProvider: func(ctx context.Context, params *iam.AddClientIDToOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.AddClientIDToOpenIDConnectProviderOutput, error) {
+				assert.Equal(t, "aws:test-org", *params.ClientID)
+				return &iam.AddClientIDToOpenIDConnectProviderOutput{}, nil
+			},
+		}
+
+		isNew, err := createOrUpdateOIDCProvider(context.Background(), esc, iamClient, "arn:aws:iam::123456789012:oidc-provider/api.pulumi.com/oidc", "aws:test-org", "thumbprint123")
+
+		require.NoError(t, err)
+		assert.False(t, isNew)
+		assert.Contains(t, stdout.String(), "(existing)")
+		assert.Contains(t, stdout.String(), "Added audience")
+	})
+}
+
+func TestCreateRole(t *testing.T) {
+	t.Run("creates new role", func(t *testing.T) {
+		var stdout bytes.Buffer
+		esc := &escCommand{stdout: &stdout}
+
+		iamClient := &mockIAMClient{
+			createRoleFunc: func(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error) {
+				assert.Equal(t, "TestRole", *params.RoleName)
+				assert.Contains(t, *params.AssumeRolePolicyDocument, "sts:AssumeRoleWithWebIdentity")
+				assert.Contains(t, *params.AssumeRolePolicyDocument, "aws:test-org")
+				return &iam.CreateRoleOutput{}, nil
+			},
+		}
+
+		isNew, err := createRole(context.Background(), esc, iamClient, "TestRole", "arn:aws:iam::123456789012:oidc-provider/api.pulumi.com/oidc", "aws:test-org")
+
+		require.NoError(t, err)
+		assert.True(t, isNew)
+		assert.Contains(t, stdout.String(), "(created)")
+	})
+
+	t.Run("handles existing role", func(t *testing.T) {
+		var stdout bytes.Buffer
+		esc := &escCommand{stdout: &stdout}
+
+		iamClient := &mockIAMClient{
+			createRoleFunc: func(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error) {
+				return nil, &iamtypes.EntityAlreadyExistsException{Message: aws.String("role already exists")}
+			},
+		}
+
+		isNew, err := createRole(context.Background(), esc, iamClient, "TestRole", "arn:aws:iam::123456789012:oidc-provider/api.pulumi.com/oidc", "aws:test-org")
+
+		require.NoError(t, err)
+		assert.False(t, isNew)
+		assert.Contains(t, stdout.String(), "(existing)")
+	})
+
+	t.Run("returns error on failure", func(t *testing.T) {
+		var stdout bytes.Buffer
+		esc := &escCommand{stdout: &stdout}
+
+		iamClient := &mockIAMClient{
+			createRoleFunc: func(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error) {
+				return nil, errors.New("access denied")
+			},
+		}
+
+		_, err := createRole(context.Background(), esc, iamClient, "TestRole", "arn:aws:iam::123456789012:oidc-provider/api.pulumi.com/oidc", "aws:test-org")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "creating IAM role")
+	})
+}
+
+func TestAttachRolePolicy(t *testing.T) {
+	t.Run("attaches policy successfully", func(t *testing.T) {
+		var stdout bytes.Buffer
+		esc := &escCommand{stdout: &stdout}
+
+		iamClient := &mockIAMClient{
+			attachRolePolicyFunc: func(ctx context.Context, params *iam.AttachRolePolicyInput, optFns ...func(*iam.Options)) (*iam.AttachRolePolicyOutput, error) {
+				assert.Equal(t, "TestRole", *params.RoleName)
+				assert.Equal(t, "arn:aws:iam::aws:policy/AdministratorAccess", *params.PolicyArn)
+				return &iam.AttachRolePolicyOutput{}, nil
+			},
+		}
+
+		err := attachRolePolicy(context.Background(), esc, iamClient, "TestRole", "arn:aws:iam::aws:policy/AdministratorAccess")
+
+		require.NoError(t, err)
+		assert.Contains(t, stdout.String(), "Policy Attached")
+	})
+
+	t.Run("returns error on failure", func(t *testing.T) {
+		var stdout bytes.Buffer
+		esc := &escCommand{stdout: &stdout}
+
+		iamClient := &mockIAMClient{
+			attachRolePolicyFunc: func(ctx context.Context, params *iam.AttachRolePolicyInput, optFns ...func(*iam.Options)) (*iam.AttachRolePolicyOutput, error) {
+				return nil, errors.New("policy not found")
+			},
+		}
+
+		err := attachRolePolicy(context.Background(), esc, iamClient, "TestRole", "arn:aws:iam::aws:policy/InvalidPolicy")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "attaching policy to role")
+	})
+}
+
+func TestPrintEnvironmentYAML(t *testing.T) {
+	var stdout bytes.Buffer
+	esc := &escCommand{stdout: &stdout}
+
+	printEnvironmentYAML(esc, "arn:aws:iam::123456789012:role/TestRole")
+
+	output := stdout.String()
+	assert.Contains(t, output, "Add the following to your ESC environment:")
+	assert.Contains(t, output, "arn:aws:iam::123456789012:role/TestRole")
+	assert.Contains(t, output, "fn::open::aws-login:")
+}

--- a/cmd/esc/cli/testdata/usage-esc.yaml
+++ b/cmd/esc/cli/testdata/usage-esc.yaml
@@ -32,6 +32,7 @@ Available Commands:
   logout      Log out of the Pulumi Cloud
   open        Open the environment with the given name.
   run         Open the environment with the given name and run a command.
+  setup       Setup cloud integrations for Pulumi ESC
   version     Print esc's version number
 
 Flags:

--- a/cmd/esc/cli/testdata/usage-parent.yaml
+++ b/cmd/esc/cli/testdata/usage-parent.yaml
@@ -31,6 +31,7 @@ Available Commands:
   logout      Log out of the Pulumi Cloud
   open        Open the environment with the given name.
   run         Open the environment with the given name and run a command.
+  setup       Setup cloud integrations for Pulumi ESC
   version     Print esc's version number
 
 Flags:

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,10 @@ retract v0.14.0
 
 require (
 	github.com/alecthomas/chroma/v2 v2.13.0
+	github.com/aws/aws-sdk-go-v2 v1.26.1
+	github.com/aws/aws-sdk-go-v2/config v1.27.11
+	github.com/aws/aws-sdk-go-v2/service/iam v1.31.4
+	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6
 	github.com/ccojocar/zxcvbn-go v1.0.1
 	github.com/charmbracelet/glamour v0.6.0
 	github.com/gofrs/uuid v4.2.0+incompatible
@@ -59,9 +63,7 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go v1.50.36 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.26.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.2 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.27.11 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.11 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.1 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.15 // indirect
@@ -77,7 +79,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.20.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.4 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect


### PR DESCRIPTION
This command sets up the necessary AWS resources for OIDC authentication
with Pulumi ESC:
- Creates an OIDC identity provider for Pulumi Cloud (or adds audience to existing)
- Creates an IAM role with the correct trust policy
- Attaches the specified AWS managed policy

Usage:
  esc setup aws --role-name PulumiESCRole
  esc setup aws --role-name PulumiESCRole --policy ReadOnlyAccess
  esc setup aws --role-name PulumiESCRole --org myorg
  esc setup aws --role-name PulumiESCRole --environment myorg/myproject/aws-dev

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
