### PR TITLE
ci: migrate golangci-lint to v2

### DIFF
--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -33,9 +33,9 @@ jobs:
       # The action doesn't have an install-only mode,
       # so we'll ask it to print its version only.
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64.7
+          version: v2.9.0
 
       - name: Lint
         run: make lint-golang

--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.9.0
+          version: v2.12.2
 
       - name: Lint
         run: make lint-golang

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,18 +1,40 @@
-run:
-  timeout: 10m
+version: "2"
 linters:
-  enable-all: false
   enable:
-    - errcheck
-    - gofmt
     - gosec
-    - govet
-    - ineffassign
     - misspell
     - nakedret
     - unconvert
   disable:
-    - lll
     - goconst
+    - lll
     - paralleltest
     - revive
+    - staticcheck
+    - unused
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gosec
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - testdata$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - testdata$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - lll
     - paralleltest
     - revive
-    - staticcheck
     - unused
   exclusions:
     generated: lax

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,10 @@
 - Surface warnings when editing environments with the CLI
   [#631](https://github.com/pulumi/esc/pull/631)
 
+- Migrate golangci-lint to v2 and enable `staticcheck`; minor reword of
+  a handful of CLI error messages as a result
+  [#648](https://github.com/pulumi/esc/pull/648)
+
 ### Bug Fixes
 
 ### Breaking changes

--- a/cmd/esc/cli/client/client.go
+++ b/cmd/esc/cli/client/client.go
@@ -1436,7 +1436,7 @@ func (pc *client) restCallWithOptions(
 			// Return the raw bytes of the response body.
 			*respObj = respBody
 		case []byte:
-			return fmt.Errorf("Can't unmarshal response body to []byte. Try *[]byte")
+			return fmt.Errorf("can't unmarshal response body to []byte, try *[]byte")
 		default:
 			// Else, unmarshal as JSON.
 			if err = json.Unmarshal(respBody, respObj); err != nil {

--- a/cmd/esc/cli/env_edit.go
+++ b/cmd/esc/cli/env_edit.go
@@ -224,8 +224,8 @@ func (edit *envEditCommand) getEditor() ([]string, error) {
 	if len(args) == 0 {
 		path, err := edit.env.esc.exec.LookPath("vi")
 		if err != nil {
-			return nil, errors.New("No available editor. Please use the --editor flag or set one of the " +
-				"VISUAL or EDITOR environment variables.")
+			return nil, errors.New("no available editor; please use the --editor flag or set one of the " +
+				"VISUAL or EDITOR environment variables")
 		}
 		args = []string{path}
 		return args, nil

--- a/cmd/esc/cli/env_rotate.go
+++ b/cmd/esc/cli/env_rotate.go
@@ -61,9 +61,10 @@ func newEnvRotateCmd(envcmd *envCommand) *cobra.Command {
 
 			// Print result of rotation
 			var b strings.Builder
-			if event.Status == client.RotationEventSucceeded {
+			switch event.Status {
+			case client.RotationEventSucceeded:
 				fmt.Fprintf(&b, "Environment '%s' rotated.\n", args[0])
-			} else if event.Status == client.RotationEventFailed {
+			case client.RotationEventFailed:
 				if event.ErrorMessage != nil {
 					fmt.Fprintf(&b, "%vError rotating: %s.%v\n", colors.SpecError, *event.ErrorMessage, colors.Reset)
 				} else {

--- a/cmd/esc/cli/gen_docs.go
+++ b/cmd/esc/cli/gen_docs.go
@@ -105,7 +105,7 @@ func newGenDocsCmd(root *cobra.Command) *cobra.Command {
 				// heading levels when these files are used to render the CLI docs on the docs site.
 				result = h3Pattern.ReplaceAllString(result, "## ")
 
-				if err := os.WriteFile(file, []byte(result), 0o600); err != nil {
+				if err := os.WriteFile(file, []byte(result), 0o600); err != nil { // #nosec G703 -- developer tool writing to user-supplied output dir
 					return err
 				}
 			}

--- a/cmd/esc/cli/login.go
+++ b/cmd/esc/cli/login.go
@@ -189,7 +189,7 @@ func (esc *escCommand) checkBackendURL(url string) error {
 		return fmt.Errorf("%s is not a valid self-hosted backend, "+
 			"use `%s login` without arguments to log into the Pulumi Cloud backend", url, esc.command)
 	case diy.IsDIYBackendURL(url):
-		return fmt.Errorf("%s does not support Pulumi ESC.", url)
+		return fmt.Errorf("%s does not support Pulumi ESC", url)
 	default:
 		return nil
 	}
@@ -234,7 +234,7 @@ func (esc *escCommand) getCachedClient(ctx context.Context) error {
 		return fmt.Errorf("getting credentials: %w", err)
 	}
 	if !ok {
-		return fmt.Errorf("no credentials. Please run `%v login` to log in.", esc.command)
+		return fmt.Errorf("no credentials, please run `%v login` to log in", esc.command)
 	}
 
 	esc.client = esc.newClient(esc.userAgent, account.BackendURL, account.AccessToken, account.Insecure)

--- a/cmd/esc/cli/login_test.go
+++ b/cmd/esc/cli/login_test.go
@@ -117,7 +117,7 @@ func TestCurrentAccountButInvalidToken(t *testing.T) {
 		login: invalidatedCredsLoginManager(0),
 	}
 	err := esc.getCachedClient(context.Background())
-	assert.ErrorContains(t, err, "no credentials. Please run `esc login` to log in.")
+	assert.ErrorContains(t, err, "no credentials, please run `esc login` to log in")
 }
 
 func TestInvalidSelfHostedBackend(t *testing.T) {

--- a/cmd/esc/cli/testdata/env-edit-none-not-found.yaml
+++ b/cmd/esc/cli/testdata/env-edit-none-not-found.yaml
@@ -6,4 +6,4 @@ error: exit status 1
 
 ---
 > esc env edit default/test
-Error: No available editor. Please use the --editor flag or set one of the VISUAL or EDITOR environment variables.
+Error: no available editor; please use the --editor flag or set one of the VISUAL or EDITOR environment variables

--- a/cmd/esc/cli/workspace/credentials.go
+++ b/cmd/esc/cli/workspace/credentials.go
@@ -106,8 +106,8 @@ func (w *Workspace) GetCurrentAccount(shared bool) (*Account, bool, error) {
 	// If the account does not exist, fail.
 	account, ok := pulumiCreds.Accounts[backendURL]
 	if !ok {
-		return nil, false, fmt.Errorf("account '%s' not found."+
-			"Please re-run `esc login` to reset your credentials file.", backendURL)
+		return nil, false, fmt.Errorf("account '%s' not found, "+
+			"please re-run `esc login` to reset your credentials file", backendURL)
 	}
 
 	config, err := w.pulumi.GetPulumiConfig()

--- a/syntax/encoding/object.go
+++ b/syntax/encoding/object.go
@@ -50,7 +50,7 @@ func decodeValue(v reflect.Value) (syntax.Node, syntax.Diagnostics) {
 
 	for {
 		switch v.Kind() {
-		case reflect.Interface, reflect.Ptr:
+		case reflect.Interface, reflect.Pointer:
 			if v.IsNil() {
 				return syntax.Null(), nil
 			}
@@ -204,7 +204,7 @@ func encodeValue(n syntax.Node, v reflect.Value) syntax.Diagnostics {
 		return nil
 	}
 
-	for v.Kind() == reflect.Ptr {
+	for v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			if !v.CanSet() {
 				return nil


### PR DESCRIPTION
## Summary

Migrates the repo from golangci-lint v1.64.7 to v2.12.2. The v1 config schema is rejected by current v2 binaries (`unsupported version of the configuration: ""`), so anyone with a fresh Homebrew install can't run `make lint` against `main` today — this PR fixes that.

Aligns the toolchain with `pulumi/pulumi`, which is already on v2 (currently pinned at v2.9.0; we go to v2.12.2 to match a fresh `brew install`).

## Changes

**Config (`.golangci.yml`):**
- Migrated via `golangci-lint migrate` (v2 schema, `version: "2"`, `gofmt` moved into the new `formatters` section).
- Preserved the v1 enabled-linter set: `errcheck`, `govet`, `ineffassign` are kept (now v2 defaults); `gosec`, `misspell`, `nakedret`, `unconvert` stay explicitly enabled; `gofmt` lives in `formatters`.
- **Enabled `staticcheck`** (a v2 default — was not on under v1). `unused` stays explicitly disabled.
- Added `testdata$` to exclusion paths and a `_test.go`-scoped `gosec` exclusion (v1 didn't flag the test-file findings these new rules surface).

**Workflow (`.github/workflows/stage-lint.yml`):**
- `golangci-lint-action@v3` → `@v8`.
- `version: v1.64.7` → `version: v2.12.2`.

**Code fixes for findings surfaced under v2:**
- `syntax/encoding/object.go`: 2× `reflect.Ptr` → `reflect.Pointer` (v2 `govet/inline` flags the deprecated alias).
- `cmd/esc/cli/gen_docs.go`: `// #nosec G703` on the `WriteFile` call — `gen-docs` is a developer tool that intentionally writes to a user-supplied output directory.
- **ST1005** (5 fixes): rewrote error messages to lowercase with no trailing punctuation in `client/client.go`, `env_edit.go`, `login.go` (×2), `workspace/credentials.go`. Also fixed a latent missing-space bug in `credentials.go` where `"not found." + "Please..."` rendered as `"not found.Please..."`.
- **QF1003**: converted the `if/else-if` chain in `env_rotate.go:64` to a tagged `switch event.Status`.

**Test follow-ups for the message rewording:**
- `login_test.go:120`: `ErrorContains` substring updated.
- `testdata/env-edit-none-not-found.yaml`: golden trailer updated.

## Why

Two problems on `main` today:
1. `make lint` is unrunnable for anyone with a current local golangci-lint install — v2 binaries refuse the v1 schema.
2. The CI pin (v1.64.7) is two major versions behind, and v1.x no longer receives fixes.

Enabling `staticcheck` is a deliberate scope addition: the blast radius is small (6 findings, all minor message/style fixes), and `staticcheck` is a v2 default that brings the repo in line with pulumi/pulumi's lint posture.

## User-visible message changes

The ST1005 fixes touched 5 error strings rendered to end users. Substrings used by existing `ErrorContains` assertions were preserved where possible (e.g. `does not support Pulumi ESC` is untouched apart from the trailing period). If downstream tooling greps the exact wording of any of these messages, they'll need updating:

- `Can't unmarshal response body to []byte. Try *[]byte` → `can't unmarshal response body to []byte, try *[]byte`
- `No available editor. Please use the --editor flag or set one of the VISUAL or EDITOR environment variables.` → `no available editor; please use the --editor flag or set one of the VISUAL or EDITOR environment variables`
- `%s does not support Pulumi ESC.` → `%s does not support Pulumi ESC`
- `no credentials. Please run \`%v login\` to log in.` → `no credentials, please run \`%v login\` to log in`
- `account '%s' not found.Please re-run \`esc login\`...` → `account '%s' not found, please re-run \`esc login\`...`

## Test plan

- [x] `make format` — clean
- [x] `make lint` — 0 issues under v2.12.2 locally
- [x] `make test` — full suite passes (including the updated `TestCLI/env-edit-none-not-found.yaml` golden and the `login_test.go` substring assertion)
- [ ] CI lint job runs against v2.12.2 (this PR is the first chance to see it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)