### PR TITLE
add request ID to error messages in the api client

### DIFF
--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -1536,13 +1536,18 @@ func (pc *client) httpCall(ctx context.Context, method, path string, body []byte
 		if err != nil {
 			return nil, fmt.Errorf("API call failed (%s), could not read response: %w", resp.Status, err)
 		}
-		return nil, decodeError(respBody, resp.StatusCode, opts)
+
+		reqID := ""
+		if resp.StatusCode >= 500 {
+			reqID = resp.Header.Get("X-Pulumi-Request-ID")
+		}
+		return nil, decodeError(respBody, resp.StatusCode, opts, reqID)
 	}
 
 	return resp, nil
 }
 
-func decodeError(respBody []byte, statusCode int, opts httpCallOptions) error {
+func decodeError(respBody []byte, statusCode int, opts httpCallOptions, reqID string) error {
 	if opts.ErrorResponse != nil {
 		if err := json.Unmarshal(respBody, opts.ErrorResponse); err == nil {
 			return opts.ErrorResponse.(error)
@@ -1553,6 +1558,9 @@ func decodeError(respBody []byte, statusCode int, opts httpCallOptions) error {
 	if err := json.Unmarshal(respBody, &errResp); err != nil {
 		errResp.Code = statusCode
 		errResp.Message = strings.TrimSpace(string(respBody))
+	}
+	if reqID != "" {
+		errResp.Message = fmt.Sprintf("%s (Request ID: %s)", errResp.Message, reqID)
 	}
 	return &errResp
 }

--- a/cmd/esc/cli/client/client_test.go
+++ b/cmd/esc/cli/client/client_test.go
@@ -1304,6 +1304,58 @@ func TestDeleteEnvironmentTags(t *testing.T) {
 	})
 }
 
+func TestServerErrorRequestID(t *testing.T) {
+	t.Run("500 with request ID", func(t *testing.T) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Pulumi-Request-ID", "test-req-id-123")
+			w.WriteHeader(http.StatusInternalServerError)
+
+			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
+				Code:    500,
+				Message: "internal server error",
+			})
+			require.NoError(t, err)
+		})
+
+		_, _, err := client.ListEnvironments(context.Background(), "")
+		assert.ErrorContains(t, err, "internal server error")
+		assert.ErrorContains(t, err, "(Request ID: test-req-id-123)")
+	})
+
+	t.Run("500 without request ID", func(t *testing.T) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+
+			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
+				Code:    500,
+				Message: "internal server error",
+			})
+			require.NoError(t, err)
+		})
+
+		_, _, err := client.ListEnvironments(context.Background(), "")
+		assert.ErrorContains(t, err, "internal server error")
+		assert.NotContains(t, err.Error(), "Request ID")
+	})
+
+	t.Run("4xx does not include request ID", func(t *testing.T) {
+		client := newTestClient(t, http.MethodGet, "/api/esc/environments", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Pulumi-Request-ID", "test-req-id-456")
+			w.WriteHeader(http.StatusBadRequest)
+
+			err := json.NewEncoder(w).Encode(apitype.ErrorResponse{
+				Code:    400,
+				Message: "bad request",
+			})
+			require.NoError(t, err)
+		})
+
+		_, _, err := client.ListEnvironments(context.Background(), "")
+		assert.ErrorContains(t, err, "bad request")
+		assert.NotContains(t, err.Error(), "Request ID")
+	})
+}
+
 func TestGetDefaultOrg(t *testing.T) {
 	t.Run("Not Found", func(t *testing.T) {
 		// GIVEN


### PR DESCRIPTION
If we get a 500 from Pulumi Cloud, we currently get no further indication of what happened, other than "Internal Server Error".  We have a request ID in the response headers from Pulumi Cloud, so we can make use of that, and add it to the error message.

This can help us track down logs from the Cloud to see what happened.

/xref https://github.com/pulumi/pulumi/issues/22690

(We implemented the same thing in pulumi/pulumi in https://github.com/pulumi/pulumi/pull/20653).