### PR TITLE
cli: add `new` alias for `esc env init`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,7 +1,7 @@
 ### Improvements
 
 - Add `new` as an alias for `esc env init`
-  [#641](https://github.com/pulumi/esc/pull/641)
+  [#644](https://github.com/pulumi/esc/pull/644)
 
 - Surface warnings when editing environments with the CLI
   [#631](https://github.com/pulumi/esc/pull/631)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
+- Add `new` as an alias for `esc env init`
+  [#641](https://github.com/pulumi/esc/pull/641)
+
 - Surface warnings when editing environments with the CLI
   [#631](https://github.com/pulumi/esc/pull/631)
 

--- a/cmd/esc/cli/env_init.go
+++ b/cmd/esc/cli/env_init.go
@@ -16,9 +16,10 @@ func newEnvInitCmd(env *envCommand) *cobra.Command {
 	var file string
 
 	cmd := &cobra.Command{
-		Use:   "init [<org-name>/][<project-name>/]<environment-name>",
-		Args:  cobra.MaximumNArgs(1),
-		Short: "Create an empty environment with the given name.",
+		Use:     "init [<org-name>/][<project-name>/]<environment-name>",
+		Aliases: []string{"new"},
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Create an empty environment with the given name.",
 		Long: "Create an empty environment with the given name, ready for editing\n" +
 			"\n" +
 			"This command creates an empty environment with the given name. It has no definition,\n" +


### PR DESCRIPTION
## Summary

Adds `new` as a cobra alias for `esc env init`. Users can now type either form interchangeably:

```sh
esc env init acme/myproject/myenv
esc env new  acme/myproject/myenv
```

The implementation stays in `env_init.go`; only the `Aliases:` field is added.

## Why

Part of the Cloud-Ready CLI work tracked in pulumi/pulumi#22959 — specifically the per-command sub-issue pulumi/pulumi#23042 which asked for a `pulumi env new` command. Because `pulumi env *` is a thin embedding of the esc CLI, the right place for the surface is here.

## Test plan

- [x] `go run ./cmd/esc env new --help` shows the init help with `Aliases: init, new`
- [x] `go test -count=1 -short ./cmd/esc/cli/...` — pass
- [x] `gofmt -l ./cmd/esc/cli/env_init.go` — clean
- [x] `pulumictl copyright` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)