### PR TITLE
cli: consolidate SilenceUsage/SilenceErrors on the root command

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,6 +19,11 @@
   a handful of CLI error messages as a result
   [#648](https://github.com/pulumi/esc/pull/648)
 
+- Consolidate `SilenceUsage` / `SilenceErrors` on the `esc` root command,
+  matching the `pulumi/pulumi` pattern; the CLI now prints errors itself
+  rather than relying on cobra
+  [#654](https://github.com/pulumi/esc/pull/654)
+
 ### Bug Fixes
 
 ### Breaking changes

--- a/cmd/esc/cli/cli_test.go
+++ b/cmd/esc/cli/cli_test.go
@@ -1681,6 +1681,7 @@ func (c *testExec) runScript(script string, cmd *exec.Cmd) error {
 					return ctx.Err()
 				case result := <-ch:
 					if result != nil {
+						fmt.Fprintf(hc.Stderr, "Error: %s\n", result)
 						return interp.NewExitStatus(1)
 					}
 				}

--- a/cmd/esc/cli/env_clone.go
+++ b/cmd/esc/cli/env_clone.go
@@ -29,7 +29,6 @@ func newEnvCloneCmd(env *envCommand) *cobra.Command {
 			"This command clones an existing environment with the given identifier into a new environment.\n" +
 			"If a project is omitted from the new environment identifier the new environment will be created\n" +
 			"within the same project as the environment being cloned.\n",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_diff.go
+++ b/cmd/esc/cli/env_diff.go
@@ -35,7 +35,6 @@ func newEnvDiffCmd(env *envCommand) *cobra.Command {
 			"is the comparison environment. If the environment name portion of the second\n" +
 			"argument is omitted, the name of the base environment is used. If the version portion of\n" +
 			"the second argument is omitted, the 'latest' tag is used.",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_edit.go
+++ b/cmd/esc/cli/env_edit.go
@@ -46,7 +46,6 @@ func newEnvEditCmd(env *envCommand) *cobra.Command {
 			"commands to which the name of the temporary file used for the environment is appended.\n" +
 			"If no editor is specified via the --editor flag or environment variables, edit\n" +
 			"defaults to `vi`.\n",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_get.go
+++ b/cmd/esc/cli/env_get.go
@@ -47,7 +47,6 @@ func newEnvGetCmd(env *envCommand) *cobra.Command {
 			"This command fetches the current definition for the named environment and gets a\n" +
 			"value within it. The path to the value to set is a Pulumi property path. The value\n" +
 			"is printed to stdout as YAML.\n",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_init.go
+++ b/cmd/esc/cli/env_init.go
@@ -27,7 +27,6 @@ func newEnvInitCmd(env *envCommand) *cobra.Command {
 			"\n" +
 			"To create an environment in an organization when logged in to the Pulumi Cloud,\n" +
 			"prefix the stack name with the organization name and a slash (e.g. 'acmecorp/dev').\n",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_ls.go
+++ b/cmd/esc/cli/env_ls.go
@@ -24,8 +24,7 @@ func newEnvLsCmd(env *envCommand) *cobra.Command {
 		Long: "List environments\n" +
 			"\n" +
 			"This command lists environments. All environments you have access to will be listed.\n",
-		SilenceUsage: true,
-		Args:         cobra.NoArgs,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_open.go
+++ b/cmd/esc/cli/env_open.go
@@ -30,7 +30,6 @@ func newEnvOpenCmd(envcmd *envCommand) *cobra.Command {
 			"\n" +
 			"This command opens the environment with the given name. The result is written to\n" +
 			"stdout as JSON. If a property path is specified, only retrieves that property.\n",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_open_request.go
+++ b/cmd/esc/cli/env_open_request.go
@@ -22,7 +22,6 @@ func newEnvOpenRequestCmd(envcmd *envCommand) *cobra.Command {
 			"\n" +
 			"This command creates a request to open a protected environment. The request must be\n" +
 			"approved before the environment can be accessed.\n",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_referrer.go
+++ b/cmd/esc/cli/env_referrer.go
@@ -15,8 +15,7 @@ func newEnvReferrerCmd(env *envCommand) *cobra.Command {
 			"A referrer is an entity that references an environment, such as another environment\n" +
 			"that imports it, a Pulumi IaC stack that opens it, or a Pulumi Insights account\n" +
 			"that consumes it.\n",
-		Args:         cobra.NoArgs,
-		SilenceUsage: true,
+		Args: cobra.NoArgs,
 	}
 
 	cmd.AddCommand(newEnvReferrerListCmd(env))

--- a/cmd/esc/cli/env_referrer_list.go
+++ b/cmd/esc/cli/env_referrer_list.go
@@ -30,8 +30,7 @@ func newEnvReferrerListCmd(env *envCommand) *cobra.Command {
 			"This command lists referrers (other environments, Pulumi IaC stacks, and Pulumi\n" +
 			"Insights accounts) that reference the given environment. Results are grouped by\n" +
 			"the revision of the referenced environment.\n",
-		Args:         cobra.ExactArgs(1),
-		SilenceUsage: true,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_rm.go
+++ b/cmd/esc/cli/env_rm.go
@@ -37,7 +37,6 @@ func newEnvRmCmd(env *envCommand) *cobra.Command {
 			"\n" +
 			"When removing an environment, the environment will no longer be available\n" +
 			"once this command completes.",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_rotate.go
+++ b/cmd/esc/cli/env_rotate.go
@@ -20,7 +20,6 @@ func newEnvRotateCmd(envcmd *envCommand) *cobra.Command {
 		Long: "Rotate secrets in an environment\n" +
 			"\n" +
 			"Optionally accepts any number of Property Paths as additional arguments. If given any paths, will only rotate secrets at those paths.\n",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_run.go
+++ b/cmd/esc/cli/env_run.go
@@ -120,7 +120,6 @@ func newEnvRunCmd(envcmd *envCommand) *cobra.Command {
 			"arguments that follow it should be treated as positional arguments instead of flags.\n"+
 			"It is only required if the arguments to the command you would like to run include\n"+
 			"flags of the form `--flag` or `-f`.\n", shell),
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_schedule.go
+++ b/cmd/esc/cli/env_schedule.go
@@ -14,8 +14,7 @@ func newEnvScheduleCmd(env *envCommand) *cobra.Command {
 			"\n" +
 			"A scheduled action runs against an environment on a cron schedule or at a single\n" +
 			"point in time. Today the CLI exposes secret-rotation schedules.",
-		Args:         cobra.NoArgs,
-		SilenceUsage: true,
+		Args: cobra.NoArgs,
 	}
 
 	cmd.AddCommand(newEnvScheduleEditCmd(env))

--- a/cmd/esc/cli/env_schedule_edit.go
+++ b/cmd/esc/cli/env_schedule_edit.go
@@ -30,8 +30,7 @@ func newEnvScheduleEditCmd(env *envCommand) *cobra.Command {
 			"one-time schedule at a specific time (ISO 8601 / RFC 3339).\n" +
 			"\n" +
 			"The minimum cron interval is once per day.\n",
-		Args:         cobra.ExactArgs(2),
-		SilenceUsage: true,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_schedule_get.go
+++ b/cmd/esc/cli/env_schedule_get.go
@@ -18,8 +18,7 @@ func newEnvScheduleGetCmd(env *envCommand) *cobra.Command {
 		Long: "[EXPERIMENTAL] Show details for an environment scheduled action\n" +
 			"\n" +
 			"This command retrieves details for a single scheduled action.\n",
-		Args:         cobra.ExactArgs(2),
-		SilenceUsage: true,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_schedule_history.go
+++ b/cmd/esc/cli/env_schedule_history.go
@@ -26,8 +26,7 @@ func newEnvScheduleHistoryCmd(env *envCommand) *cobra.Command {
 		Long: "[EXPERIMENTAL] Show the execution history of an environment scheduled action\n" +
 			"\n" +
 			"This command lists past executions of a scheduled action.\n",
-		Args:         cobra.ExactArgs(2),
-		SilenceUsage: true,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_schedule_list.go
+++ b/cmd/esc/cli/env_schedule_list.go
@@ -26,8 +26,7 @@ func newEnvScheduleListCmd(env *envCommand) *cobra.Command {
 		Long: "[EXPERIMENTAL] List environment scheduled actions\n" +
 			"\n" +
 			"This command lists the scheduled actions configured for the given environment.\n",
-		Args:         cobra.ExactArgs(1),
-		SilenceUsage: true,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_schedule_new.go
+++ b/cmd/esc/cli/env_schedule_new.go
@@ -30,8 +30,7 @@ func newEnvScheduleNewCmd(env *envCommand) *cobra.Command {
 			"\n" +
 			"Only one schedule per environment is currently supported; creating a second\n" +
 			"schedule will fail. The minimum cron interval is once per day.\n",
-		Args:         cobra.ExactArgs(1),
-		SilenceUsage: true,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_schedule_remove.go
+++ b/cmd/esc/cli/env_schedule_remove.go
@@ -24,8 +24,7 @@ func newEnvScheduleRemoveCmd(env *envCommand) *cobra.Command {
 			"\n" +
 			"This command removes the named scheduled action from the environment.\n" +
 			"You will be prompted to confirm by typing `remove` unless --yes is passed.\n",
-		Args:         cobra.ExactArgs(2),
-		SilenceUsage: true,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_set.go
+++ b/cmd/esc/cli/env_set.go
@@ -36,7 +36,6 @@ func newEnvSetCmd(env *envCommand) *cobra.Command {
 			"This command fetches the current definition for the named environment and modifies a\n" +
 			"value within it. The path to the value to set is a Pulumi property path. The value\n" +
 			"is interpreted as YAML.\n",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_settings_get.go
+++ b/cmd/esc/cli/env_settings_get.go
@@ -24,7 +24,6 @@ func newEnvSettingsGetCmd(env *envCommand, registry *EnvSettingsRegistry) *cobra
 			"\n" +
 			"Available settings:\n" +
 			registry.GetSettingsHelpText(),
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_settings_set.go
+++ b/cmd/esc/cli/env_settings_set.go
@@ -26,7 +26,6 @@ func newEnvSettingsSetCmd(env *envCommand, registry *EnvSettingsRegistry) *cobra
 			"\n" +
 			"Available settings:\n" +
 			registry.GetSettingsHelpText(),
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_tag.go
+++ b/cmd/esc/cli/env_tag.go
@@ -25,7 +25,6 @@ func newEnvTagCmd(env *envCommand) *cobra.Command {
 			"This command creates a tag with the given name on the specified environment.\n" +
 			"\n" +
 			"Subcommands exist for reading, listing, updating, and removing tags.",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_tag_get.go
+++ b/cmd/esc/cli/env_tag_get.go
@@ -20,7 +20,6 @@ func newEnvTagGetCmd(env *envCommand) *cobra.Command {
 		Long: "Get an environment tag\n" +
 			"\n" +
 			"This command get a tag with the given name on the specified environment.",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_tag_ls.go
+++ b/cmd/esc/cli/env_tag_ls.go
@@ -25,8 +25,7 @@ func newEnvTagLsCmd(env *envCommand) *cobra.Command {
 		Long: "List environment tags\n" +
 			"\n" +
 			"This command lists an environment's tags.\n",
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_tag_mv.go
+++ b/cmd/esc/cli/env_tag_mv.go
@@ -21,7 +21,6 @@ func newEnvTagMvCmd(env *envCommand) *cobra.Command {
 			"\n" +
 			"This command updates a tag with the given name on the specified environment, " +
 			"changing it's name.\n",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_tag_rm.go
+++ b/cmd/esc/cli/env_tag_rm.go
@@ -16,8 +16,7 @@ func newEnvTagRmCmd(env *envCommand) *cobra.Command {
 		Long: "Remove an environment tag\n" +
 			"\n" +
 			"This command removes an environment tag using the tag name.\n",
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(2),
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_version.go
+++ b/cmd/esc/cli/env_version.go
@@ -29,7 +29,6 @@ func newEnvVersionCmd(env *envCommand) *cobra.Command {
 			"\n" +
 			"Subcommands exist for viewing revision history and managing" +
 			"tagged versions.",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_version_history.go
+++ b/cmd/esc/cli/env_version_history.go
@@ -24,8 +24,7 @@ func newEnvVersionHistoryCmd(env *envCommand) *cobra.Command {
 			"\n" +
 			"This command shows the revision history for an environment. If a version\n" +
 			"is present, the logs will start at the corresponding revision.\n",
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_version_retract.go
+++ b/cmd/esc/cli/env_version_retract.go
@@ -28,7 +28,6 @@ func newEnvVersionRetractCmd(env *envCommand) *cobra.Command {
 			"The revision pointed to by the `latest` tag may not be retracted. To retract\n" +
 			"the latest revision of an environment, first update the environment with a new\n" +
 			"definition.",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_version_rollback.go
+++ b/cmd/esc/cli/env_version_rollback.go
@@ -22,7 +22,6 @@ func newEnvVersionRollbackCmd(env *envCommand) *cobra.Command {
 			"This command rolls an environment's definition back to the specified\n" +
 			"version. The environment's definition will be replaced with the\n" +
 			"definition at that version, creating a new revision.\n",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_version_tag.go
+++ b/cmd/esc/cli/env_version_tag.go
@@ -26,7 +26,6 @@ func newEnvVersionTagCmd(env *envCommand) *cobra.Command {
 			"is updated to point to the latest revision.\n" +
 			"\n" +
 			"Subcommands exist for listing and removing tagged versions.",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_version_tag_ls.go
+++ b/cmd/esc/cli/env_version_tag_ls.go
@@ -23,8 +23,7 @@ func newEnvVersionTagLsCmd(env *envCommand) *cobra.Command {
 		Long: "List tagged versions\n" +
 			"\n" +
 			"This command lists an environment's tagged versions.\n",
-		SilenceUsage: true,
-		Args:         cobra.ExactArgs(1),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_version_tag_rm.go
+++ b/cmd/esc/cli/env_version_tag_rm.go
@@ -17,7 +17,6 @@ func newEnvVersionTagRmCmd(env *envCommand) *cobra.Command {
 		Long: "Remove a tagged version\n" +
 			"\n" +
 			"This command removes the tagged version with the given name",
-		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_webhook.go
+++ b/cmd/esc/cli/env_webhook.go
@@ -13,8 +13,7 @@ func newEnvWebhookCmd(env *envCommand) *cobra.Command {
 		Long: "[EXPERIMENTAL] Manage environment webhooks\n" +
 			"\n" +
 			"A webhook delivers JSON event payloads to a URL whenever the environment changes.",
-		Args:         cobra.NoArgs,
-		SilenceUsage: true,
+		Args: cobra.NoArgs,
 	}
 
 	cmd.AddCommand(newEnvWebhookListCmd(env))

--- a/cmd/esc/cli/env_webhook_delivery.go
+++ b/cmd/esc/cli/env_webhook_delivery.go
@@ -13,8 +13,7 @@ func newEnvWebhookDeliveryCmd(env *envCommand) *cobra.Command {
 		Long: "[EXPERIMENTAL] Manage environment webhook deliveries\n" +
 			"\n" +
 			"A delivery is a single attempt to deliver a webhook payload.",
-		Args:         cobra.NoArgs,
-		SilenceUsage: true,
+		Args: cobra.NoArgs,
 	}
 
 	cmd.AddCommand(newEnvWebhookDeliveryListCmd(env))

--- a/cmd/esc/cli/env_webhook_delivery_list.go
+++ b/cmd/esc/cli/env_webhook_delivery_list.go
@@ -29,8 +29,7 @@ func newEnvWebhookDeliveryListCmd(env *envCommand) *cobra.Command {
 		Long: "[EXPERIMENTAL] List environment webhook deliveries\n" +
 			"\n" +
 			"This command lists the deliveries recorded for the named webhook.\n",
-		Args:         cobra.ExactArgs(2),
-		SilenceUsage: true,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_webhook_edit.go
+++ b/cmd/esc/cli/env_webhook_edit.go
@@ -52,8 +52,7 @@ func newEnvWebhookEditCmd(env *envCommand) *cobra.Command {
 			"\n" +
 			"--secret replaces the shared secret. Use --remove-secret to clear an existing\n" +
 			"secret; passing --secret \"\" leaves it unchanged.\n",
-		Args:         cobra.ExactArgs(2),
-		SilenceUsage: true,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_webhook_get.go
+++ b/cmd/esc/cli/env_webhook_get.go
@@ -21,8 +21,7 @@ func newEnvWebhookGetCmd(env *envCommand) *cobra.Command {
 		Long: "[EXPERIMENTAL] Get an environment webhook\n" +
 			"\n" +
 			"This command prints the named webhook attached to the given environment.\n",
-		Args:         cobra.ExactArgs(2),
-		SilenceUsage: true,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_webhook_list.go
+++ b/cmd/esc/cli/env_webhook_list.go
@@ -25,8 +25,7 @@ func newEnvWebhookListCmd(env *envCommand) *cobra.Command {
 		Long: "[EXPERIMENTAL] List environment webhooks\n" +
 			"\n" +
 			"This command lists the webhooks attached to the given environment.\n",
-		Args:         cobra.ExactArgs(1),
-		SilenceUsage: true,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_webhook_new.go
+++ b/cmd/esc/cli/env_webhook_new.go
@@ -44,8 +44,7 @@ func newEnvWebhookNewCmd(env *envCommand) *cobra.Command {
 			"  raw, ms_teams:      any http(s) URL\n" +
 			"  slack:              must begin with https://hooks.slack.com/\n" +
 			"  pulumi_deployments: must be of the form <project>/<stack>\n",
-		Args:         cobra.ExactArgs(2),
-		SilenceUsage: true,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_webhook_ping.go
+++ b/cmd/esc/cli/env_webhook_ping.go
@@ -18,8 +18,7 @@ func newEnvWebhookPingCmd(env *envCommand) *cobra.Command {
 			"\n" +
 			"This command triggers a synthetic delivery against the named webhook and prints\n" +
 			"the resulting delivery record.\n",
-		Args:         cobra.ExactArgs(2),
-		SilenceUsage: true,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/env_webhook_rm.go
+++ b/cmd/esc/cli/env_webhook_rm.go
@@ -17,8 +17,7 @@ func newEnvWebhookRmCmd(env *envCommand) *cobra.Command {
 		Long: "[EXPERIMENTAL] Remove an environment webhook\n" +
 			"\n" +
 			"This command removes the named webhook from the environment.\n",
-		Args:         cobra.ExactArgs(2),
-		SilenceUsage: true,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/esc.go
+++ b/cmd/esc/cli/esc.go
@@ -121,6 +121,8 @@ func New(opts *Options) *cobra.Command {
 			"    - %[1]s open     : Open an environment and access its contents\n"+
 			"\n"+
 			"For more information, please visit the project page: https://www.pulumi.com/docs/esc", command),
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 
 	esc := newESC(opts)

--- a/cmd/esc/cli/login.go
+++ b/cmd/esc/cli/login.go
@@ -53,8 +53,7 @@ func newLoginCmd(esc *escCommand) *cobra.Command {
 			"For `https://` URLs, the CLI will speak REST to a Pulumi Cloud that manages state and concurrency control.\n" +
 			"You can specify a default org to use when logging into the Pulumi Cloud backend or a " +
 			"self-hosted Pulumi Cloud.\n",
-		SilenceUsage: true,
-		Args:         cobra.MaximumNArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/esc/cli/version.go
+++ b/cmd/esc/cli/version.go
@@ -11,10 +11,9 @@ import (
 
 func newVersionCmd(esc *escCommand) *cobra.Command {
 	return &cobra.Command{
-		Use:          "version",
-		Short:        "Print esc's version number",
-		SilenceUsage: true,
-		Args:         cobra.NoArgs,
+		Use:   "version",
+		Short: "Print esc's version number",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(esc.stdout, "%v\n", version.Version)
 			return nil

--- a/cmd/esc/main.go
+++ b/cmd/esc/main.go
@@ -43,6 +43,7 @@ func main() {
 		return cli.New(nil).Execute()
 	}()
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

- Set `SilenceUsage: true` and `SilenceErrors: true` on the `esc` root command.
- Drop the `SilenceUsage: true` line from every individual subcommand (~45 occurrences).
- Print the error from `main.go` (and mirror the same behavior in `cli_test.go`) now that cobra no longer prints it.

Matches the `pulumi/pulumi` pattern.

Fixes #652.

## Test plan
- [x] `make format && make lint && make test` — clean across all packages.
- [x] Spot-check error output: `esc env get nonexistent/env` emits `Error: getting environment definition: [404] Not Found` on stderr and exits 1.
- [x] Spot-check usage output: `esc env ls --bogus` prints `Error: unknown flag: --bogus` with no usage spam, **matching `main`** — `SilenceUsage` was already active on every subcommand pre-PR, this PR just hoists it to the root command, so observable behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
