### PR TITLE
Print retirement banner on every esc command

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,7 +8,7 @@
 
 - Print a retirement notice on every `esc` command. The standalone ESC CLI has been retired;
   install the Pulumi CLI and use the `pulumi env` subcommand instead. See
-  https://www.pulumi.com/docs/iac/cli.
+  https://www.pulumi.com/docs/install.
   [#669](https://github.com/pulumi/esc/pull/669)
 
 ### Bug Fixes

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,6 +6,11 @@
 - Report the new revision number when an environment definition is updated (e.g. `esc env edit`,
   `esc env provider`, `esc env version rollback`).
 
+- Print a retirement notice on every `esc` command. The standalone ESC CLI has been retired;
+  install the Pulumi CLI and use the `pulumi env` subcommand instead. See
+  https://www.pulumi.com/docs/iac/cli.
+  [#PR](https://github.com/pulumi/esc/pulls/PR)
+
 ### Bug Fixes
 
 ### Breaking changes

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,7 +9,7 @@
 - Print a retirement notice on every `esc` command. The standalone ESC CLI has been retired;
   install the Pulumi CLI and use the `pulumi env` subcommand instead. See
   https://www.pulumi.com/docs/iac/cli.
-  [#PR](https://github.com/pulumi/esc/pulls/PR)
+  [#669](https://github.com/pulumi/esc/pull/669)
 
 ### Bug Fixes
 

--- a/cmd/esc/main.go
+++ b/cmd/esc/main.go
@@ -19,9 +19,9 @@ import (
 // every command so that it never corrupts machine-readable output on stdout.
 func printRetirementBanner(w io.Writer) {
 	lines := []string{
-		"The ESC CLI has been retired.",
-		"Download the Pulumi CLI and use the 'pulumi env' subcommand instead.",
-		"See: https://www.pulumi.com/docs/iac/cli",
+		"The standalone ESC CLI has been retired and no longer receives updates.",
+		"ESC is now part of the Pulumi CLI — use 'pulumi env' instead.",
+		"Install: https://www.pulumi.com/docs/install",
 	}
 
 	width := 0

--- a/cmd/esc/main.go
+++ b/cmd/esc/main.go
@@ -4,13 +4,40 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"runtime/debug"
+	"strings"
 
 	"github.com/pulumi/esc/cmd/esc/cli"
 	"github.com/pulumi/esc/cmd/esc/cli/version"
 )
+
+// printRetirementBanner prints a notice informing users that the standalone esc CLI has been
+// retired in favor of the Pulumi CLI's `pulumi env` subcommand. It is printed to stderr before
+// every command so that it never corrupts machine-readable output on stdout.
+func printRetirementBanner(w io.Writer) {
+	lines := []string{
+		"The ESC CLI has been retired.",
+		"Download the Pulumi CLI and use the 'pulumi env' subcommand instead.",
+		"See: https://www.pulumi.com/docs/iac/cli",
+	}
+
+	width := 0
+	for _, line := range lines {
+		if len(line) > width {
+			width = len(line)
+		}
+	}
+
+	border := strings.Repeat("─", width+2)
+	fmt.Fprintf(w, "┌%s┐\n", border)
+	for _, line := range lines {
+		fmt.Fprintf(w, "│ %-*s │\n", width, line)
+	}
+	fmt.Fprintf(w, "└%s┘\n", border)
+}
 
 // panicHandler displays an emergency error message to the user and a stack trace to
 // report the panic.
@@ -38,6 +65,8 @@ func panicHandler() {
 }
 
 func main() {
+	printRetirementBanner(os.Stderr)
+
 	err := func() error {
 		defer panicHandler()
 		return cli.New(nil).Execute()


### PR DESCRIPTION
## What

With [pulumi/pulumi#23746](https://github.com/pulumi/pulumi/pull/23746) the standalone `esc` binary is being retired — users should use the Pulumi CLI's `pulumi env` subcommand instead. This adds a retirement notice printed on **every** invocation of the standalone `esc` binary, ahead of one final release.

```
┌─────────────────────────────────────────────────────────────────────────┐
│ The standalone ESC CLI has been retired and no longer receives updates. │
│ ESC is now part of the Pulumi CLI — use 'pulumi env' instead.           │
│ Install: https://www.pulumi.com/docs/install/                           │
└─────────────────────────────────────────────────────────────────────────┘
```

The wording scopes the retirement to the *binary* rather than the ESC product, and links straight to the install page — the actionable target, since commands map 1:1 (`esc env ls` → `pulumi env ls`).

## How

The banner is printed from `cmd/esc/main.go` (the `package main` entrypoint), to **stderr**, before `cli.New(nil).Execute()`.

Placing it in `main.go` rather than the shared `cli.New`/command tree means:

- It appears **only** in the standalone `esc` binary — never under `pulumi env`, however the Pulumi CLI now embeds the esc code.
- It prints for every command, including `--help`, `version`, and unknown/invalid commands.
- It goes to stderr, so it never corrupts machine-readable stdout (`esc env open`, `esc run`, `esc gen-docs`, ...).
- The 102 `cmd/esc/cli` stderr snapshot tests (which drive `New()` directly, not `main()`) are untouched.

The box auto-sizes to its longest line, so it stays aligned if the text changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
