### PR TITLE
cli: infer a default environment when none is specified

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,10 @@
 - Surface warnings when editing environments with the CLI
   [#631](https://github.com/pulumi/esc/pull/631)
 
+- Infer a default environment from a `.esc.yaml` in the working directory or from the selected
+  Pulumi IaC stack when no environment is given on the command line. Run `esc env --help` for
+  the `.esc.yaml` schema.
+
 ### Bug Fixes
 
 ### Breaking changes

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -1282,6 +1282,7 @@ type testExec struct {
 	fs       testFS
 	environ  map[string]string
 	commands map[string]string
+	cwd      string
 
 	parentPath string
 	login      *testLoginManager
@@ -1303,6 +1304,19 @@ func (c *testExec) Run(cmd *exec.Cmd) error {
 		return errors.New("command not found")
 	}
 	return c.runScript(script, cmd)
+}
+
+func (c *testExec) Output(cmd *exec.Cmd) ([]byte, error) {
+	if cmd.Stdout != nil {
+		return nil, errors.New("exec: Stdout already set")
+	}
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if cmd.Stderr == nil {
+		cmd.Stderr = io.Discard
+	}
+	err := c.Run(cmd)
+	return stdout.Bytes(), err
 }
 
 func (c *testExec) runScript(script string, cmd *exec.Cmd) error {
@@ -1341,6 +1355,7 @@ func (c *testExec) runScript(script string, cmd *exec.Cmd) error {
 					environ:         environ,
 					exec:            c,
 					pager:           testPager(0),
+					cwd:             c.cwd,
 					newClient: func(_, backendURL, accessToken string, insecure bool) client.Client {
 						return c.client
 					},
@@ -1421,6 +1436,7 @@ type cliTestcaseProcess struct {
 	FS       map[string]string `yaml:"fs,omitempty"`
 	Environ  map[string]string `yaml:"environ,omitempty"`
 	Commands map[string]string `yaml:"commands,omitempty"`
+	Cwd      string            `yaml:"cwd,omitempty"`
 }
 
 type cliTestcaseRetract struct {
@@ -1495,6 +1511,7 @@ func loadTestcase(path string) (*cliTestcaseYAML, *cliTestcase, error) {
 
 		exec.environ = testcase.Process.Environ
 		exec.commands = testcase.Process.Commands
+		exec.cwd = testcase.Process.Cwd
 	}
 
 	environments := map[string]*testEnvironment{}

--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -53,6 +53,25 @@ func newEnvCmd(esc *escCommand) *cobra.Command {
 			"\n" +
 			"This will prompt you to create a new environment to hold secrets and configuration.\n" +
 			"\n" +
+			"Most subcommands accept an explicit environment name. When one is not given, the default\n" +
+			"environment is inferred from a `.esc.yaml` file in the current directory or any parent,\n" +
+			"falling back to the imports of the currently-selected Pulumi IaC stack.\n" +
+			"\n" +
+			"The `.esc.yaml` schema accepts three forms under its `environment` field:\n" +
+			"\n" +
+			"  # A reference to a single environment.\n" +
+			"  environment: my-org/my-project/my-env\n" +
+			"\n" +
+			"  # An anonymous list of imports, opened in the named organization.\n" +
+			"  environment:\n" +
+			"    organization: my-org\n" +
+			"    imports:\n" +
+			"      - my-project/my-env\n" +
+			"\n" +
+			"  # A command to run. Its stdout must be JSON in either of the two forms above.\n" +
+			"  environment:\n" +
+			"    command: my-tool resolve-env\n" +
+			"\n" +
 			"For more information, please visit the project page: https://www.pulumi.com/docs/esc",
 
 		Args: cobra.NoArgs,
@@ -81,6 +100,17 @@ func newEnvCmd(esc *escCommand) *cobra.Command {
 	return cmd
 }
 
+type environmentDesc interface {
+	isEnvironmentDesc()
+}
+
+type importList struct {
+	orgName string
+	imports []string
+}
+
+func (importList) isEnvironmentDesc() {}
+
 type environmentRef struct {
 	orgName     string
 	projectName string
@@ -90,6 +120,8 @@ type environmentRef struct {
 	isUsingLegacyID  bool
 	hasAmbiguousPath bool
 }
+
+func (r environmentRef) isEnvironmentDesc() {}
 
 func (r *environmentRef) Id() string {
 	s := fmt.Sprintf("%s/%s", r.projectName, r.envName)
@@ -244,20 +276,19 @@ func (cmd *envCommand) getNewEnvRef(
 
 // Get an environment reference for an existing environment
 // If the given path is ambiguous, we need to make additional API calls to disambiguate
-func (cmd *envCommand) getExistingEnvRef(
-	ctx context.Context,
-	args []string,
-) (environmentRef, []string, error) {
+func (cmd *envCommand) getExistingEnvRefArg(ctx context.Context, args []string) (*environmentRef, []string, error) {
 	if cmd.envNameFlag == "" {
 		if len(args) == 0 {
-			return environmentRef{}, nil, fmt.Errorf("no environment name specified")
+			return nil, nil, nil
 		}
 		cmd.envNameFlag, args = args[0], args[1:]
 	}
 
 	envRef, err := cmd.getExistingEnvRefWithRelative(ctx, cmd.envNameFlag, nil)
-
-	return envRef, args, err
+	if err != nil {
+		return nil, nil, err
+	}
+	return &envRef, args, err
 }
 
 func (cmd *envCommand) getExistingEnvRefWithRelative(
@@ -266,7 +297,6 @@ func (cmd *envCommand) getExistingEnvRefWithRelative(
 	rel *environmentRef,
 ) (environmentRef, error) {
 	ref, _ := cmd.getEnvRef(refString, rel)
-
 	if !ref.hasAmbiguousPath {
 		return ref, nil
 	}
@@ -305,6 +335,45 @@ func (cmd *envCommand) getExistingEnvRefWithRelative(
 	}
 
 	return ref, nil
+}
+
+// getExistingEnvDesc resolves the environment to operate on, falling back to the inferred default
+// when args is empty and -e was not given. Returns a nil environmentDesc when neither an explicit
+// nor a default environment is available; callers that require one must check for nil.
+func (cmd *envCommand) getExistingEnvDesc(ctx context.Context, args []string) (environmentDesc, []string, error) {
+	ref, rest, err := cmd.getExistingEnvRefArg(ctx, args)
+	if err != nil {
+		return nil, nil, err
+	}
+	if ref != nil {
+		return *ref, rest, nil
+	}
+
+	desc, err := cmd.inferDefaultEnv(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("configuring default environment: %w", err)
+	}
+	return desc, args, nil
+}
+
+// getExistingEnvRef is like getExistingEnvDesc but errors if the resolved environment is an
+// anonymous import list rather than a single environment reference. Use it for commands that
+// must operate on a specific named environment.
+func (cmd *envCommand) getExistingEnvRef(ctx context.Context, args []string) (environmentRef, []string, error) {
+	desc, rest, err := cmd.getExistingEnvDesc(ctx, args)
+	if err != nil {
+		return environmentRef{}, nil, err
+	}
+	switch desc := desc.(type) {
+	case nil:
+		return environmentRef{}, nil, fmt.Errorf("no environment name specified")
+	case environmentRef:
+		return desc, rest, nil
+	case importList:
+		return environmentRef{}, nil, fmt.Errorf("this command does not support inferred environment lists")
+	default:
+		return environmentRef{}, nil, fmt.Errorf("unexpected environment desc of type %T", desc)
+	}
 }
 
 func sortEnvironmentDiagnostics(diags []client.EnvironmentDiagnostic) {

--- a/cmd/esc/cli/env_get.go
+++ b/cmd/esc/cli/env_get.go
@@ -40,7 +40,7 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "get [<org-name>/][<project-name>/]<environment-name>[@<version>] <path>",
-		Args:  cobra.RangeArgs(1, 2),
+		Args:  cobra.RangeArgs(0, 2),
 		Short: "Get a value within an environment.",
 		Long: "Get a value within an environment\n" +
 			"\n" +

--- a/cmd/esc/cli/env_infer.go
+++ b/cmd/esc/cli/env_infer.go
@@ -1,0 +1,219 @@
+// Copyright 2023, Pulumi Corporation.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+	"mvdan.cc/sh/v3/shell"
+)
+
+// dotESC is the parsed shape of a .esc.yaml file. See `esc env --help` for the user-facing schema.
+type dotESC struct {
+	Environment *dotESCEnv `yaml:"environment,omitempty"`
+}
+
+// dotESCEnv decodes from a string, an organization+imports object, or a command object. The
+// UnmarshalYAML method picks the form based on the shape of the value; exactly one of the three
+// fields will be set.
+type dotESCEnv struct {
+	Environment string
+	Imports     *dotESCImports
+	Command     *dotESCCommand
+}
+
+type dotESCImports struct {
+	Organization string   `yaml:"organization"`
+	Imports      []string `yaml:"imports"`
+}
+
+type dotESCCommand struct {
+	Command string `yaml:"command"`
+}
+
+func (e *dotESCEnv) UnmarshalYAML(n *yaml.Node) error {
+	stringErr := n.Decode(&e.Environment)
+	if stringErr == nil {
+		return nil
+	}
+
+	var command dotESCCommand
+	commandErr := n.Decode(&command)
+	if commandErr == nil && command.Command != "" {
+		e.Command = &command
+		return nil
+	}
+
+	var imports dotESCImports
+	importsErr := n.Decode(&imports)
+	if importsErr == nil && (imports.Organization != "" || len(imports.Imports) != 0) {
+		e.Imports = &imports
+		return nil
+	}
+
+	return errors.Join(stringErr, commandErr, importsErr)
+}
+
+// inferCommandEnv runs command and decodes its stdout as a JSON-encoded environment reference or
+// import list.
+func (cmd *envCommand) inferCommandEnv(ctx context.Context, command string) (environmentDesc, error) {
+	fields, err := shell.Fields(command, nil)
+	if err != nil {
+		return nil, fmt.Errorf("parsing default environment command: %w", err)
+	}
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("default environment command is empty")
+	}
+
+	// The command comes from a .esc.yaml file under the user's control, just like the editor in
+	// `esc env edit`. Running it is the whole point.
+	//nolint:gosec
+	out, err := cmd.esc.exec.Output(exec.CommandContext(ctx, fields[0], fields[1:]...))
+	if err != nil {
+		return nil, fmt.Errorf("running %q: %w", command, err)
+	}
+
+	var environment string
+	if err := json.Unmarshal(out, &environment); err == nil {
+		return cmd.parseRef(environment), nil
+	}
+
+	var imports dotESCImports
+	if err := json.Unmarshal(out, &imports); err == nil {
+		return importList{orgName: imports.Organization, imports: imports.Imports}, nil
+	}
+
+	return nil, fmt.Errorf(
+		"parsing default environment command output: must be string | "+
+			"{organization: string, imports: []string}, got %q", string(out))
+}
+
+// inferFSEnv walks up from startDir looking for a .esc.yaml that names a default environment.
+func (cmd *envCommand) inferFSEnv(ctx context.Context, startDir string) (environmentDesc, error) {
+	dotESC, err := cmd.findDotESC(startDir)
+	if err != nil || dotESC == nil || dotESC.Environment == nil {
+		return nil, err
+	}
+
+	switch {
+	case dotESC.Environment.Environment != "":
+		return cmd.parseRef(dotESC.Environment.Environment), nil
+	case dotESC.Environment.Imports != nil:
+		return importList{
+			orgName: dotESC.Environment.Imports.Organization,
+			imports: dotESC.Environment.Imports.Imports,
+		}, nil
+	case dotESC.Environment.Command != nil:
+		return cmd.inferCommandEnv(ctx, dotESC.Environment.Command.Command)
+	default:
+		return nil, nil
+	}
+}
+
+// findDotESC walks up from startDir and decodes the first .esc.yaml it finds.
+func (cmd *envCommand) findDotESC(startDir string) (*dotESC, error) {
+	dir := startDir
+	var dotESCFile fs.File
+	for {
+		path := filepath.Join(dir, ".esc.yaml")
+		f, err := cmd.esc.fs.Open(path)
+		if err == nil {
+			dotESCFile = f
+			break
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("opening %v: %w", path, err)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil, nil
+		}
+		dir = parent
+	}
+	defer dotESCFile.Close()
+
+	var dotESC dotESC
+	if err := yaml.NewDecoder(dotESCFile).Decode(&dotESC); err != nil {
+		return nil, fmt.Errorf("decoding .esc.yaml: %w", err)
+	}
+	return &dotESC, nil
+}
+
+// inferPulumiIaCEnv resolves the imports of the currently-selected Pulumi IaC stack as an
+// anonymous environment.
+func (cmd *envCommand) inferPulumiIaCEnv(ctx context.Context) (environmentDesc, error) {
+	// Imported environments come from the selected stack's config.
+	out, err := cmd.esc.exec.Output(exec.CommandContext(ctx, "pulumi", "config", "env", "ls", "-j"))
+	if err != nil {
+		return nil, fmt.Errorf(`running "pulumi config env ls -j": %w`, err)
+	}
+	var imports []string
+	if err := json.Unmarshal(out, &imports); err != nil {
+		return nil, fmt.Errorf("unmarshaling environment list: %w", err)
+	}
+	if len(imports) == 0 {
+		return nil, nil
+	}
+
+	// The organization comes from the selected stack's name.
+	out, err = cmd.esc.exec.Output(exec.CommandContext(ctx, "pulumi", "stack", "ls", "-Q", "-j"))
+	if err != nil {
+		return nil, fmt.Errorf(`running "pulumi stack ls -Q -j": %w`, err)
+	}
+
+	var stacks []struct {
+		Name    string `json:"name"`
+		Current bool   `json:"current"`
+	}
+	if err := json.Unmarshal(out, &stacks); err != nil {
+		return nil, fmt.Errorf("unmarshaling stack list: %w", err)
+	}
+
+	var stackName string
+	for _, s := range stacks {
+		if s.Current {
+			stackName = s.Name
+			break
+		}
+	}
+	if stackName == "" {
+		return nil, fmt.Errorf("no stack selected")
+	}
+	orgName, _, ok := strings.Cut(stackName, "/")
+	if !ok {
+		return nil, fmt.Errorf("could not determine organization for stack %q", stackName)
+	}
+	return importList{orgName: orgName, imports: imports}, nil
+}
+
+// inferDefaultEnv resolves the default environment from a .esc.yaml in the working directory or
+// any parent, falling back to the imports of the currently-selected Pulumi IaC stack.
+func (cmd *envCommand) inferDefaultEnv(ctx context.Context) (environmentDesc, error) {
+	dir := cmd.esc.cwd
+	if dir == "" {
+		var err error
+		dir, err = os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("getting working directory: %w", err)
+		}
+	}
+
+	env, err := cmd.inferFSEnv(ctx, dir)
+	if err != nil || env != nil {
+		return env, err
+	}
+
+	// The Pulumi IaC fallback is best-effort: pulumi may not be installed and the working
+	// directory may not be a Pulumi project.
+	env, _ = cmd.inferPulumiIaCEnv(ctx)
+	return env, nil
+}

--- a/cmd/esc/cli/env_infer_test.go
+++ b/cmd/esc/cli/env_infer_test.go
@@ -1,0 +1,366 @@
+// Copyright 2023, Pulumi Corporation.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/esc/cmd/esc/cli/client"
+	"github.com/pulumi/esc/cmd/esc/cli/workspace"
+)
+
+// inferFixture wires up an envCommand with the minimum dependencies needed by the inference code:
+// a virtual filesystem, an account (for parseRef defaults), and a stub exec for command-form
+// inference and the Pulumi IaC fallback.
+type inferFixture struct {
+	cmd *envCommand
+	fs  testFS
+	exe *inferExec
+}
+
+func newInferFixture() *inferFixture {
+	fs := testFS{MapFS: fstest.MapFS{}}
+	exe := &inferExec{
+		results: map[string]inferExecResult{},
+	}
+	esc := &escCommand{
+		fs:      fs,
+		exec:    exe,
+		account: workspace.Account{DefaultOrg: "default-org"},
+	}
+	return &inferFixture{
+		cmd: &envCommand{esc: esc},
+		fs:  fs,
+		exe: exe,
+	}
+}
+
+// writeFile adds a file to the fixture's virtual filesystem at the given (slash-separated, no
+// leading slash) path.
+func (f *inferFixture) writeFile(path, contents string) {
+	f.fs.MapFS[path] = &fstest.MapFile{Data: []byte(contents), Mode: 0o600}
+}
+
+// inferExecResult is the canned result for a single Output() invocation, keyed by the joined
+// command line in inferExec.results.
+type inferExecResult struct {
+	stdout string
+	err    error
+}
+
+type inferExec struct {
+	results map[string]inferExecResult
+	calls   []string
+}
+
+func (e *inferExec) LookPath(command string) (string, error) {
+	return command, nil
+}
+
+func (e *inferExec) Run(cmd *exec.Cmd) error {
+	_, err := e.Output(cmd)
+	return err
+}
+
+func (e *inferExec) Output(cmd *exec.Cmd) ([]byte, error) {
+	key := commandKey(cmd)
+	e.calls = append(e.calls, key)
+	r, ok := e.results[key]
+	if !ok {
+		return nil, errors.New("command not found: " + key)
+	}
+	if cmd.Stdout != nil {
+		_, _ = io.Copy(cmd.Stdout, bytes.NewReader([]byte(r.stdout)))
+	}
+	return []byte(r.stdout), r.err
+}
+
+func commandKey(cmd *exec.Cmd) string {
+	args := append([]string{filepath.Base(cmd.Path)}, cmd.Args[1:]...)
+	return shellJoin(args)
+}
+
+func shellJoin(args []string) string {
+	var b bytes.Buffer
+	for i, a := range args {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(a)
+	}
+	return b.String()
+}
+
+func TestInferFSEnv_StringRef(t *testing.T) {
+	f := newInferFixture()
+	f.writeFile("home/user/project/.esc.yaml", "environment: my-org/my-project/my-env@v1\n")
+
+	desc, err := f.cmd.inferFSEnv(context.Background(), "home/user/project")
+	require.NoError(t, err)
+
+	ref, ok := desc.(environmentRef)
+	require.True(t, ok, "expected environmentRef, got %T", desc)
+	assert.Equal(t, "my-org", ref.orgName)
+	assert.Equal(t, "my-project", ref.projectName)
+	assert.Equal(t, "my-env", ref.envName)
+	assert.Equal(t, "v1", ref.version)
+}
+
+func TestInferFSEnv_LegacyOneIdentifier(t *testing.T) {
+	f := newInferFixture()
+	f.writeFile("home/user/.esc.yaml", "environment: my-env\n")
+
+	desc, err := f.cmd.inferFSEnv(context.Background(), "home/user")
+	require.NoError(t, err)
+
+	ref, ok := desc.(environmentRef)
+	require.True(t, ok)
+	assert.Equal(t, "default-org", ref.orgName)
+	assert.Equal(t, client.DefaultProject, ref.projectName)
+	assert.Equal(t, "my-env", ref.envName)
+}
+
+func TestInferFSEnv_Imports(t *testing.T) {
+	f := newInferFixture()
+	f.writeFile("home/user/.esc.yaml", `environment:
+  organization: my-org
+  imports:
+    - my-project/my-env
+    - other-project/other-env
+`)
+
+	desc, err := f.cmd.inferFSEnv(context.Background(), "home/user")
+	require.NoError(t, err)
+
+	list, ok := desc.(importList)
+	require.True(t, ok, "expected importList, got %T", desc)
+	assert.Equal(t, "my-org", list.orgName)
+	assert.Equal(t, []string{"my-project/my-env", "other-project/other-env"}, list.imports)
+}
+
+func TestInferFSEnv_Command(t *testing.T) {
+	f := newInferFixture()
+	f.writeFile("home/user/.esc.yaml", `environment:
+  command: my-tool resolve-env
+`)
+	f.exe.results["my-tool resolve-env"] = inferExecResult{stdout: `"my-org/my-project/my-env"`}
+
+	desc, err := f.cmd.inferFSEnv(context.Background(), "home/user")
+	require.NoError(t, err)
+
+	ref, ok := desc.(environmentRef)
+	require.True(t, ok)
+	assert.Equal(t, "my-org", ref.orgName)
+	assert.Equal(t, "my-project", ref.projectName)
+	assert.Equal(t, "my-env", ref.envName)
+}
+
+func TestInferFSEnv_WalksUp(t *testing.T) {
+	f := newInferFixture()
+	f.writeFile("home/user/.esc.yaml", "environment: my-env\n")
+
+	desc, err := f.cmd.inferFSEnv(context.Background(), "home/user/project/sub/dir")
+	require.NoError(t, err)
+
+	ref, ok := desc.(environmentRef)
+	require.True(t, ok)
+	assert.Equal(t, "my-env", ref.envName)
+}
+
+func TestInferFSEnv_NoFile(t *testing.T) {
+	f := newInferFixture()
+
+	desc, err := f.cmd.inferFSEnv(context.Background(), "home/user/project")
+	require.NoError(t, err)
+	assert.Nil(t, desc)
+}
+
+func TestInferFSEnv_EmptyEnvironmentField(t *testing.T) {
+	f := newInferFixture()
+	f.writeFile("home/user/.esc.yaml", "environment:\n")
+
+	desc, err := f.cmd.inferFSEnv(context.Background(), "home/user")
+	require.NoError(t, err)
+	assert.Nil(t, desc)
+}
+
+func TestInferFSEnv_InvalidYAML(t *testing.T) {
+	f := newInferFixture()
+	f.writeFile("home/user/.esc.yaml", "environment: { unclosed\n")
+
+	_, err := f.cmd.inferFSEnv(context.Background(), "home/user")
+	assert.Error(t, err)
+}
+
+func TestInferFSEnv_NearestWins(t *testing.T) {
+	// A .esc.yaml in a closer ancestor takes precedence over one further up the tree.
+	f := newInferFixture()
+	f.writeFile("home/.esc.yaml", "environment: outer-env\n")
+	f.writeFile("home/user/.esc.yaml", "environment: inner-env\n")
+
+	desc, err := f.cmd.inferFSEnv(context.Background(), "home/user/project")
+	require.NoError(t, err)
+
+	ref, ok := desc.(environmentRef)
+	require.True(t, ok)
+	assert.Equal(t, "inner-env", ref.envName)
+}
+
+func TestInferCommandEnv_StringOutput(t *testing.T) {
+	f := newInferFixture()
+	f.exe.results["my-tool"] = inferExecResult{stdout: `"my-org/my-project/my-env"`}
+
+	desc, err := f.cmd.inferCommandEnv(context.Background(), "my-tool")
+	require.NoError(t, err)
+
+	ref, ok := desc.(environmentRef)
+	require.True(t, ok)
+	assert.Equal(t, "my-env", ref.envName)
+}
+
+func TestInferCommandEnv_ImportsOutput(t *testing.T) {
+	f := newInferFixture()
+	f.exe.results["my-tool resolve"] = inferExecResult{
+		stdout: `{"organization":"my-org","imports":["a/b","c/d"]}`,
+	}
+
+	desc, err := f.cmd.inferCommandEnv(context.Background(), "my-tool resolve")
+	require.NoError(t, err)
+
+	list, ok := desc.(importList)
+	require.True(t, ok)
+	assert.Equal(t, "my-org", list.orgName)
+	assert.Equal(t, []string{"a/b", "c/d"}, list.imports)
+}
+
+func TestInferCommandEnv_UnparseableOutput(t *testing.T) {
+	f := newInferFixture()
+	f.exe.results["my-tool"] = inferExecResult{stdout: `not json`}
+
+	_, err := f.cmd.inferCommandEnv(context.Background(), "my-tool")
+	assert.ErrorContains(t, err, "parsing default environment command output")
+}
+
+func TestInferCommandEnv_EmptyCommand(t *testing.T) {
+	f := newInferFixture()
+
+	_, err := f.cmd.inferCommandEnv(context.Background(), "   ")
+	assert.ErrorContains(t, err, "default environment command is empty")
+}
+
+func TestInferCommandEnv_CommandFails(t *testing.T) {
+	f := newInferFixture()
+	f.exe.results["my-tool"] = inferExecResult{err: errors.New("boom")}
+
+	_, err := f.cmd.inferCommandEnv(context.Background(), "my-tool")
+	assert.ErrorContains(t, err, "running")
+	assert.ErrorContains(t, err, "boom")
+}
+
+func TestInferPulumiIaCEnv_NoImports(t *testing.T) {
+	f := newInferFixture()
+	f.exe.results["pulumi config env ls -j"] = inferExecResult{stdout: `[]`}
+
+	desc, err := f.cmd.inferPulumiIaCEnv(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, desc)
+}
+
+func TestInferPulumiIaCEnv_OK(t *testing.T) {
+	f := newInferFixture()
+	f.exe.results["pulumi config env ls -j"] = inferExecResult{stdout: `["my-project/my-env"]`}
+	f.exe.results["pulumi stack ls -Q -j"] = inferExecResult{
+		stdout: `[{"name":"other-org/other-project/dev","current":false},
+			    {"name":"my-org/my-project/prod","current":true}]`,
+	}
+
+	desc, err := f.cmd.inferPulumiIaCEnv(context.Background())
+	require.NoError(t, err)
+
+	list, ok := desc.(importList)
+	require.True(t, ok)
+	assert.Equal(t, "my-org", list.orgName)
+	assert.Equal(t, []string{"my-project/my-env"}, list.imports)
+}
+
+func TestInferPulumiIaCEnv_NoCurrentStack(t *testing.T) {
+	f := newInferFixture()
+	f.exe.results["pulumi config env ls -j"] = inferExecResult{stdout: `["my-project/my-env"]`}
+	f.exe.results["pulumi stack ls -Q -j"] = inferExecResult{stdout: `[]`}
+
+	_, err := f.cmd.inferPulumiIaCEnv(context.Background())
+	assert.ErrorContains(t, err, "no stack selected")
+}
+
+func TestInferPulumiIaCEnv_StackNameWithoutOrg(t *testing.T) {
+	f := newInferFixture()
+	f.exe.results["pulumi config env ls -j"] = inferExecResult{stdout: `["my-env"]`}
+	f.exe.results["pulumi stack ls -Q -j"] = inferExecResult{
+		stdout: `[{"name":"dev","current":true}]`,
+	}
+
+	_, err := f.cmd.inferPulumiIaCEnv(context.Background())
+	assert.ErrorContains(t, err, "could not determine organization")
+}
+
+func TestInferPulumiIaCEnv_PulumiNotFound(t *testing.T) {
+	f := newInferFixture()
+	// No pulumi command registered: Output returns an error.
+
+	_, err := f.cmd.inferPulumiIaCEnv(context.Background())
+	assert.Error(t, err)
+}
+
+func TestInferDefaultEnv_FSWins(t *testing.T) {
+	// When both .esc.yaml and Pulumi context are available, .esc.yaml wins.
+	f := newInferFixture()
+	f.cmd.esc.cwd = "home/user"
+	f.writeFile("home/user/.esc.yaml", "environment: fs-env\n")
+	f.exe.results["pulumi config env ls -j"] = inferExecResult{stdout: `["a/b"]`}
+	f.exe.results["pulumi stack ls -Q -j"] = inferExecResult{
+		stdout: `[{"name":"my-org/my-project/dev","current":true}]`,
+	}
+
+	desc, err := f.cmd.inferDefaultEnv(context.Background())
+	require.NoError(t, err)
+
+	ref, ok := desc.(environmentRef)
+	require.True(t, ok)
+	assert.Equal(t, "fs-env", ref.envName)
+}
+
+func TestInferDefaultEnv_FallsBackToPulumi(t *testing.T) {
+	f := newInferFixture()
+	f.cmd.esc.cwd = "home/user"
+	f.exe.results["pulumi config env ls -j"] = inferExecResult{stdout: `["a/b"]`}
+	f.exe.results["pulumi stack ls -Q -j"] = inferExecResult{
+		stdout: `[{"name":"my-org/my-project/dev","current":true}]`,
+	}
+
+	desc, err := f.cmd.inferDefaultEnv(context.Background())
+	require.NoError(t, err)
+
+	list, ok := desc.(importList)
+	require.True(t, ok)
+	assert.Equal(t, "my-org", list.orgName)
+}
+
+func TestInferDefaultEnv_NoSourceReturnsNil(t *testing.T) {
+	f := newInferFixture()
+	f.cmd.esc.cwd = "home/user"
+	// No .esc.yaml; pulumi command not registered, error is suppressed.
+
+	desc, err := f.cmd.inferDefaultEnv(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, desc)
+}

--- a/cmd/esc/cli/env_ls.go
+++ b/cmd/esc/cli/env_ls.go
@@ -29,8 +29,20 @@ func newEnvLsCmd(env *envCommand) *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 
+			desc, err := env.inferDefaultEnv(ctx)
+			if err != nil {
+				return fmt.Errorf("configuring default environment: %w", err)
+			}
+			ref, hasDefaultRef := desc.(environmentRef)
+
 			if err := env.esc.getCachedClient(ctx); err != nil {
 				return err
+			}
+
+			// listEnvironments empties Organization for envs in the calling user's namespace, so
+			// normalize the inferred ref the same way before comparing.
+			if hasDefaultRef && ref.orgName == env.esc.account.Username {
+				ref.orgName = ""
 			}
 
 			allEnvs, err := env.listEnvironments(ctx, orgFilter, projectFilter)
@@ -51,10 +63,16 @@ func newEnvLsCmd(env *envCommand) *cobra.Command {
 			})
 
 			for _, e := range allEnvs {
+				isDefault := hasDefaultRef && ref.orgName == e.Organization && ref.projectName == e.Project && ref.envName == e.Name
+				defaultSuffix := ""
+				if isDefault {
+					defaultSuffix = " (default)"
+				}
+
 				if e.Organization == "" {
-					fmt.Fprintf(env.esc.stdout, "%v/%v\n", e.Project, e.Name)
+					fmt.Fprintf(env.esc.stdout, "%v/%v%v\n", e.Project, e.Name, defaultSuffix)
 				} else {
-					fmt.Fprintf(env.esc.stdout, "%v/%v/%v\n", e.Organization, e.Project, e.Name)
+					fmt.Fprintf(env.esc.stdout, "%v/%v/%v%v\n", e.Organization, e.Project, e.Name, defaultSuffix)
 				}
 			}
 

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -29,7 +29,10 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 		Long: "Open the environment with the given name and return the result\n" +
 			"\n" +
 			"This command opens the environment with the given name. The result is written to\n" +
-			"stdout as JSON. If a property path is specified, only retrieves that property.\n",
+			"stdout as JSON. If a property path is specified, only retrieves that property.\n" +
+			"\n" +
+			"If no environment is specified, the default environment is inferred from the working\n" +
+			"directory. See `esc env --help` for details.\n",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -38,9 +41,12 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 				return err
 			}
 
-			ref, args, err := envcmd.getExistingEnvRef(ctx, args)
+			desc, args, err := envcmd.getExistingEnvDesc(ctx, args)
 			if err != nil {
 				return err
+			}
+			if desc == nil {
+				return fmt.Errorf("no environment name specified")
 			}
 
 			var path resource.PropertyPath
@@ -63,7 +69,7 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 				return fmt.Errorf("unknown output format %q", format)
 			}
 
-			env, diags, err := envcmd.openEnvironment(ctx, ref, duration, draft)
+			env, diags, err := envcmd.openEnvironmentDesc(ctx, desc, duration, draft)
 			if err != nil {
 				return err
 			}
@@ -190,4 +196,43 @@ func (env *envCommand) openEnvironment(
 	}
 	open, err := env.esc.client.GetOpenEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName, envID)
 	return open, nil, err
+}
+
+func (env *envCommand) openImportList(
+	ctx context.Context,
+	list importList,
+	duration time.Duration,
+) (*esc.Environment, []client.EnvironmentDiagnostic, error) {
+	def, err := yaml.Marshal(map[string]any{"imports": list.imports})
+	if err != nil {
+		return nil, nil, err
+	}
+	envID, diags, err := env.esc.client.OpenYAMLEnvironment(ctx, list.orgName, def, duration)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(diags) != 0 {
+		return nil, diags, err
+	}
+	open, err := env.esc.client.GetAnonymousOpenEnvironment(ctx, list.orgName, envID)
+	return open, nil, err
+}
+
+func (env *envCommand) openEnvironmentDesc(
+	ctx context.Context,
+	desc environmentDesc,
+	duration time.Duration,
+	changeRequestID string,
+) (*esc.Environment, []client.EnvironmentDiagnostic, error) {
+	switch desc := desc.(type) {
+	case environmentRef:
+		return env.openEnvironment(ctx, desc, duration, changeRequestID)
+	case importList:
+		if changeRequestID != "" {
+			return nil, nil, fmt.Errorf("--draft is not supported for an inferred environment list")
+		}
+		return env.openImportList(ctx, desc, duration)
+	default:
+		return nil, nil, fmt.Errorf("unexpected environment desc of type %T", desc)
+	}
 }

--- a/cmd/esc/cli/env_run.go
+++ b/cmd/esc/cli/env_run.go
@@ -119,7 +119,14 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 			"It is not strictly required that you pass `--`. The `--` indicates that any\n"+
 			"arguments that follow it should be treated as positional arguments instead of flags.\n"+
 			"It is only required if the arguments to the command you would like to run include\n"+
-			"flags of the form `--flag` or `-f`.\n", shell),
+			"flags of the form `--flag` or `-f`.\n"+
+			"\n"+
+			"If no environment is specified before `--`, the default environment is inferred from\n"+
+			"the working directory:\n"+
+			"\n"+
+			"    run -- mycommand\n"+
+			"\n"+
+			"See `esc env --help` for details.\n", shell),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -128,13 +135,25 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 				return err
 			}
 
