### PR TITLE
Add CLAUDE.md as symlink to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` as a symlink to the existing `AGENTS.md`.
- Claude Code only reads `CLAUDE.md` natively ([docs](https://code.claude.com/docs/en/memory.md#agents-md)), so without this file Claude Code sessions miss the repo's agent context.
- Symlinking (vs. duplicating or using an `@AGENTS.md` import file) keeps the two files in lockstep with no maintenance overhead.

## Test plan
- [x] Confirm `CLAUDE.md` resolves to `AGENTS.md` content (`cat CLAUDE.md`).
- [x] Open the repo in Claude Code and verify the agent picks up `AGENTS.md` instructions via `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)