### PR TITLE
Show revision on env edit

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,9 @@
 - Add support for `fn::toYAML` built-in function that encodes a value as YAML.
   [#642](https://github.com/pulumi/esc/pulls/642)
 
+- Report the new revision number when an environment definition is updated (e.g. `esc env edit`,
+  `esc env provider`, `esc env version rollback`).
+
 ### Bug Fixes
 
 ### Breaking changes

--- a/cmd/esc/cli/env.go
+++ b/cmd/esc/cli/env.go
@@ -471,12 +471,12 @@ func (esc *escCommand) updateEnvironment(
 		return diags, nil
 
 	} else {
-		diags, err := esc.client.UpdateEnvironmentWithProject(ctx, ref.orgName, ref.projectName, ref.envName, yaml, tag)
+		diags, revision, err := esc.client.UpdateEnvironmentWithRevision(ctx, ref.orgName, ref.projectName, ref.envName, yaml, tag)
 		if err != nil {
 			return nil, fmt.Errorf("updating environment definition: %w", err)
 		}
 		if !client.DiagnosticsHaveErrors(diags) && envUpdateSuccessMessage != "" {
-			fmt.Fprintln(esc.stdout, envUpdateSuccessMessage)
+			fmt.Fprintf(esc.stdout, "%s (revision %d)\n", envUpdateSuccessMessage, revision)
 		}
 		return diags, nil
 	}

--- a/cmd/esc/cli/testdata/env-edit-editor-diags.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-diags.yaml
@@ -16,7 +16,7 @@ environments:
 
 ---
 > esc env edit default/test
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/cmd/esc/cli/testdata/env-edit-editor-docs-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-docs-ok.yaml
@@ -14,7 +14,7 @@ environments:
 
 ---
 > esc env edit default/test
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/cmd/esc/cli/testdata/env-edit-editor-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-editor-ok.yaml
@@ -14,7 +14,7 @@ environments:
 
 ---
 > esc env edit default/test
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/cmd/esc/cli/testdata/env-edit-file-warnings.yaml
+++ b/cmd/esc/cli/testdata/env-edit-file-warnings.yaml
@@ -8,7 +8,7 @@ environments:
 
 ---
 > esc env edit default/test -f=-
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/cmd/esc/cli/testdata/env-edit-file.yaml
+++ b/cmd/esc/cli/testdata/env-edit-file.yaml
@@ -11,7 +11,7 @@ environments:
 
 ---
 > esc env edit default/test -f=-
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json
@@ -26,7 +26,7 @@ Environment updated.
 ```
 
 > esc env edit default/test -f=def.yaml
-Environment updated.
+Environment updated. (revision 4)
 > esc env get default/test
 # Value
 ```json

--- a/cmd/esc/cli/testdata/env-edit-flag-code-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-code-ok.yaml
@@ -13,7 +13,7 @@ environments:
 
 ---
 > esc env edit default/test --editor code
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/cmd/esc/cli/testdata/env-edit-flag-editor-args.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-editor-args.yaml
@@ -14,7 +14,7 @@ environments:
 
 ---
 > esc env edit default/test --editor editor --some-flag --other-flag="a\"b"
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/cmd/esc/cli/testdata/env-edit-flag-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-flag-ok.yaml
@@ -12,7 +12,7 @@ environments:
 
 ---
 > esc env edit default/test --editor my-editor
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/cmd/esc/cli/testdata/env-edit-none-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-none-ok.yaml
@@ -12,7 +12,7 @@ environments:
 
 ---
 > esc env edit default/test
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/cmd/esc/cli/testdata/env-edit-visual-ok.yaml
+++ b/cmd/esc/cli/testdata/env-edit-visual-ok.yaml
@@ -14,7 +14,7 @@ environments:
 
 ---
 > esc env edit default/test
-Environment updated.
+Environment updated. (revision 3)
 > esc env get default/test
 # Value
 ```json

--- a/cmd/esc/cli/testdata/env-provider-aws-login-oidc.yaml
+++ b/cmd/esc/cli/testdata/env-provider-aws-login-oidc.yaml
@@ -8,7 +8,7 @@ run: |
 > esc env init default/test
 Environment created: test-user/default/test
 > esc env provider aws-login oidc default/test arn:aws:iam::123456789012:role/role-name sess
-Provider updated.
+Provider updated. (revision 2)
 > esc env get default/test --definition
 values:
   aws:
@@ -18,7 +18,7 @@ values:
           roleArn: arn:aws:iam::123456789012:role/role-name
           sessionName: sess
 > esc env provider aws-login oidc default/test arn:aws:iam::123456789012:role/role-name sess --duration 1h
-Provider updated.
+Provider updated. (revision 3)
 > esc env get default/test --definition
 values:
   aws:
@@ -29,7 +29,7 @@ values:
           sessionName: sess
           duration: 1h
 > esc env provider aws-login oidc default/test arn:aws:iam::123456789012:role/role-name sess --policy-arn arn:aws:iam::aws:policy/ReadOnlyAccess --policy-arn arn:aws:iam::aws:policy/Other --subject-attribute env --subject-attribute team
-Provider updated.
+Provider updated. (revision 4)
 > esc env get default/test --definition
 values:
   aws:

--- a/cmd/esc/cli/testdata/env-provider-aws-login-static.yaml
+++ b/cmd/esc/cli/testdata/env-provider-aws-login-static.yaml
@@ -8,7 +8,7 @@ run: |
 > esc env init default/test
 Environment created: test-user/default/test
 > esc env provider aws-login static default/test AKIAEXAMPLE shhhhhh
-Provider updated.
+Provider updated. (revision 2)
 > esc env get default/test --definition
 values:
   aws:
@@ -20,7 +20,7 @@ values:
             fn::secret:
               ciphertext: ZXNjeAAAAAHz6Ojo6OjoVtjhwQ==
 > esc env provider aws-login static default/test AKIAEXAMPLE shhhhhh --session-token toktok
-Provider updated.
+Provider updated. (revision 3)
 > esc env get default/test --definition
 values:
   aws:
@@ -35,7 +35,7 @@ values:
             fn::secret:
               ciphertext: ZXNjeAAAAAH07+v07+saq0zU
 > esc env provider aws-login static default/test AKIANEW newshhh --path other.creds
-Provider updated.
+Provider updated. (revision 4)
 > esc env get default/test --definition
 values:
   aws:

--- a/cmd/esc/cli/testdata/env-provider-azure-login-oidc.yaml
+++ b/cmd/esc/cli/testdata/env-provider-azure-login-oidc.yaml
@@ -7,7 +7,7 @@ run: |
 > esc env init default/test
 Environment created: test-user/default/test
 > esc env provider azure-login oidc default/test tid /subscriptions/sub cid
-Provider updated.
+Provider updated. (revision 2)
 > esc env get default/test --definition
 values:
   azure:
@@ -18,7 +18,7 @@ values:
         subscriptionId: /subscriptions/sub
         oidc: true
 > esc env provider azure-login oidc default/test tid /subscriptions/sub cid --subject-attribute env --subject-attribute team
-Provider updated.
+Provider updated. (revision 3)
 > esc env get default/test --definition
 values:
   azure:

--- a/cmd/esc/cli/testdata/env-provider-azure-login-static.yaml
+++ b/cmd/esc/cli/testdata/env-provider-azure-login-static.yaml
@@ -6,7 +6,7 @@ run: |
 > esc env init default/test
 Environment created: test-user/default/test
 > esc env provider azure-login static default/test tid /subscriptions/sub cid shhhhhh
-Provider updated.
+Provider updated. (revision 2)
 > esc env get default/test --definition
 values:
   azure:

--- a/cmd/esc/cli/testdata/env-provider-gcp-login-oidc.yaml
+++ b/cmd/esc/cli/testdata/env-provider-gcp-login-oidc.yaml
@@ -7,7 +7,7 @@ run: |
 > esc env init default/test
 Environment created: test-user/default/test
 > esc env provider gcp-login oidc default/test 123456789 --workload-pool-id pool --provider-id provider --service-account sa@proj.iam.gserviceaccount.com
-Provider updated.
+Provider updated. (revision 2)
 > esc env get default/test --definition
 values:
   gcp:
@@ -19,7 +19,7 @@ values:
           providerId: provider
           serviceAccount: sa@proj.iam.gserviceaccount.com
 > esc env provider gcp-login oidc default/test 123456789 --workload-pool-id pool --provider-id provider --service-account sa@proj.iam.gserviceaccount.com --region us-central1 --token-lifetime 1h --subject-attribute env
-Provider updated.
+Provider updated. (revision 3)
 > esc env get default/test --definition
 values:
   gcp:

--- a/cmd/esc/cli/testdata/env-provider-gcp-login-static.yaml
+++ b/cmd/esc/cli/testdata/env-provider-gcp-login-static.yaml
@@ -7,7 +7,7 @@ run: |
 > esc env init default/test
 Environment created: test-user/default/test
 > esc env provider gcp-login static default/test 123456789 ya29.token
-Provider updated.
+Provider updated. (revision 2)
 > esc env get default/test --definition
 values:
   gcp:
@@ -19,7 +19,7 @@ values:
             fn::secret:
               ciphertext: ZXNjeAAAAAH54bK5rvTv6+Xuek7KOw==
 > esc env provider gcp-login static default/test 123456789 ya29.token --service-account sa@proj.iam.gserviceaccount.com --token-lifetime 1h
-Provider updated.
+Provider updated. (revision 3)
 > esc env get default/test --definition
 values:
   gcp:

--- a/cmd/esc/cli/testdata/env-provider-missing-env.yaml
+++ b/cmd/esc/cli/testdata/env-provider-missing-env.yaml
@@ -6,7 +6,7 @@ run: |
 ---
 > esc env provider aws-login static default/created AKIAEXAMPLE shhhhhh --create
 Environment created: test-user/default/created
-Provider updated.
+Provider updated. (revision 2)
 > esc env get default/created --definition
 values:
   aws:
@@ -18,7 +18,7 @@ values:
             fn::secret:
               ciphertext: ZXNjeAAAAAHz6Ojo6OjoVtjhwQ==
 > esc env provider aws-login static default/created AKIANEW newshhh
-Provider updated.
+Provider updated. (revision 3)
 > esc env get default/created --definition
 values:
   aws:

--- a/cmd/esc/cli/testdata/env-version-rollback.yaml
+++ b/cmd/esc/cli/testdata/env-version-rollback.yaml
@@ -37,7 +37,7 @@ environments:
 
 ---
 > esc env version rollback default/test@stable
-Environment updated.
+Environment updated. (revision 5)
 > esc env get default/test
 # Value
 ```json


### PR DESCRIPTION
## Summary
resolves: https://github.com/pulumi/esc/issues/509

Now it prints the new revision after env edit
```
❯ esc env edit syeh/aaa/yo
Environment updated. (revision 19)
```
<!-- Describe any new or modified tests. If snapshot files changed, confirm the diff is intentional. -->

## Risk
<!-- What could go wrong? What's the blast radius? -->

## Rollback
<!-- How to revert if this causes problems. Usually: revert the commit. -->