-			// If -- was used but there's no arguments, it means no environment was specified before the command
-			if cmd.ArgsLenAtDash() == 0 {
-				return fmt.Errorf("no environment specified")
+			// `--` separates the environment name (before) from the command (after). Without
+			// `--`, the first arg is the environment name and the rest is the command.
+			dashAt := cmd.ArgsLenAtDash()
+			hasDash := dashAt != -1
+			beforeDash := args
+			if hasDash {
+				beforeDash = args[:dashAt]
 			}
-			ref, args, err := envcmd.getExistingEnvRef(ctx, args)
+			desc, rest, err := envcmd.getExistingEnvDesc(ctx, beforeDash)
 			if err != nil {
 				return err
+			}
+			if hasDash {
+				args = args[dashAt:]
+			} else {
+				args = rest
+			}
+			if desc == nil {
+				return fmt.Errorf("no environment specified")
 			}
 
 			if len(args) == 0 {
@@ -146,7 +165,7 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 			}
 			args = args[1:]
 
-			env, diags, err := envcmd.openEnvironment(ctx, ref, duration, draft)
+			env, diags, err := envcmd.openEnvironmentDesc(ctx, desc, duration, draft)
 			if err != nil {
 				return err
 			}

--- a/cmd/esc/cli/esc.go
+++ b/cmd/esc/cli/esc.go
@@ -38,6 +38,7 @@ type Options struct {
 	environ environ
 	exec    cmdExec
 	pager   pager
+	cwd     string
 
 	newClient func(userAgent, backendURL, accessToken string, insecure bool) client.Client
 }
@@ -47,6 +48,7 @@ type escCommand struct {
 	environ environ
 	exec    cmdExec
 	pager   pager
+	cwd     string
 
 	stdin  io.Reader
 	stdout io.Writer
@@ -72,6 +74,7 @@ func newESC(opts *Options) *escCommand {
 		environ:   valueOrDefault(opts.environ, newEnviron()),
 		exec:      valueOrDefault(opts.exec, newCmdExec()),
 		pager:     valueOrDefault(opts.pager, newPager()),
+		cwd:       opts.cwd,
 		stdin:     valueOrDefault(opts.Stdin, io.Reader(os.Stdin)),
 		stdout:    valueOrDefault(opts.Stdout, io.Writer(os.Stdout)),
 		stderr:    valueOrDefault(opts.Stderr, io.Writer(os.Stderr)),

--- a/cmd/esc/cli/exec.go
+++ b/cmd/esc/cli/exec.go
@@ -7,6 +7,7 @@ import "os/exec"
 type cmdExec interface {
 	LookPath(command string) (string, error)
 	Run(cmd *exec.Cmd) error
+	Output(cmd *exec.Cmd) ([]byte, error)
 }
 
 type defaultCmdExec int
@@ -21,4 +22,8 @@ func (defaultCmdExec) LookPath(command string) (string, error) {
 
 func (defaultCmdExec) Run(cmd *exec.Cmd) error {
 	return cmd.Run()
+}
+
+func (defaultCmdExec) Output(cmd *exec.Cmd) ([]byte, error) {
+	return cmd.Output()
 }

--- a/cmd/esc/cli/testdata/env-default-fs.yaml
+++ b/cmd/esc/cli/testdata/env-default-fs.yaml
@@ -1,0 +1,36 @@
+run: |
+  esc env open
+  esc env get
+process:
+  fs:
+    proj/.esc.yaml: |
+      environment: test-user/default/the-env
+  cwd: proj/sub
+environments:
+  test-user/default/the-env:
+    values:
+      foo: bar
+
+---
+> esc env open
+{
+  "foo": "bar"
+}
+> esc env get
+# Value
+```json
+{
+  "foo": "bar"
+}
+```
+# Definition
+```yaml
+values:
+  foo: bar
+
+```
+
+
+---
+> esc env open
+> esc env get

--- a/cmd/esc/cli/testdata/env-default-imports.yaml
+++ b/cmd/esc/cli/testdata/env-default-imports.yaml
@@ -1,0 +1,22 @@
+run: esc env open
+process:
+  fs:
+    proj/.esc.yaml: |
+      environment:
+        organization: test-user
+        imports:
+          - default/the-env
+  cwd: proj
+environments:
+  test-user/default/the-env:
+    values:
+      foo: bar
+
+---
+> esc env open
+{
+  "foo": "bar"
+}
+
+---
+> esc env open

--- a/cmd/esc/cli/testdata/env-default-ls.yaml
+++ b/cmd/esc/cli/testdata/env-default-ls.yaml
@@ -1,0 +1,17 @@
+run: esc env ls
+process:
+  fs:
+    proj/.esc.yaml: |
+      environment: test-user/default/env-2
+  cwd: proj
+environments:
+  test-user/default/env: true
+  test-user/default/env-2: true
+
+---
+> esc env ls
+default/env
+default/env-2 (default)
+
+---
+> esc env ls

--- a/cmd/esc/cli/testdata/env-default-none.yaml
+++ b/cmd/esc/cli/testdata/env-default-none.yaml
@@ -1,0 +1,11 @@
+run: esc env open
+error: exit status 1
+process:
+  cwd: proj
+
+---
+> esc env open
+
+---
+> esc env open
+Error: no environment name specified

--- a/cmd/esc/cli/testdata/env-default-pulumi.yaml
+++ b/cmd/esc/cli/testdata/env-default-pulumi.yaml
@@ -1,0 +1,22 @@
+run: esc env open
+process:
+  commands:
+    pulumi: |
+      case "$1 $2 $3" in
+        "config env ls") echo '["default/the-env"]' ;;
+        "stack ls -Q") echo '[{"name":"test-user/my-project/dev","current":true}]' ;;
+      esac
+  cwd: proj
+environments:
+  test-user/default/the-env:
+    values:
+      foo: bar
+
+---
+> esc env open
+{
+  "foo": "bar"
+}
+
+---
+> esc env open

--- a/cmd/esc/cli/testdata/env-default-run.yaml
+++ b/cmd/esc/cli/testdata/env-default-run.yaml
@@ -1,0 +1,20 @@
+run: esc env run -- esc-test-cmd
+process:
+  fs:
+    proj/.esc.yaml: |
+      environment: test-user/default/the-env
+  commands:
+    esc-test-cmd: echo "hello $FOO"
+  cwd: proj
+environments:
+  test-user/default/the-env:
+    values:
+      environmentVariables:
+        FOO: world
+
+---
+> esc env run -- esc-test-cmd
+hello world
+
+---
+> esc env run -- esc-test-cmd


### PR DESCRIPTION
These changes allow `esc env open`, `esc env run`, `esc env get`, and friends
to operate without an explicit environment argument. The default environment
is inferred from a `.esc.yaml` file in the working directory or any parent,
falling back to the imports of the currently-selected Pulumi IaC stack.

The `.esc.yaml` schema accepts three forms under its `environment` field: a
single environment reference, an anonymous list of imports, or a command
whose JSON stdout matches either of the prior two forms. See `esc env --help`
for the full schema.

`esc env open` and `esc env run` accept an inferred import list directly,
opening it as an anonymous environment. Commands that operate on a specific
named environment error if the inferred default is a list rather than a
single reference. `esc env ls` annotates the inferred default with `(default)`.